### PR TITLE
refactor(speed): 🚀 Optimize post-processing for detection and segmentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use metadata::ModelMetadata;
 
 // Re-export preprocessing utilities
 pub use preprocessing::{
-    PreprocessResult, TensorData, preprocess_image, preprocess_image_with_precision,
+    preprocess_image, preprocess_image_with_precision, PreprocessResult, TensorData,
 };
 
 /// Library version.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use inference::annotate::{annotate_image, find_next_run_dir};
 #[cfg(feature = "visualize")]
 use inference::visualizer::Viewer;
 
-use inference::{InferenceConfig, Results, VERSION, YOLOModel};
+use inference::{InferenceConfig, Results, YOLOModel, VERSION};
 
 /// Default model path when not specified.
 const DEFAULT_MODEL: &str = "yolo11n.onnx";

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
-use ndarray::{Array2, Array3, ArrayView2, Zip, s};
+use ndarray::{s, Array2, Array3, ArrayView2, Zip};
 
 use crate::inference::InferenceConfig;
-use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
+use crate::preprocessing::{clip_coords, scale_coords, PreprocessResult};
 use crate::results::{Boxes, Keypoints, Masks, Obb, Probs, Results, Speed};
 use crate::task::Task;
 use crate::utils::nms_per_class;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -182,7 +182,7 @@ fn letterbox_image(
     pad_top: u32,
     target_size: (usize, usize),
 ) -> RgbImage {
-    use fast_image_resize::{PixelType, ResizeAlg, ResizeOptions, Resizer, images::Image};
+    use fast_image_resize::{images::Image, PixelType, ResizeAlg, ResizeOptions, Resizer};
 
     // Convert to RGB8
     let src_rgb = image.to_rgb8();
@@ -438,7 +438,7 @@ pub fn preprocess_image_center_crop(
 /// maintaining aspect ratio, then crops the center `target_size`.
 #[allow(clippy::similar_names)]
 fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbImage, (f32, f32)) {
-    use fast_image_resize::{PixelType, ResizeAlg, ResizeOptions, Resizer, images::Image};
+    use fast_image_resize::{images::Image, PixelType, ResizeAlg, ResizeOptions, Resizer};
 
     let (src_w, src_h) = image.dimensions();
     #[allow(clippy::cast_possible_truncation)]

--- a/src/results.rs
+++ b/src/results.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use ndarray::{Array1, Array2, Array3, ArrayView1, ArrayView2, Axis, s};
+use ndarray::{s, Array1, Array2, Array3, ArrayView1, ArrayView2, Axis};
 
 /// Timing information for inference operations (in milliseconds).
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
This PR focus on optimizing CPU inference performance by refining post-processing logic for Detection and Segmentation tasks. It introduces parallel execution for heavy mask processing and early filtering strategies to reduce computational overhead. 

1. Segmentation Optimization (Parallelization)

What: Refactored "postprocess_segment" to utilize rayon parallel iterators via ndarray::Zip.
Why: Segmentation post-processing involves resizing 160x160 masks to the original image size for every detected object, which is computationally expensive.
How: Replaced the sequential  for loop with par_for_each, distributing the mask resizing and cropping workload across all available CPU cores.

2. Detection Optimization (Early Filtering)

What: Optimized  extract_detect_boxes to apply confidence threshold filtering earlier in the pipeline.
Why: Previously, coordinate scaling and clipping were performed on all 8400+ candidates before filtering.
How: Candidates falling below conf_thres are now skipped immediately, saving unnecessary floating-point operations on thousands of background predictions.


Task | Baseline Post-process | Optimized Post-process | Improvement
-- | -- | -- | --
Segmentation | ~5.95 ms | ~4.23 ms | ~29% Speedup 🚀
Detection | ~1.00 ms | ~0.75 ms | ~25% Speedup



<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Speeds up postprocessing for detection and segmentation by optimizing box extraction and parallelizing mask generation 🚀🧠

### 📊 Key Changes
- ⚡ **Faster detection box extraction**: Refactors `extract_detect_boxes()` to:
  - Iterate rows more efficiently (`outer_iter`) and avoid repeated indexing
  - **Early-filter** low-confidence predictions before doing extra math
  - Inline coordinate scaling + padding removal and **clamp** to image bounds (instead of calling helper funcs)
- 🧵 **Parallel segmentation mask postprocessing**: Refactors `postprocess_segment()` to process masks **in parallel** using Rayon via `ndarray::Zip(...).par_for_each`, including per-thread `Resizer` instances (since `Resizer` isn’t `Sync`)
- 🧹 **Minor import/re-export cleanup**: Reorders some `use` lists and public re-exports (no functional change) ✨

### 🎯 Purpose & Impact
- 🚀 **Better CPU performance**, especially:
  - Detection: less wasted work by dropping low-confidence candidates early
  - Segmentation: potentially **30–50% faster** mask processing by using all CPU cores
- 🧩 **Same outputs, faster pipeline**: Changes are largely internal optimizations; users should see improved throughput/latency without API changes
- 🛡️ **More robust mask processing**: Keeps “graceful failure” behavior (skip problematic masks/resizes) while running safely in parallel