### PR TITLE
fix: 🐞 Enhance atomic download by creating unique temporary file names to prevent race conditions

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -166,7 +166,6 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
     let total_size = content_length.unwrap_or(0);
 
-    // Create temp file for atomic download (same directory for atomic rename)
     // Create unique temp file for atomic download to prevent race conditions
     // Format: <filename>.part.<pid>.<timestamp_nanos>
     let unique_suffix = format!(


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves download safety by using uniquely named temp files to avoid collisions during concurrent downloads 🛡️⬇️

### 📊 Key Changes
- Replaced a fixed temp filename (`<dest>.part`) with a **unique temp filename** format: `<filename>.part.<pid>.<timestamp_nanos>` 🧩
- Builds the temp file name from the destination’s filename (or falls back to `"download"` if missing) 🗂️
- Ensures the temp file is still created **in the same directory as the final destination** so the final rename remains atomic ⚙️
- Keeps existing behavior of removing any pre-existing temp file at that unique path before starting 🧹

### 🎯 Purpose & Impact
- Prevents **race conditions and file clobbering** when multiple processes/threads download the same asset at once (e.g., parallel inference workers) 🚦
- Makes downloads more robust in shared environments (CI, servers, multi-user systems) 🏗️
- Preserves **atomic “download then rename”** behavior, reducing the risk of partially downloaded files being mistaken for complete ones ✅