### PR TITLE
fix: match Python Ultralytics detection output for YOLO ONNX inference

### DIFF
--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -56,7 +56,7 @@ pub fn run_prediction(args: &PredictArgs) {
         .map(|d| d.parse().expect("Invalid device"));
     #[cfg(feature = "visualize")]
     let show = args.show;
-    // Warn if using default model (like Python does)
+    // Warn if using default model
     if model_is_default && verbose {
         warn!(
             "'model' argument is missing. Using default '--model={}'.",

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -37,9 +37,17 @@ use ndarray::{Array3, Array4};
 /// Default letterbox padding color (gray).
 pub const LETTERBOX_COLOR: [u8; 3] = [114, 114, 114];
 
-/// Fixed-point scale factor for integer bilinear interpolation (2^11 = 2048).
+/// Fixed-point scale factor for bilinear interpolation (2^11 = 2048).
+/// Matches `OpenCV`'s `INTER_RESIZE_COEF_BITS = 11` for `INTER_LINEAR`.
 const SCALE_BITS: i32 = 11;
 const SCALE_INT: i32 = 1 << SCALE_BITS;
+
+/// Double scale bits for single-pass bilinear interpolation.
+const SCALE_BITS_2X: i32 = 2 * SCALE_BITS;
+
+/// Rounding bias for fixed-point bilinear, added before the final right-shift
+/// to achieve round-to-nearest behavior matching `OpenCV`'s `saturate_cast`.
+const ROUND_BIAS: i32 = 1 << (SCALE_BITS_2X - 1);
 
 /// Normalized letterbox padding color (114/255 ≈ 0.447).
 const LETTERBOX_NORM: f32 = 114.0 / 255.0;
@@ -54,6 +62,8 @@ const LUT_CACHE_SIZE: usize = 8;
 // Type Aliases
 // ================================================================================================
 
+/// X LUT entry: (`x0_byte_offset`, `x1_byte_offset`, 1-fx, fx) using 11-bit fixed-point
+/// weights matching `OpenCV`'s `INTER_LINEAR` coordinate mapping.
 type XLutEntry = (usize, usize, i32, i32);
 type XLutKey = (u32, u32);
 
@@ -204,6 +214,12 @@ pub fn preprocess_image_with_precision(
 // ================================================================================================
 
 /// Get or compute the X coordinate LUT for bilinear interpolation.
+///
+/// Uses 11-bit fixed-point weights matching `OpenCV`'s `INTER_LINEAR` coordinate mapping:
+/// `src_x = (dst_x + 0.5) * (src_w / dst_w) - 0.5`
+///
+/// Weight computation matches `OpenCV`'s `resize.cpp`:
+/// `cbuf[0] = saturate_cast<short>((1-fx) * 2048); cbuf[1] = 2048 - cbuf[0];`
 fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Vec<XLutEntry> {
     let key = (src_w, dst_w);
 
@@ -221,10 +237,14 @@ fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Vec<XLutEntry> {
             .map(|dx| {
                 let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
                 let x0 = sx.floor() as i32;
-                let fx = ((sx - x0 as f32) * SCALE_INT as f32) as i32;
+                // Match OpenCV: cbuf[0] = saturate_cast<short>((1-fx)*SCALE),
+                //               cbuf[1] = SCALE - cbuf[0]
+                let fx_f = sx - x0 as f32;
+                let fx_inv = ((1.0 - fx_f) * SCALE_INT as f32 + 0.5) as i32;
+                let fx = SCALE_INT - fx_inv;
                 let x0c = x0.clamp(0, src_w_max) as usize * 3;
                 let x1c = (x0 + 1).clamp(0, src_w_max) as usize * 3;
-                (x0c, x1c, SCALE_INT - fx, fx)
+                (x0c, x1c, fx_inv, fx)
             })
             .collect();
 
@@ -250,7 +270,6 @@ fn fused_zerocopy_preprocess(
     use rayon::prelude::*;
     use std::mem::MaybeUninit;
     use std::sync::atomic::{AtomicPtr, Ordering};
-    use wide::f32x4;
 
     let (dst_h, dst_w) = target_size;
     let channel_size = dst_h * dst_w;
@@ -266,7 +285,6 @@ fn fused_zerocopy_preprocess(
     let x_lut = get_or_compute_x_lut(src_w, new_width);
     let scale_y = src_h as f32 / new_height as f32;
     let src_h_max = (src_h - 1) as i32;
-    let inv_255_vec = f32x4::splat(INV_255);
 
     let pad_top_usize = pad_top as usize;
     let pad_left_usize = pad_left as usize;
@@ -293,12 +311,14 @@ fn fused_zerocopy_preprocess(
                 return;
             }
 
-            // Image row calculations
+            // Image row calculations - 11-bit fixed-point bilinear matching
+            // OpenCV's INTER_LINEAR (INTER_RESIZE_COEF_BITS = 11).
             let img_dy = dy - pad_top_usize;
             let sy = ((img_dy as f32 + 0.5) * scale_y - 0.5).max(0.0);
             let y0 = sy.floor() as i32;
-            let fy = ((sy - y0 as f32) * SCALE_INT as f32) as i32;
-            let fy_inv = SCALE_INT - fy;
+            let fy_f = sy - y0 as f32;
+            let fy_inv = ((1.0 - fy_f) * SCALE_INT as f32 + 0.5) as i32;
+            let fy = SCALE_INT - fy_inv;
 
             let y0c = y0.clamp(0, src_h_max) as usize;
             let y1c = (y0 + 1).clamp(0, src_h_max) as usize;
@@ -312,69 +332,20 @@ fn fused_zerocopy_preprocess(
                 *b_row.add(dx) = LETTERBOX_NORM;
             }
 
-            // Inner image - SIMD loop (4 pixels at a time)
+            // Inner image pixels - fixed-point bilinear with rounding.
+            // Uses untruncated weights (w = fx * fy, range [0, 2048^2]) and a
+            // single shift with rounding bias, matching OpenCV's saturate_cast:
+            //   result = (sum + ROUND_BIAS) >> 22
+            // Max intermediate: 255 * 2048^2 + 2^21 ≈ 1.07B < i32::MAX.
             let mut img_dx = 0usize;
             let src_ptr = src_raw.as_ptr();
 
-            while img_dx + 4 <= new_width_usize {
-                let mut r_vals = [0.0f32; 4];
-                let mut g_vals = [0.0f32; 4];
-                let mut b_vals = [0.0f32; 4];
-
-                for i in 0..4 {
-                    let (x0_off, x1_off, fx_inv, fx) = *x_lut.get_unchecked(img_dx + i);
-                    let w00 = (fx_inv * fy_inv) >> SCALE_BITS;
-                    let w10 = (fx * fy_inv) >> SCALE_BITS;
-                    let w01 = (fx_inv * fy) >> SCALE_BITS;
-                    let w11 = (fx * fy) >> SCALE_BITS;
-
-                    let p00 = src_ptr.add(row0_off + x0_off);
-                    let p10 = src_ptr.add(row0_off + x1_off);
-                    let p01 = src_ptr.add(row1_off + x0_off);
-                    let p11 = src_ptr.add(row1_off + x1_off);
-
-                    r_vals[i] = ((*p00 as i32 * w00
-                        + *p10 as i32 * w10
-                        + *p01 as i32 * w01
-                        + *p11 as i32 * w11)
-                        >> SCALE_BITS) as f32;
-                    g_vals[i] = ((*p00.add(1) as i32 * w00
-                        + *p10.add(1) as i32 * w10
-                        + *p01.add(1) as i32 * w01
-                        + *p11.add(1) as i32 * w11)
-                        >> SCALE_BITS) as f32;
-                    b_vals[i] = ((*p00.add(2) as i32 * w00
-                        + *p10.add(2) as i32 * w10
-                        + *p01.add(2) as i32 * w01
-                        + *p11.add(2) as i32 * w11)
-                        >> SCALE_BITS) as f32;
-                }
-
-                // SIMD normalize
-                let r_simd = f32x4::new(r_vals) * inv_255_vec;
-                let g_simd = f32x4::new(g_vals) * inv_255_vec;
-                let b_simd = f32x4::new(b_vals) * inv_255_vec;
-
-                let out_x = pad_left_usize + img_dx;
-                let r_arr: [f32; 4] = r_simd.into();
-                let g_arr: [f32; 4] = g_simd.into();
-                let b_arr: [f32; 4] = b_simd.into();
-
-                // Direct raw pointer writes (no bounds checks)
-                std::ptr::copy_nonoverlapping(r_arr.as_ptr(), r_row.add(out_x), 4);
-                std::ptr::copy_nonoverlapping(g_arr.as_ptr(), g_row.add(out_x), 4);
-                std::ptr::copy_nonoverlapping(b_arr.as_ptr(), b_row.add(out_x), 4);
-
-                img_dx += 4;
-            }
-
-            // Scalar tail
             while img_dx < new_width_usize {
                 let (x0_off, x1_off, fx_inv, fx) = *x_lut.get_unchecked(img_dx);
-                let w00 = (fx_inv * fy_inv) >> SCALE_BITS;
-                let w10 = (fx * fy_inv) >> SCALE_BITS;
-                let w01 = (fx_inv * fy) >> SCALE_BITS;
-                let w11 = (fx * fy) >> SCALE_BITS;
+                let w00 = fx_inv * fy_inv;
+                let w10 = fx * fy_inv;
+                let w01 = fx_inv * fy;
+                let w11 = fx * fy;
 
                 let p00 = src_ptr.add(row0_off + x0_off);
                 let p10 = src_ptr.add(row0_off + x1_off);
@@ -385,20 +356,23 @@ fn fused_zerocopy_preprocess(
                 *r_row.add(out_x) = ((*p00 as i32 * w00
                     + *p10 as i32 * w10
                     + *p01 as i32 * w01
-                    + *p11 as i32 * w11)
-                    >> SCALE_BITS) as f32
+                    + *p11 as i32 * w11
+                    + ROUND_BIAS)
+                    >> SCALE_BITS_2X) as f32
                     * INV_255;
                 *g_row.add(out_x) = ((*p00.add(1) as i32 * w00
                     + *p10.add(1) as i32 * w10
                     + *p01.add(1) as i32 * w01
-                    + *p11.add(1) as i32 * w11)
-                    >> SCALE_BITS) as f32
+                    + *p11.add(1) as i32 * w11
+                    + ROUND_BIAS)
+                    >> SCALE_BITS_2X) as f32
                     * INV_255;
                 *b_row.add(out_x) = ((*p00.add(2) as i32 * w00
                     + *p10.add(2) as i32 * w10
                     + *p01.add(2) as i32 * w01
-                    + *p11.add(2) as i32 * w11)
-                    >> SCALE_BITS) as f32
+                    + *p11.add(2) as i32 * w11
+                    + ROUND_BIAS)
+                    >> SCALE_BITS_2X) as f32
                     * INV_255;
 
                 img_dx += 1;
@@ -510,7 +484,6 @@ fn calculate_letterbox_params(
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let new_h = (orig_h * scale).round() as u32;
 
-    // Calculate padding to center the image (matching Python Ultralytics default)
     #[allow(clippy::cast_possible_truncation)]
     let pad_w = (target_size.1 as u32).saturating_sub(new_w);
     #[allow(clippy::cast_possible_truncation)]
@@ -520,13 +493,13 @@ fn calculate_letterbox_params(
     let pad_left = pad_w / 2;
     let pad_top = pad_h / 2;
 
-    // Scale factors for coordinate conversion back to original
-    #[allow(clippy::cast_precision_loss)]
-    let scale_x = new_w as f32 / orig_w;
-    #[allow(clippy::cast_precision_loss)]
-    let scale_y = new_h as f32 / orig_h;
-
-    (new_w, new_h, pad_left, pad_top, (scale_y, scale_x))
+    // Use a uniform gain for coordinate back-projection.
+    // This matches Ultralytics `scale_boxes()`, which applies a single
+    // `gain = min(target_h / orig_h, target_w / orig_w)` to both axes.
+    // Per-axis gains (`new_w / orig_w`, `new_h / orig_h`) can diverge slightly
+    // after rounding `new_w`/`new_h`, leading to small box shifts and
+    // different NMS results.
+    (new_w, new_h, pad_left, pad_top, (scale, scale))
 }
 
 /// Convert an RGB image to a normalized NCHW tensor (FP32).

--- a/src/source.rs
+++ b/src/source.rs
@@ -230,13 +230,158 @@ impl Default for SourceMeta {
 #[cfg(feature = "video")]
 use video_rs::ffmpeg;
 
+/// Custom FFmpeg video decoder using `SWS_BILINEAR` for YUV→RGB conversion.
+///
+/// `video-rs` defaults to `SWS_AREA`, which can produce slightly different
+/// pixel values during colorspace conversion. Those differences can affect
+/// borderline confidence predictions and lead to small detection drift.
+/// For consistency, this decoder uses `SWS_BILINEAR` explicitly.
+#[cfg(feature = "video")]
+struct BilinearVideoDecoder {
+    input_ctx: ffmpeg::format::context::Input,
+    decoder: ffmpeg::decoder::Video,
+    scaler: Option<ffmpeg::software::scaling::context::Context>,
+    stream_index: usize,
+    /// Total frames (estimated from duration * fps).
+    total_frames: Option<usize>,
+    /// Frames per second.
+    fps: f32,
+}
+
+#[cfg(feature = "video")]
+impl BilinearVideoDecoder {
+    fn new(path: &Path) -> Result<Self> {
+        ffmpeg::init().map_err(|e| InferenceError::VideoError(format!("FFmpeg init: {e}")))?;
+
+        let input_ctx = ffmpeg::format::input(path)
+            .map_err(|e| InferenceError::VideoError(format!("Cannot open {}: {e}", path.display())))?;
+
+        let stream = input_ctx
+            .streams()
+            .best(ffmpeg::media::Type::Video)
+            .ok_or_else(|| InferenceError::VideoError("No video stream found".into()))?;
+
+        let stream_index = stream.index();
+
+        // Estimate total frames
+        #[allow(clippy::cast_possible_truncation)]
+        let fps = f64::from(stream.avg_frame_rate()) as f32;
+        #[allow(clippy::cast_precision_loss)]
+        let duration_secs = input_ctx.duration() as f64 / f64::from(ffmpeg::ffi::AV_TIME_BASE);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let total_frames = if duration_secs > 0.0 && fps > 0.0 {
+            Some((duration_secs * f64::from(fps)) as usize)
+        } else {
+            None
+        };
+
+        let context_decoder = ffmpeg::codec::context::Context::from_parameters(stream.parameters())
+            .map_err(|e| InferenceError::VideoError(format!("Codec context: {e}")))?;
+        let decoder = context_decoder
+            .decoder()
+            .video()
+            .map_err(|e| InferenceError::VideoError(format!("Video decoder: {e}")))?;
+
+        Ok(Self {
+            input_ctx,
+            decoder,
+            scaler: None,
+            stream_index,
+            total_frames,
+            fps,
+        })
+    }
+
+    /// Decode the next frame as an RGB24 `DynamicImage`.
+    fn decode_next(&mut self) -> Option<Result<DynamicImage>> {
+        let mut decoded = ffmpeg::util::frame::video::Video::empty();
+
+        loop {
+            // Try to receive a frame from the decoder first
+            if self.decoder.receive_frame(&mut decoded).is_ok() {
+                return Some(self.frame_to_image(&decoded));
+            }
+
+            // Read packets until we find one for our stream
+            let mut found_packet = false;
+            for (stream, packet) in self.input_ctx.packets() {
+                if stream.index() == self.stream_index {
+                    if self.decoder.send_packet(&packet).is_err() {
+                        continue;
+                    }
+                    found_packet = true;
+                    break;
+                }
+            }
+
+            if !found_packet {
+                // End of stream - flush decoder
+                let _ = self.decoder.send_eof();
+                return if self.decoder.receive_frame(&mut decoded).is_ok() {
+                    Some(self.frame_to_image(&decoded))
+                } else {
+                    None
+                };
+            }
+
+            // Try to receive again after sending the packet
+            if self.decoder.receive_frame(&mut decoded).is_ok() {
+                return Some(self.frame_to_image(&decoded));
+            }
+        }
+    }
+
+    /// Convert a decoded video frame to RGB24 DynamicImage using BILINEAR scaler.
+    fn frame_to_image(&mut self, decoded: &ffmpeg::util::frame::video::Video) -> Result<DynamicImage> {
+        // Initialize scaler on first frame (we need actual dimensions)
+        if self.scaler.is_none() {
+            self.scaler = Some(
+                ffmpeg::software::scaling::context::Context::get(
+                    decoded.format(),
+                    decoded.width(),
+                    decoded.height(),
+                    ffmpeg::format::Pixel::RGB24,
+                    decoded.width(),
+                    decoded.height(),
+                    ffmpeg::software::scaling::flag::Flags::BILINEAR,
+                )
+                .map_err(|e| InferenceError::VideoError(format!("Scaler init: {e}")))?,
+            );
+        }
+
+        let mut rgb_frame = ffmpeg::util::frame::video::Video::empty();
+        self.scaler
+            .as_mut()
+            .unwrap()
+            .run(decoded, &mut rgb_frame)
+            .map_err(|e| InferenceError::VideoError(format!("Scale: {e}")))?;
+
+        let width = rgb_frame.width();
+        let height = rgb_frame.height();
+        let data = rgb_frame.data(0);
+        let stride = rgb_frame.stride(0);
+
+        // Copy tightly-packed RGB data (stride may be wider than width*3)
+        let mut rgb_data = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height as usize {
+            let row = &data[y * stride..y * stride + (width as usize) * 3];
+            rgb_data.extend_from_slice(row);
+        }
+
+        let img_buffer = image::RgbImage::from_raw(width, height, rgb_data).ok_or_else(|| {
+            InferenceError::ImageError("Failed to create image from video frame".into())
+        })?;
+        Ok(DynamicImage::ImageRgb8(img_buffer))
+    }
+}
+
 /// Iterator over frames from a source.
 pub struct SourceIterator {
     source: Source,
     current_frame: usize,
     image_paths: Vec<PathBuf>,
     #[cfg(feature = "video")]
-    decoder: Option<video_rs::decode::Decoder>,
+    decoder: Option<BilinearVideoDecoder>,
     #[cfg(feature = "video")]
     webcam_decoder: Option<(ffmpeg::format::context::Input, ffmpeg::decoder::Video)>,
     #[cfg(feature = "video")]
@@ -625,27 +770,13 @@ impl SourceIterator {
             let path_str = match &self.source {
                 Source::Video(p) => Some(p.to_string_lossy().to_string()),
                 Source::Stream(s) => Some(s.clone()),
-                // Webcam handled above
                 _ => None,
             };
 
             if let Some(path_str) = path_str {
-                match video_rs::decode::Decoder::new(Path::new(&path_str)) {
+                match BilinearVideoDecoder::new(Path::new(&path_str)) {
                     Ok(d) => {
-                        // Calculate total frames from duration and frame rate
-                        // Note: limit to Video source only as streams/webcams are infinite
-                        #[allow(clippy::collapsible_if)]
-                        if let Source::Video(_) = &self.source {
-                            if let Ok(duration) = d.duration() {
-                                let fps = d.frame_rate();
-                                let duration_seconds = duration.as_secs_f64();
-                                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                                {
-                                    self.total_frames =
-                                        Some((duration_seconds * f64::from(fps)) as usize);
-                                }
-                            }
-                        }
+                        self.total_frames = d.total_frames;
                         self.decoder = Some(d);
                     }
                     Err(e) => {
@@ -659,10 +790,8 @@ impl SourceIterator {
         }
 
         if let Some(decoder) = &mut self.decoder {
-            // Attempt to decode next frame
-            match decoder.decode() {
-                Ok((_ts, frame)) => {
-                    let fps = decoder.frame_rate();
+            match decoder.decode_next() {
+                Some(Ok(img)) => {
                     let meta = SourceMeta {
                         frame_idx: self.current_frame,
                         total_frames: self.total_frames,
@@ -671,16 +800,13 @@ impl SourceIterator {
                             .path()
                             .map(|p| p.to_string_lossy().to_string())
                             .unwrap_or_default(),
-                        fps: Some(fps),
+                        fps: Some(decoder.fps),
                     };
                     self.current_frame += 1;
-
-                    match video_frame_to_image(&frame) {
-                        Ok(img) => Some(Ok((img, meta))),
-                        Err(e) => Some(Err(e)),
-                    }
+                    Some(Ok((img, meta)))
                 }
-                Err(_e) => None,
+                Some(Err(e)) => Some(Err(e)),
+                None => None,
             }
         } else {
             None
@@ -739,29 +865,6 @@ impl Iterator for SourceIterator {
     }
 }
 
-#[cfg(feature = "video")]
-fn video_frame_to_image(arr: &video_rs::Frame) -> Result<DynamicImage> {
-    let shape = arr.shape();
-    let height = u32::try_from(shape[0])
-        .map_err(|_| InferenceError::ImageError("Image height exceeds u32::MAX".to_string()))?;
-    let width = u32::try_from(shape[1])
-        .map_err(|_| InferenceError::ImageError("Image width exceeds u32::MAX".to_string()))?;
-
-    // video_rs::Frame is an ndarray::Array3<u8> with shape (H, W, 3) and standard layout (C-contiguous).
-    // We can directly copy the raw data.
-    let rgb_data = arr
-        .as_slice()
-        .ok_or_else(|| {
-            InferenceError::ImageError("Failed to get raw slice from video frame".to_string())
-        })?
-        .to_vec();
-
-    let img_buffer = image::RgbImage::from_raw(width, height, rgb_data).ok_or_else(|| {
-        InferenceError::ImageError("Failed to create image from video frame".to_string())
-    })?;
-
-    Ok(DynamicImage::ImageRgb8(img_buffer))
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/source.rs
+++ b/src/source.rs
@@ -253,8 +253,9 @@ impl BilinearVideoDecoder {
     fn new(path: &Path) -> Result<Self> {
         ffmpeg::init().map_err(|e| InferenceError::VideoError(format!("FFmpeg init: {e}")))?;
 
-        let input_ctx = ffmpeg::format::input(path)
-            .map_err(|e| InferenceError::VideoError(format!("Cannot open {}: {e}", path.display())))?;
+        let input_ctx = ffmpeg::format::input(path).map_err(|e| {
+            InferenceError::VideoError(format!("Cannot open {}: {e}", path.display()))
+        })?;
 
         let stream = input_ctx
             .streams()
@@ -332,7 +333,10 @@ impl BilinearVideoDecoder {
     }
 
     /// Convert a decoded video frame to RGB24 DynamicImage using BILINEAR scaler.
-    fn frame_to_image(&mut self, decoded: &ffmpeg::util::frame::video::Video) -> Result<DynamicImage> {
+    fn frame_to_image(
+        &mut self,
+        decoded: &ffmpeg::util::frame::video::Video,
+    ) -> Result<DynamicImage> {
         // Initialize scaler on first frame (we need actual dimensions)
         if self.scaler.is_none() {
             self.scaler = Some(
@@ -864,7 +868,6 @@ impl Iterator for SourceIterator {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/source.rs
+++ b/src/source.rs
@@ -230,7 +230,7 @@ impl Default for SourceMeta {
 #[cfg(feature = "video")]
 use video_rs::ffmpeg;
 
-/// Custom FFmpeg video decoder using `SWS_BILINEAR` for YUV→RGB conversion.
+/// Custom `FFmpeg` video decoder using `SWS_BILINEAR` for YUV→RGB conversion.
 ///
 /// `video-rs` defaults to `SWS_AREA`, which can produce slightly different
 /// pixel values during colorspace conversion. Those differences can affect
@@ -332,7 +332,7 @@ impl BilinearVideoDecoder {
         }
     }
 
-    /// Convert a decoded video frame to RGB24 DynamicImage using BILINEAR scaler.
+    /// Convert a decoded video frame to RGB24 `DynamicImage` using BILINEAR scaler.
     fn frame_to_image(
         &mut self,
         decoded: &ffmpeg::util::frame::video::Video,


### PR DESCRIPTION
- Use uniform gain for coordinate back-projection in letterbox params, matching Python's scale_boxes() which applies a single gain to both axes instead of per-axis scales that diverge after rounding

- Fix bilinear interpolation to match OpenCV's INTER_LINEAR exactly: use single-pass fixed-point with rounding bias (ROUND_BIAS = 1 << 21) and OpenCV-matching weight computation (saturate_cast<short>((1-fx)*2048))

- Replace video-rs Decoder with custom BilinearVideoDecoder using raw ffmpeg-next API with SWS_BILINEAR flag for YUV→RGB conversion, avoiding video-rs's hardcoded SWS_AREA which can drift pixel values

- Remove unused video_frame_to_image function

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves preprocessing and video decoding consistency in `ultralytics/inference` 🎯, helping Rust inference outputs align more closely with OpenCV/Ultralytics behavior and reducing small prediction differences across images and videos.

### 📊 Key Changes
- Updated image resizing and bilinear interpolation logic to better match OpenCV’s `INTER_LINEAR` behavior 🖼️
- Added more precise fixed-point rounding during preprocessing, replacing the previous approximation-based path for resized pixels 🔍
- Removed the SIMD-based 4-pixel resize loop in favor of a simpler single-pass fixed-point implementation ⚙️
- Changed letterbox coordinate scaling to use one uniform gain for both axes, matching Ultralytics box rescaling behavior 📏
- Introduced a custom FFmpeg-based video decoder that explicitly uses bilinear scaling for YUV-to-RGB conversion 🎥
- Replaced the previous `video-rs` decoder path for videos with the new custom decoder, while preserving frame metadata like FPS and estimated total frames 📦
- Cleaned up comments and messaging, including a small CLI warning text simplification ✨

### 🎯 Purpose & Impact
- Improves output consistency between Rust inference and other Ultralytics/OpenCV-based pipelines, which is especially important for reproducible results ✅
- Reduces small pixel-level differences that can cause borderline detections, box shifts, or slightly different NMS outcomes 🎯
- Makes video predictions more stable by standardizing color conversion behavior during decoding 🎞️
- Helps users get results that better match expectations from Python-based Ultralytics workflows 🤝
- The preprocessing changes may slightly affect performance due to removal of the SIMD resize path, but they prioritize correctness and cross-platform consistency ⚖️
- Overall, this should lead to more reliable and predictable inference results for both images and videos 🚀