### PR TITLE
feat: ✨ Add panic abort and strip options for optimized builds in Cargo.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,3 @@ PKG_CONFIG_PATH = "/opt/homebrew/opt/ffmpeg@7/lib/pkgconfig"
 CPATH = "/opt/homebrew/opt/ffmpeg@7/include"
 LIBRARY_PATH = "/opt/homebrew/opt/ffmpeg@7/lib"
 BINDGEN_EXTRA_CLANG_ARGS = "-I/opt/homebrew/opt/ffmpeg@7/include"
-
-[build]
-rustflags = ["-C", "target-cpu=native"]


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tweaks Rust build profiles to speed up development builds while producing smaller, faster, and leaner release binaries 🚀🦀

### 📊 Key Changes
- Added a custom **`dev` profile**:
  - Keeps the main crate at **`opt-level = 0`** for faster incremental builds 🛠️
  - Sets **`split-debuginfo = "unpacked"`** to improve debug experience and build performance on supported platforms 🐞
- Enabled **high optimization for dependencies in dev builds** via **`[profile.dev.package."*"] opt-level = 3`** ⚡
- Hardened the **`release` profile**:
  - Set **`panic = "abort"`** to reduce binary size and simplify panic behavior 🧩
  - Enabled **`strip = true`** to remove symbols and shrink final artifacts 📦

### 🎯 Purpose & Impact
- **Faster local development loops** 🏃‍♂️: your code compiles quickly (low optimization), while dependencies remain fast at runtime (high optimization).
- **Better dev-time performance** ⚡: benchmarks/tests that rely on dependency-heavy code may run closer to release speeds.
- **Smaller production binaries** 📉: stripping symbols and aborting on panic reduces size, which helps shipping, deployment, and cold-start scenarios.
- **Behavioral note for production** 🚨: with `panic = "abort"`, panics will terminate immediately (no unwinding), which can affect error recovery patterns if any code relied on unwinding.