### PR TITLE
refactor: ♻️ disable window resizing in the viewer

### DIFF
--- a/src/visualizer/viewer.rs
+++ b/src/visualizer/viewer.rs
@@ -39,7 +39,7 @@ impl Viewer {
             width,
             height,
             WindowOptions {
-                resize: true,
+                resize: false,
                 ..WindowOptions::default()
             },
         )


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Disables window resizing in the visualizer viewer to keep the display size fixed 🪟🔒

### 📊 Key Changes
- Set `WindowOptions { resize: false, .. }` in `src/visualizer/viewer.rs` (was `true`)
- The viewer window is now **non-resizable** by the user 🚫↔️

### 🎯 Purpose & Impact
- Prevents unexpected UI/layout issues when users resize the viewer window (e.g., stretched frames or misaligned overlays) 🎯
- Makes visual output more consistent and predictable across runs and environments ✅
- Tradeoff: users lose the ability to manually resize the window for larger/smaller viewing ✋📏