### PR TITLE
fix: 🐞 Update dependency versions in Cargo.toml for consistency and compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
 dependencies = [
  "as-slice",
 ]
@@ -168,7 +168,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -212,9 +212,9 @@ checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
@@ -299,6 +299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,12 +372,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "der"
@@ -986,6 +990,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1074,9 +1087,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1159,11 +1172,12 @@ dependencies = [
 
 [[package]]
 name = "minifb"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05eddefadb505d3dcb66a89fa77dd0936e72ec84e891cc8fc36e3c05bfe61103"
+checksum = "d1a093126f2ed9012fc0b146934c97eb0273e54983680a8bf5309b6b4a365b32"
 dependencies = [
  "cc",
+ "console_error_panic_hook",
  "dlib",
  "futures",
  "instant",
@@ -1175,10 +1189,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "tempfile",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+ "web-sys",
  "winapi",
  "x11-dl",
 ]
@@ -1201,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1481,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "ort"
 version = "2.0.0-rc.10"
-source = "git+https://github.com/pykeio/ort.git#0a593a59d778aa75d0617429c4620dcdc414427a"
+source = "git+https://github.com/pykeio/ort.git#45d6a267b57c8b24ce49b75811e57ffced7ceebc"
 dependencies = [
  "half",
  "ndarray 0.17.1",
@@ -1494,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "ort-sys"
 version = "2.0.0-rc.10"
-source = "git+https://github.com/pykeio/ort.git#0a593a59d778aa75d0617429c4620dcdc414427a"
+source = "git+https://github.com/pykeio/ort.git#45d6a267b57c8b24ce49b75811e57ffced7ceebc"
 dependencies = [
  "glob",
  "hmac-sha256",
@@ -1790,12 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.4.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
-dependencies = [
- "cty",
-]
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rawpointer"
@@ -1825,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1928,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -1951,6 +1964,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -2050,6 +2069,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2208,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2230,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2377,6 +2409,8 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,14 @@ path = "src/main.rs"
 
 [dependencies]
 # Core - Image loading and processing
-image = "0.25"
-jpeg-decoder = "0.3"
-fast_image_resize = { version = "5.4", features = ["image", "rayon"] }
+image = "^0.25"
+jpeg-decoder = "^0.3"
+fast_image_resize = { version = "^5.4", features = ["image", "rayon"] }
 # Workaround: Pin zune-jpeg to 0.5.5 due to a macOS-specific bug in 0.5.6
 zune-jpeg = "=0.5.5"
 
 # Numerical computing (must match ort's ndarray version 0.17)
-ndarray = { version = "0.17", features = ["rayon"] }
+ndarray = { version = "^0.17", features = ["rayon"] }
 
 # ONNX Runtime 1.23 - using latest from GitHub for best performance
 ort = { git = "https://github.com/pykeio/ort.git", default-features = false, features = [
@@ -55,18 +55,18 @@ ort = { git = "https://github.com/pykeio/ort.git", default-features = false, fea
 ] }
 
 # Core - FP16 support (required by ort's half feature)
-half = { version = "2.4", features = ["num-traits"] }
-ureq = "3.1.4"
-dirs = "6.0"
-rayon = "1.10"
-minifb = { version = "0.25", optional = true }
-video-rs = { version = "0.10.5", features = ["ndarray"], optional = true }
-bytemuck = { version = "1.21", features = ["derive"] }
+half = { version = "^2.4", features = ["num-traits"] }
+ureq = "^3.1.4"
+dirs = "^6.0"
+rayon = "^1.10"
+minifb = { version = "^0.28.0", optional = true }
+video-rs = { version = "^0.10.5", features = ["ndarray"], optional = true }
+bytemuck = { version = "^1.21", features = ["derive"] }
 
 
 # Optional - Image annotation (for --save feature)
-imageproc = { version = "0.25", optional = true }
-ab_glyph = { version = "0.2", optional = true }
+imageproc = { version = "^0.25", optional = true }
+ab_glyph = { version = "^0.2", optional = true }
 
 [features]
 default = ["annotate", "visualize"]


### PR DESCRIPTION
Fix #16 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Rust dependencies (notably `minifb` and ONNX Runtime `ort`) and relaxes version constraints to improve compatibility and keep builds current 🚀🦀

### 📊 Key Changes
- ⬆️ Bumped several locked dependency versions in `Cargo.lock` (e.g., `minifb` 0.25.0 → 0.28.0, `itertools` 0.12.1 → 0.13.0, `tracing` 0.1.43 → 0.1.44).
- 🔄 Updated the git revision for ONNX Runtime bindings (`ort` / `ort-sys`) to a newer commit for performance/bugfix improvements.
- 🧩 Added new transitive dependencies used by updated crates, including `console_error_panic_hook`, `serde`, and `serde_json` (primarily relevant for WASM and tooling).
- 🧹 Removed the legacy `cty` dependency via upgrading `raw-window-handle` (0.4.x → 0.6.x).
- 📌 In `Cargo.toml`, switched many dependencies to caret (`^`) version requirements (e.g., `image`, `rayon`, `ureq`, `ndarray`, `minifb`) to allow compatible updates automatically.

### 🎯 Purpose & Impact
- ✅ **Easier maintenance & smoother upgrades**: Caret constraints reduce “dependency lock-in” and allow compatible patch/minor releases without manual edits 🔧.
- 🖥️ **Improved visualization stack**: Updating `minifb` and window-handle dependencies can improve cross-platform windowing behavior and compatibility (especially on newer systems) 🪟.
- ⚡ **Better runtime behavior/performance potential**: Pulling a newer `ort` commit may bring bug fixes and optimizations for ONNX inference workloads 🧠.
- 🌐 **Better WASM/dev diagnostics**: `console_error_panic_hook` can improve error reporting in browser/WASM contexts, making failures easier to debug 🐛.
- ⚠️ **Potential integration considerations**: Dependency bumps (especially windowing and `ort`) can introduce subtle behavior changes; downstream builds may need a quick re-test in CI 🧪.