### PR TITLE
feat: ✨ Update dependencies in Cargo.lock and add deny.toml configuration for cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -83,7 +83,7 @@ deny = [
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/pykeio/ort.git"]
 
 [sources.allow-org]
 github = ["ultralytics"]


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a `cargo-deny` configuration to improve Rust dependency security, license compliance, and supply-chain hygiene 🔒🦀

### 📊 Key Changes
- Introduced a new `deny.toml` config for [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) (run via `cargo deny check`) ✅
- Enabled RustSec advisory scanning with a local advisory DB path and upstream source (`rustsec/advisory-db`) 🛡️
- Defined an explicit allowlist of acceptable licenses (e.g., MIT/Apache/BSD/MPL/AGPL) and set a confidence threshold 📜
- Added a license clarification for the `ring` crate to correctly interpret its licensing metadata 🧾
- Configured dependency “bans” checks to warn on multiple versions and highlight duplicates ⚠️
- Restricted allowed dependency sources:
  - Only allow crates.io as the registry
  - Allow a specific Git dependency (`pykeio/ort.git`)
  - Allow GitHub org sources from `ultralytics` 🧩

### 🎯 Purpose & Impact
- Improves security posture by catching vulnerable, yanked, or unmaintained crates earlier in CI/reviews 🔐
- Reduces legal/licensing risk by enforcing a clear, auditable license policy for dependencies 🧑‍⚖️
- Strengthens supply-chain controls by limiting where dependencies can be fetched from, lowering the risk of unexpected or malicious sources 🚧
- Minimal runtime impact: this mainly affects development/CI workflows and may surface new warnings that require dependency cleanup or explicit exceptions 🧹