### PR TITLE
build(deps): 📦 update ort dependency to version 1.24.2 and fix ort-sys cdn errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "ort"
 version = "2.0.0-rc.11"
-source = "git+https://github.com/pykeio/ort.git?rev=4caf2d6a76cf401523d351bb74f2b76acd0d1bff#4caf2d6a76cf401523d351bb74f2b76acd0d1bff"
+source = "git+https://github.com/pykeio/ort.git?rev=060aff6b63ddc02eab97c79b3839c0c90be1a8a7#060aff6b63ddc02eab97c79b3839c0c90be1a8a7"
 dependencies = [
  "half",
  "ndarray 0.17.2",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "ort-sys"
 version = "2.0.0-rc.11"
-source = "git+https://github.com/pykeio/ort.git?rev=4caf2d6a76cf401523d351bb74f2b76acd0d1bff#4caf2d6a76cf401523d351bb74f2b76acd0d1bff"
+source = "git+https://github.com/pykeio/ort.git?rev=060aff6b63ddc02eab97c79b3839c0c90be1a8a7#060aff6b63ddc02eab97c79b3839c0c90be1a8a7"
 dependencies = [
  "glob",
  "hmac-sha256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ lru = "^0.16"
 # Numerical computing (must match ort's ndarray version 0.17)
 ndarray = { version = "^0.17", features = ["rayon"] }
 
-# ONNX Runtime 1.23 - using latest from GitHub for best performance
-ort = { git = "https://github.com/pykeio/ort.git", rev = "4caf2d6a76cf401523d351bb74f2b76acd0d1bff", default-features = false, features = [
+# ONNX Runtime 1.24.2 - using latest from GitHub for best performance
+ort = { git = "https://github.com/pykeio/ort.git", rev = "060aff6b63ddc02eab97c79b3839c0c90be1a8a7", default-features = false, features = [
     "std",
     "ndarray",
     "download-binaries",


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps the Rust `ort` (ONNX Runtime) dependency to target ONNX Runtime 1.24.2 for improved performance and updated binaries 🚀

### 📊 Key Changes
- Updated the `ort` Git dependency revision in `Cargo.toml` to a newer commit (now aligned with ONNX Runtime **1.24.2**) 🔄
- Kept the same feature set (`std`, `ndarray`, `download-binaries`) while upgrading the underlying ONNX Runtime version ⚙️
- Regenerated `Cargo.lock` to reflect the dependency update 📌

### 🎯 Purpose & Impact
- Potentially faster and more efficient inference thanks to the newer ONNX Runtime release ⚡
- Better compatibility with the latest ONNX Runtime binaries and upstream fixes 🛠️
- Small upgrade risk: dependency bumps can introduce subtle behavior changes, so downstream users may want to re-test their pipelines after updating ✅
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
