### PR TITLE
feat: 🚀 add `max_det` in `InferenceConfig` and add it as a CLI argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = InferenceConfig::new()
         .with_confidence(0.5)
         .with_iou(0.45)
-        .with_max_detections(100);
+        .with_max_det(100);
 
     let mut model = YOLOModel::load_with_config("yolo11n.onnx", config)?;
     let results = model.predict("image.jpg")?;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -61,6 +61,10 @@ pub struct PredictArgs {
     #[arg(long, default_value_t = 0.45)]
     pub iou: f32,
 
+    /// Maximum number of detections
+    #[arg(long, default_value_t = 300)]
+    pub max_det: usize,
+
     /// Inference image size
     #[arg(long)]
     pub imgsz: Option<usize>,
@@ -112,6 +116,7 @@ mod tests {
                 assert_eq!(predict_args.model, "yolo11n.onnx");
                 assert!((predict_args.conf - 0.25).abs() < f32::EPSILON);
                 assert!((predict_args.iou - 0.45).abs() < f32::EPSILON);
+                assert_eq!(predict_args.max_det, 300);
                 assert!(!predict_args.half);
                 assert!(predict_args.verbose);
                 assert!(predict_args.source.is_none());

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -59,6 +59,7 @@ pub fn run_prediction(args: &PredictArgs) {
         .with_iou(iou_threshold)
         .with_half(half)
         .with_batch(batch_size)
+        .with_max_det(args.max_det)
         .with_save_frames(save_frames);
 
     // Apply imgsz if specified

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20,7 +20,7 @@
 /// let config = InferenceConfig::new()
 ///     .with_confidence(0.5)
 ///     .with_iou(0.45)
-///     .with_max_detections(100)
+///     .with_max_det(100)
 ///     .with_imgsz(640, 640);
 /// ```
 ///
@@ -42,7 +42,7 @@ pub struct InferenceConfig {
     pub iou_threshold: f32,
     /// Maximum number of detections to return per image.
     /// The top-k detections sorted by confidence will be returned.
-    pub max_detections: usize,
+    pub max_det: usize,
     /// Explicit input image size (height, width).
     /// If `None`, the model's metadata will be used to determine input size.
     pub imgsz: Option<(usize, usize)>,
@@ -72,7 +72,7 @@ impl Default for InferenceConfig {
         Self {
             confidence_threshold: 0.25,
             iou_threshold: 0.45,
-            max_detections: 300,
+            max_det: 300,
             imgsz: None,
             batch: None,
             num_threads: 0, // 0 = let ONNX Runtime decide (typically uses all cores efficiently)
@@ -157,8 +157,8 @@ impl InferenceConfig {
     ///
     /// * The modified `InferenceConfig`.
     #[must_use]
-    pub const fn with_max_detections(mut self, max: usize) -> Self {
-        self.max_detections = max;
+    pub const fn with_max_det(mut self, max: usize) -> Self {
+        self.max_det = max;
         self
     }
 
@@ -278,7 +278,7 @@ mod tests {
         let config = InferenceConfig::default();
         assert!((config.confidence_threshold - 0.25).abs() < f32::EPSILON);
         assert!((config.iou_threshold - 0.45).abs() < f32::EPSILON);
-        assert_eq!(config.max_detections, 300);
+        assert_eq!(config.max_det, 300);
     }
 
     #[test]
@@ -286,13 +286,13 @@ mod tests {
         let config = InferenceConfig::new()
             .with_confidence(0.5)
             .with_iou(0.6)
-            .with_max_detections(100)
+            .with_max_det(100)
             .with_imgsz(640, 640)
             .with_threads(8);
 
         assert!((config.confidence_threshold - 0.5).abs() < f32::EPSILON);
         assert!((config.iou_threshold - 0.6).abs() < f32::EPSILON);
-        assert_eq!(config.max_detections, 100);
+        assert_eq!(config.max_det, 100);
         assert_eq!(config.imgsz, Some((640, 640)));
         assert_eq!(config.num_threads, 8);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@
 //! let config = InferenceConfig::new()
 //!     .with_confidence(0.5)    // Confidence threshold
 //!     .with_iou(0.45)          // NMS IoU threshold
-//!     .with_max_detections(100) // Max detections per image
+//!     .with_max_det(100) // Max detections per image
 //!     .with_imgsz(640, 640);   // Input image size
 //! ```
 //!

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -317,7 +317,7 @@ fn extract_detect_boxes(
     let keep_indices = nms_per_class(&candidates, config.iou_threshold);
 
     // Build output array with kept detections
-    let num_kept = keep_indices.len().min(config.max_detections);
+    let num_kept = keep_indices.len().min(config.max_det);
     let mut result = Array2::zeros((num_kept, 6));
 
     for (out_idx, &keep_idx) in keep_indices.iter().take(num_kept).enumerate() {
@@ -468,7 +468,7 @@ fn postprocess_segment(
         .collect();
 
     let keep_indices = nms_per_class(&nms_candidates, config.iou_threshold);
-    let num_kept = keep_indices.len().min(config.max_detections);
+    let num_kept = keep_indices.len().min(config.max_det);
 
     // 2. Extract Box Results
     let mut boxes_data = Array2::zeros((num_kept, 6));
@@ -804,7 +804,7 @@ fn postprocess_pose(
         .map(|(bbox, score, class, _)| (*bbox, *score, *class))
         .collect();
     let keep_indices = nms_per_class(&nms_candidates, config.iou_threshold);
-    let num_kept = keep_indices.len().min(config.max_detections);
+    let num_kept = keep_indices.len().min(config.max_det);
 
     // Build output arrays
     let mut boxes_data = Array2::zeros((num_kept, 6));
@@ -1038,7 +1038,7 @@ fn postprocess_obb(
     // This ensures that overlapping rotated boxes are correctly filtered based on their
     // actual geometric overlap, which standard axis-aligned IoU cannot handle.
     let keep_indices = nms_rotated_per_class(&candidates, config.iou_threshold);
-    let num_kept = keep_indices.len().min(config.max_detections);
+    let num_kept = keep_indices.len().min(config.max_det);
 
     // Build output array: [cx, cy, w, h, rotation, conf, cls]
     let mut obb_data = Array2::zeros((num_kept, 7));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,6 +20,7 @@ fn test_run_prediction_e2e() {
         conf: 0.25,
         iou: 0.45,
         imgsz: Some(640),
+        max_det: 300,
         batch: 1,
         half: false,
         save: false,
@@ -38,7 +39,7 @@ fn test_inference_config_creation() {
     let config = InferenceConfig::default();
     assert_eq!(config.confidence_threshold, 0.25);
     assert_eq!(config.iou_threshold, 0.45);
-    assert_eq!(config.max_detections, 300);
+    assert_eq!(config.max_det, 300);
 }
 
 #[test]
@@ -46,11 +47,11 @@ fn test_inference_config_builder() {
     let config = InferenceConfig::new()
         .with_confidence(0.5)
         .with_iou(0.7)
-        .with_max_detections(100);
+        .with_max_det(100);
 
     assert_eq!(config.confidence_threshold, 0.5);
     assert_eq!(config.iou_threshold, 0.7);
-    assert_eq!(config.max_detections, 100);
+    assert_eq!(config.max_det, 100);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a `--max-det` CLI option and standardizes the config/API naming from `max_detections` to `max_det` for consistent detection limits 🧰✅

### 📊 Key Changes
- Renamed `InferenceConfig` field and builder method:
  - `max_detections` → `max_det`
  - `with_max_detections(...)` → `with_max_det(...)` 🔁
- Added CLI flag `--max-det` (default `300`) to control the maximum number of detections returned per image 🖥️🎛️
- Wired `--max-det` into prediction config creation so it affects runtime outputs ⚙️
- Updated docs/examples (`README.md`, crate docs) and all unit/integration tests to match the new naming 📚🧪
- Updated postprocessing paths (detect/segment/pose/OBB) to use `config.max_det` when limiting kept detections 🧩

### 🎯 Purpose & Impact
- Improves consistency with common YOLO parameter naming (`max_det`), reducing confusion and aligning CLI + Rust API 🧠✨
- Gives users an easy way to cap detections from the command line (useful for crowded scenes, speed, and output size control) 🚀📉
- **Breaking change** for Rust users: code using `with_max_detections` or `max_detections` must be updated to the new names ⚠️🛠️
- Keeps behavior the same by default (still `300`), so most users won’t see changes unless they rely on the old API name 🔒✅