### PR TITLE
fix: 🐞 ensure canonical path resolution in Source conversion from string

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -137,7 +137,9 @@ impl From<&str> for Source {
             return Self::Glob(s.to_string());
         }
 
-        let path = PathBuf::from(s).canonicalize().unwrap_or_else(|_| PathBuf::from(s));
+        let path = PathBuf::from(s)
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(s));
 
         // Check if it's a directory
         if path.is_dir() {

--- a/src/source.rs
+++ b/src/source.rs
@@ -137,7 +137,7 @@ impl From<&str> for Source {
             return Self::Glob(s.to_string());
         }
 
-        let path = PathBuf::from(s);
+        let path = PathBuf::from(s).canonicalize().unwrap_or_else(|_| PathBuf::from(s));
 
         // Check if it's a directory
         if path.is_dir() {


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📁 This PR improves source path handling by converting input file paths to their canonical absolute form when possible before determining how to treat them.

### 📊 Key Changes
- Updated `Source::from<&str>` in `src/source.rs` to canonicalize input paths using Rust’s `PathBuf::canonicalize()`.
- Added a safe fallback so that if canonicalization fails, the original input path is still used.
- Path checks such as `is_dir()` now run against the normalized path when available.

### 🎯 Purpose & Impact
- ✅ Makes file and directory source detection more reliable, especially for relative paths or paths containing components like `.` and `..`.
- 🔒 Preserves existing behavior when a path cannot be resolved, reducing the risk of breaking current workflows.
- 🧭 Helps standardize path handling across environments, which can improve consistency for users loading local inference sources.
- ⚙️ Likely reduces edge-case bugs related to ambiguous or non-normalized filesystem paths.