### PR TITLE
Feat/post process speed up

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use metadata::ModelMetadata;
 
 // Re-export preprocessing utilities
 pub use preprocessing::{
-    PreprocessResult, TensorData, preprocess_image, preprocess_image_with_precision,
+    preprocess_image, preprocess_image_with_precision, PreprocessResult, TensorData,
 };
 
 /// Library version.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use inference::annotate::{annotate_image, find_next_run_dir};
 #[cfg(feature = "visualize")]
 use inference::visualizer::Viewer;
 
-use inference::{InferenceConfig, Results, VERSION, YOLOModel};
+use inference::{InferenceConfig, Results, YOLOModel, VERSION};
 
 /// Default model path when not specified.
 const DEFAULT_MODEL: &str = "yolo11n.onnx";

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
-use ndarray::{Array2, Array3, ArrayView2, Zip, s};
+use ndarray::{s, Array2, Array3, ArrayView2, Zip};
 
 use crate::inference::InferenceConfig;
-use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
+use crate::preprocessing::{clip_coords, scale_coords, PreprocessResult};
 use crate::results::{Boxes, Keypoints, Masks, Obb, Probs, Results, Speed};
 use crate::task::Task;
 use crate::utils::nms_per_class;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -182,7 +182,7 @@ fn letterbox_image(
     pad_top: u32,
     target_size: (usize, usize),
 ) -> RgbImage {
-    use fast_image_resize::{PixelType, ResizeAlg, ResizeOptions, Resizer, images::Image};
+    use fast_image_resize::{images::Image, PixelType, ResizeAlg, ResizeOptions, Resizer};
 
     // Convert to RGB8
     let src_rgb = image.to_rgb8();
@@ -438,7 +438,7 @@ pub fn preprocess_image_center_crop(
 /// maintaining aspect ratio, then crops the center `target_size`.
 #[allow(clippy::similar_names)]
 fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbImage, (f32, f32)) {
-    use fast_image_resize::{PixelType, ResizeAlg, ResizeOptions, Resizer, images::Image};
+    use fast_image_resize::{images::Image, PixelType, ResizeAlg, ResizeOptions, Resizer};
 
     let (src_w, src_h) = image.dimensions();
     #[allow(clippy::cast_possible_truncation)]

--- a/src/results.rs
+++ b/src/results.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use ndarray::{Array1, Array2, Array3, ArrayView1, ArrayView2, Axis, s};
+use ndarray::{s, Array1, Array2, Array3, ArrayView1, ArrayView2, Axis};
 
 /// Timing information for inference operations (in milliseconds).
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Speeds up postprocessing by optimizing detection box extraction and parallelizing segmentation mask generation.

### 📊 Key Changes
- ⚡ Optimized detection box extraction to reduce per-row overhead (early confidence filtering, fewer array accesses, inline scaling + clipping).
- 🧵 Parallelized segmentation mask postprocessing using `ndarray::Zip` with `par_for_each`, with per-thread `Resizer` instances.
- 🧹 Minor import/re-export ordering cleanups across `lib.rs`, `main.rs`, `preprocessing.rs`, and `results.rs`.

### 🎯 Purpose & Impact
- 📈 Faster CPU postprocessing, especially for segmentation workloads with multiple kept masks.
- 🕒 Reduced unnecessary work by skipping low-confidence detections before coordinate transforms and downstream steps.
- 🔄 Mostly internal changes; expected to be behavior-preserving, but worth validating for edge cases (e.g., box clipping/boundaries and mask crop/resize error paths).