### PR TITLE
feat: add YOLO26 model support with end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,7 +2685,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "ab_glyph",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 authors = [
     "Glenn Jocher <glenn.jocher@ultralytics.com>",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 ### Prerequisites
 
 - [Rust 1.85+](https://rustup.rs/) (install via rustup, edition 2024 required)
-- A YOLO ONNX model (export from Ultralytics: `yolo export model=yolo11n.pt format=onnx`)
+- A YOLO ONNX model (export from Ultralytics: `yolo export model=yolo26n.pt format=onnx`)
 
 ### Installation
 
@@ -73,11 +73,11 @@ ultralytics-inference --help
 
 ```bash
 # Using Ultralytics CLI
-yolo export model=yolo11n.pt format=onnx
+yolo export model=yolo26n.pt format=onnx
 
 # Or with Python
 from ultralytics import YOLO
-model = YOLO("yolo11n.pt")
+model = YOLO("yolo26n.pt")
 model.export(format="onnx")
 ```
 
@@ -88,22 +88,22 @@ model.export(format="onnx")
 cargo run --release -- predict
 
 # With explicit arguments
-cargo run --release -- predict --model yolo11n.onnx --source image.jpg
+cargo run --release -- predict --model yolo26n.onnx --source image.jpg
 
 # On a directory of images
-cargo run --release -- predict --model yolo11n.onnx --source assets/
+cargo run --release -- predict --model yolo26n.onnx --source assets/
 
 # With custom thresholds
-cargo run --release -- predict -m yolo11n.onnx -s image.jpg --conf 0.5 --iou 0.45
+cargo run --release -- predict -m yolo26n.onnx -s image.jpg --conf 0.5 --iou 0.45
 
 # With visualization and custom image size
-cargo run --release -- predict --model yolo11n.onnx --source video.mp4 --show --imgsz 1280
+cargo run --release -- predict --model yolo26n.onnx --source video.mp4 --show --imgsz 1280
 
 # Save individual frames for video input
-cargo run --release -- predict --model yolo11n.onnx --source video.mp4 --save-frames
+cargo run --release -- predict --model yolo26n.onnx --source video.mp4 --save-frames
 
 # Rectangular inference
-cargo run --release -- predict --model yolo11n.onnx --source image.jpg --rect
+cargo run --release -- predict --model yolo26n.onnx --source image.jpg --rect
 ```
 
 ### Example Output
@@ -111,11 +111,11 @@ cargo run --release -- predict --model yolo11n.onnx --source image.jpg --rect
 ```
 # ultralytics-inference predict
 
-WARNING ⚠️ 'model' argument is missing. Using default 'model=yolo11n.onnx'.
+WARNING ⚠️ 'model' argument is missing. Using default 'model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
 Ultralytics 0.0.8 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
-YOLO11n summary: 80 classes, imgsz=(640, 640)
+YOLO26n summary: 80 classes, imgsz=(640, 640)
 
 image 1/2 /home/ultralytics/inference/bus.jpg: 640x480 640x480 4 persons, 1 bus, 36.4ms
 image 2/2 /home/ultralytics/inference/zidane.jpg: 384x640 2 persons, 1 tie, 28.6ms
@@ -143,7 +143,7 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 
 | Option          | Short | Description                                       | Default                                 |
 | --------------- | ----- | ------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file                           | `yolo11n.onnx`                          |
+| `--model`       | `-m`  | Path to ONNX model file                           | `yolo26n.onnx`                          |
 | `--source`      | `-s`  | Input source (image, video, webcam index, or URL) | `Task dependent Ultralytics URL assets` |
 | `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)    | `cpu`                                   |
 | `--conf`        |       | Confidence threshold                              | `0.25`                                  |
@@ -185,7 +185,7 @@ use ultralytics_inference::{YOLOModel, InferenceConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load model - metadata (classes, task, imgsz) is read automatically
-    let mut model = YOLOModel::load("yolo11n.onnx")?;
+    let mut model = YOLOModel::load("yolo26n.onnx")?;
 
     // Run inference
     let results = model.predict("image.jpg")?;
@@ -218,7 +218,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_iou(0.45)
         .with_max_det(300);
 
-    let mut model = YOLOModel::load_with_config("yolo11n.onnx", config)?;
+    let mut model = YOLOModel::load_with_config("yolo26n.onnx", config)?;
     let results = model.predict("image.jpg")?;
 
     Ok(())
@@ -253,7 +253,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Configure the model to use this device
     let config = InferenceConfig::new().with_device(device);
 
-    let mut model = YOLOModel::load_with_config("yolo11n.onnx", config)?;
+    let mut model = YOLOModel::load_with_config("yolo26n.onnx", config)?;
     let results = model.predict("image.jpg")?;
 
     Ok(())
@@ -405,7 +405,7 @@ cargo test test_boxes_creation
 
 Benchmarks on Apple M4 MacBook Pro (CPU, ONNX Runtime):
 
-### YOLO11n Detection Model (640x640)
+### YOLO26n Detection Model (640x640)
 
 | Precision | Model Size | Preprocess | Inference | Postprocess | Total |
 | --------- | ---------- | ---------- | --------- | ----------- | ----- |

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -15,7 +15,7 @@
 //! ```no_run
 //! use ultralytics_inference::{YOLOModel, batch::BatchProcessor};
 //!
-//! let mut model = YOLOModel::load("yolo11n.onnx")?;
+//! let mut model = YOLOModel::load("yolo26n.onnx")?;
 //! let mut processor = BatchProcessor::new(&mut model, 4, |results, images, paths, metas| {
 //!     for (idx, result_vec) in results.iter().enumerate() {
 //!         println!("Image {}: {} detections", paths[idx], result_vec.len());
@@ -44,7 +44,7 @@ use image::DynamicImage;
 /// use ultralytics_inference::{YOLOModel, batch::BatchProcessor};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let mut model = YOLOModel::load("yolo11n.onnx")?;
+///     let mut model = YOLOModel::load("yolo26n.onnx")?;
 ///     let batch_size = 4;
 ///     
 ///     let mut processor = BatchProcessor::new(&mut model, batch_size, |results, images, paths, metas| {
@@ -180,12 +180,12 @@ mod tests {
 
     /// Test that `BatchProcessor` correctly buffers images and invokes callback.
     ///
-    /// Uses `batch_size=1` since the default yolo11n.onnx model only supports batch=1.
+    /// Uses `batch_size=1` since the default yolo26n.onnx model only supports batch=1.
     /// The model is auto-downloaded if not present.
     #[test]
     #[serial]
     fn test_batch_processor_with_model() {
-        let mut model = YOLOModel::load("yolo11n.onnx").expect("Model should load");
+        let mut model = YOLOModel::load("yolo26n.onnx").expect("Model should load");
 
         let callback_count = Rc::new(RefCell::new(0));
         let callback_count_clone = Rc::clone(&callback_count);
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_batch_processor_empty_flush() {
-        let mut model = YOLOModel::load("yolo11n.onnx").expect("Model should load");
+        let mut model = YOLOModel::load("yolo26n.onnx").expect("Model should load");
 
         let callback_count = Rc::new(RefCell::new(0));
         let callback_count_clone = Rc::clone(&callback_count);
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_batch_processor_callback_count() {
-        let mut model = YOLOModel::load("yolo11n.onnx").expect("Model should load");
+        let mut model = YOLOModel::load("yolo26n.onnx").expect("Model should load");
 
         let count = Rc::new(RefCell::new(0));
         let count_clone = Rc::clone(&count);

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -8,7 +8,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
 #[command(after_help = r#"Predict Options:
-    --model, -m <MODEL>    Path to ONNX model file [default: yolo11n.onnx]
+    --model, -m <MODEL>    Path to ONNX model file [default: yolo26n.onnx]
     --source, -s <SOURCE>  Input source (image, directory, glob, video, webcam, or URL)
     --conf <CONF>          Confidence threshold [default: 0.25]
     --iou <IOU>            IoU threshold for NMS [default: 0.7]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -26,7 +26,7 @@ use clap::{Args, Parser, Subcommand};
 
 Examples:
     ultralytics-inference predict
-    ultralytics-inference predict --model yolo11n.onnx --source image.jpg
+    ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
     ultralytics-inference predict --source 0 --conf 0.5 --show
@@ -156,10 +156,10 @@ mod tests {
 
     #[test]
     fn test_predict_args_defaults() {
-        let args = Cli::parse_from(["app", "predict", "--model", "yolo11n.onnx"]);
+        let args = Cli::parse_from(["app", "predict", "--model", "yolo26n.onnx"]);
         match args.command {
             Commands::Predict(predict_args) => {
-                assert_eq!(predict_args.model, Some("yolo11n.onnx".to_string()));
+                assert_eq!(predict_args.model, Some("yolo26n.onnx".to_string()));
                 assert!((predict_args.conf - InferenceConfig::DEFAULT_CONF).abs() < f32::EPSILON);
                 assert!((predict_args.iou - InferenceConfig::DEFAULT_IOU).abs() < f32::EPSILON);
                 assert!(predict_args.rect);

--- a/src/download.rs
+++ b/src/download.rs
@@ -12,40 +12,40 @@ use std::time::{Duration, Instant};
 
 use crate::error::{InferenceError, Result};
 
-/// Default YOLO model name.
-pub const DEFAULT_MODEL: &str = "yolo11n.onnx";
+/// Base URL for Ultralytics ONNX model assets. All downloadable models share this prefix.
+const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/download/v8.4.0";
+
+/// Default YOLO detection model name.
+pub const DEFAULT_MODEL: &str = "yolo26n.onnx";
 
 /// Default YOLO segmentation model name.
-pub const DEFAULT_SEGMENT_MODEL: &str = "yolo11n-seg.onnx";
-
-/// URL for downloading the default YOLO model.
-const DEFAULT_DETECT_MODEL_URL: &str =
-    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.onnx";
-
-/// URL for downloading the default YOLO model.
-const DEFAULT_SEGMENT_MODEL_URL: &str =
-    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-seg.onnx";
+pub const DEFAULT_SEGMENT_MODEL: &str = "yolo26n-seg.onnx";
 
 /// Default YOLO pose model name.
-pub const DEFAULT_POSE_MODEL: &str = "yolo11n-pose.onnx";
-
-/// URL for downloading the default YOLO pose model.
-const DEFAULT_POSE_MODEL_URL: &str =
-    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-pose.onnx";
+pub const DEFAULT_POSE_MODEL: &str = "yolo26n-pose.onnx";
 
 /// Default YOLO OBB model name.
-pub const DEFAULT_OBB_MODEL: &str = "yolo11n-obb.onnx";
-
-/// URL for downloading the default YOLO OBB model.
-const DEFAULT_OBB_MODEL_URL: &str =
-    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-obb.onnx";
+pub const DEFAULT_OBB_MODEL: &str = "yolo26n-obb.onnx";
 
 /// Default YOLO classification model name.
-pub const DEFAULT_CLS_MODEL: &str = "yolo11n-cls.onnx";
+pub const DEFAULT_CLS_MODEL: &str = "yolo26n-cls.onnx";
 
-/// URL for downloading the default YOLO classification model.
-const DEFAULT_CLS_MODEL_URL: &str =
-    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-cls.onnx";
+/// Filenames that can be auto-downloaded from the Ultralytics assets release.
+/// Each entry resolves to `{ASSETS_BASE_URL}/{filename}`.
+const DOWNLOADABLE_MODELS: &[&str] = &[
+    // YOLO26 (end-to-end by default)
+    "yolo26n.onnx",
+    "yolo26n-seg.onnx",
+    "yolo26n-pose.onnx",
+    "yolo26n-obb.onnx",
+    "yolo26n-cls.onnx",
+    // YOLO11
+    "yolo11n.onnx",
+    "yolo11n-seg.onnx",
+    "yolo11n-pose.onnx",
+    "yolo11n-obb.onnx",
+    "yolo11n-cls.onnx",
+];
 
 /// URL for downloading the default Bus.jpg image
 const DEFAULT_BUS_IMAGE_URL: &str = "https://ultralytics.com/images/bus.jpg";
@@ -330,41 +330,26 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
 /// Attempt to download a model if it matches a known downloadable model.
 ///
-/// Currently supports:
-/// - `yolo11n.onnx` - Default `YOLO11n` detection model
-/// - `yolo11n-seg.onnx` - `YOLO11n` segmentation model
-/// - `yolo11n-pose.onnx` - `YOLO11n` pose estimation model
-/// - `yolo11n-obb.onnx` - `YOLO11n` oriented bounding box model
-/// - `yolo11n-cls.onnx` - `YOLO11n` classification model
-/// Downloads a YOLO model from Ultralytics assets if it's a known model.
+/// Supports the YOLO26 and YOLO11 nano ONNX models listed in [`DOWNLOADABLE_MODELS`].
+/// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// Returns the path to the downloaded model.
-#[allow(clippy::missing_errors_doc, clippy::doc_lazy_continuation)]
+#[allow(clippy::missing_errors_doc)]
 pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
     let path = path.as_ref();
     let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-    // Map of supported downloadable models
-    let url = match filename {
-        DEFAULT_MODEL => DEFAULT_DETECT_MODEL_URL,
-        DEFAULT_SEGMENT_MODEL => DEFAULT_SEGMENT_MODEL_URL,
-        DEFAULT_POSE_MODEL => DEFAULT_POSE_MODEL_URL,
-        DEFAULT_OBB_MODEL => DEFAULT_OBB_MODEL_URL,
-        DEFAULT_CLS_MODEL => DEFAULT_CLS_MODEL_URL,
-        _ => {
-            return Err(InferenceError::ModelLoadError(format!(
-                "Model file not found: {}. Auto-download is supported for: yolo11n.onnx, yolo11n-seg.onnx, yolo11n-pose.onnx, yolo11n-obb.onnx, yolo11n-cls.onnx",
-                path.display(),
-            )));
-        }
-    };
+    if !DOWNLOADABLE_MODELS.contains(&filename) {
+        return Err(InferenceError::ModelLoadError(format!(
+            "Model file not found: {}. Auto-download is supported for: {}",
+            path.display(),
+            DOWNLOADABLE_MODELS.join(", "),
+        )));
+    }
 
-    // Use the path as provided (current directory if just filename)
+    let url = format!("{ASSETS_BASE_URL}/{filename}");
     let dest_path = path.to_path_buf();
-
-    // Download the model
-    download_file(url, &dest_path)?;
-
+    download_file(&url, &dest_path)?;
     Ok(dest_path)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! - **High Performance** - Pure Rust with zero-cost abstractions and SIMD-optimized preprocessing
 //! - **ONNX Runtime** - Leverages ONNX Runtime for cross-platform hardware acceleration
-//! - **All YOLO Versions** - Supports `YOLOv5`, `YOLOv8`, `YOLO11`, and future versions
+//! - **Supported YOLO Versions** - `YOLO11` and `YOLO26` (including YOLO26 end-to-end NMS-free exports)
 //! - **All Tasks** - Detection, segmentation, pose estimation, classification, and OBB
 //! - **Ultralytics API** - Results API matches the Python package for easy migration
 //! - **Multiple Backends** - CPU, CUDA, `TensorRT`, `CoreML`, `OpenVINO`, and more
@@ -45,7 +45,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Load model - metadata (classes, task, imgsz) is read automatically
-//!     let mut model = YOLOModel::load("yolo11n.onnx")?;
+//!     let mut model = YOLOModel::load("yolo26n.onnx")?;
 //!
 //!     // Run inference
 //!     let results = model.predict("image.jpg")?;
@@ -79,19 +79,19 @@
 //! ultralytics-inference predict
 //!
 //! # Run on a specific image
-//! ultralytics-inference predict --model yolo11n.onnx --source image.jpg
+//! ultralytics-inference predict --model yolo26n.onnx --source image.jpg
 //!
 //! # Run on a directory of images
-//! ultralytics-inference predict --model yolo11n.onnx --source images/
+//! ultralytics-inference predict --model yolo26n.onnx --source images/
 //!
 //! # With custom thresholds
-//! ultralytics-inference predict -m yolo11n.onnx -s image.jpg --conf 0.5 --iou 0.45
+//! ultralytics-inference predict -m yolo26n.onnx -s image.jpg --conf 0.5 --iou 0.45
 //!
 //! # With visualization window
-//! ultralytics-inference predict --model yolo11n.onnx --source video.mp4 --show
+//! ultralytics-inference predict --model yolo26n.onnx --source video.mp4 --show
 //!
 //! # Save annotated results
-//! ultralytics-inference predict --model yolo11n.onnx --source image.jpg --save
+//! ultralytics-inference predict --model yolo26n.onnx --source image.jpg --save
 //!
 //! # Show help
 //! ultralytics-inference help
@@ -101,7 +101,7 @@
 //!
 //! | Option | Short | Description | Default |
 //! |--------|-------|-------------|---------|
-//! | `--model` | `-m` | Path to ONNX model | `yolo11n.onnx` |
+//! | `--model` | `-m` | Path to ONNX model | `yolo26n.onnx` |
 //! | `--source` | `-s` | Input source | Sample images |
 //! | `--device` | | Device to use (cpu, cuda:0, mps, coreml, etc.) | `cpu` |
 //! | `--conf` | | Confidence threshold | `0.25` |
@@ -117,19 +117,19 @@
 //!
 //! ```bash
 //! # Detection (default)
-//! yolo export model=yolo11n.pt format=onnx
+//! yolo export model=yolo26n.pt format=onnx
 //!
 //! # Segmentation
-//! yolo export model=yolo11n-seg.pt format=onnx
+//! yolo export model=yolo26n-seg.pt format=onnx
 //!
 //! # Pose Estimation
-//! yolo export model=yolo11n-pose.pt format=onnx
+//! yolo export model=yolo26n-pose.pt format=onnx
 //!
 //! # Classification
-//! yolo export model=yolo11n-cls.pt format=onnx
+//! yolo export model=yolo26n-cls.pt format=onnx
 //!
 //! # Oriented Bounding Boxes
-//! yolo export model=yolo11n-obb.pt format=onnx
+//! yolo export model=yolo26n-obb.pt format=onnx
 //! ```
 //!
 //! The task is auto-detected from ONNX metadata:
@@ -139,21 +139,21 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Segmentation model - returns masks
-//! let mut model = YOLOModel::load("yolo11n-seg.onnx")?;
+//! let mut model = YOLOModel::load("yolo26n-seg.onnx")?;
 //! let results = model.predict("image.jpg")?;
 //! if let Some(ref masks) = results[0].masks {
 //!     println!("Found {} instance masks", masks.len());
 //! }
 //!
 //! // Pose model - returns keypoints
-//! let mut model = YOLOModel::load("yolo11n-pose.onnx")?;
+//! let mut model = YOLOModel::load("yolo26n-pose.onnx")?;
 //! let results = model.predict("image.jpg")?;
 //! if let Some(ref keypoints) = results[0].keypoints {
 //!     println!("Found {} poses", keypoints.len());
 //! }
 //!
 //! // Classification model - returns probabilities
-//! let mut model = YOLOModel::load("yolo11n-cls.onnx")?;
+//! let mut model = YOLOModel::load("yolo26n-cls.onnx")?;
 //! let results = model.predict("image.jpg")?;
 //! if let Some(ref probs) = results[0].probs {
 //!     println!("Top-1: class {} ({:.1}%)", probs.top1(), probs.top1conf() * 100.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,11 @@
 //! # Usage
 //!
 //! ```bash
-//! ultralytics-inference predict --model yolo11n.onnx --source image.jpg
-//! ultralytics-inference predict --model yolo11n.onnx --source video.mp4
-//! ultralytics-inference predict --model yolo11n.onnx --source 0 --conf 0.5
-//! ultralytics-inference predict -m yolo11n.onnx -s assets/ --save --half
-//! ultralytics-inference predict -m yolo11n.onnx -s video.mp4 --imgsz 1280 --show
+//! ultralytics-inference predict --model yolo26n.onnx --source image.jpg
+//! ultralytics-inference predict --model yolo26n.onnx --source video.mp4
+//! ultralytics-inference predict --model yolo26n.onnx --source 0 --conf 0.5
+//! ultralytics-inference predict -m yolo26n.onnx -s assets/ --save --half
+//! ultralytics-inference predict -m yolo26n.onnx -s video.mp4 --imgsz 1280 --show
 //! ultralytics-inference version
 //! ultralytics-inference help
 //! ```

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -179,9 +179,11 @@ impl ModelMetadata {
         Ok(metadata)
     }
 
-    /// Parse a `kpt_shape` value like "[17, 3]" into a tuple.
+    /// Parse a `kpt_shape` value like "[17, 3]" or "(17, 3)" into a tuple.
     fn parse_kpt_shape(value: &str) -> Option<(usize, usize)> {
-        let inner = value.trim().trim_start_matches('[').trim_end_matches(']');
+        let inner = value
+            .trim()
+            .trim_matches(|c| matches!(c, '[' | ']' | '(' | ')'));
         let parts: Vec<usize> = inner
             .split(',')
             .filter_map(|s| s.trim().parse().ok())

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -42,6 +42,11 @@ pub struct ModelMetadata {
     pub half: bool,
     /// Class ID to class name mapping.
     pub names: HashMap<usize, String>,
+    /// Whether the model was exported with end-to-end NMS-free output
+    /// (YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
+    pub end2end: bool,
+    /// Pose keypoint shape as (`num_keypoints`, `dims`), e.g. (17, 3).
+    pub kpt_shape: Option<(usize, usize)>,
 }
 
 impl ModelMetadata {
@@ -136,6 +141,12 @@ impl ModelMetadata {
                     "half" => {
                         metadata.half = value == "true" || value == "True";
                     }
+                    "end2end" => {
+                        metadata.end2end = value == "true" || value == "True";
+                    }
+                    "kpt_shape" => {
+                        metadata.kpt_shape = Self::parse_kpt_shape(value);
+                    }
                     "args" => {
                         // Parse args dict for half flag: {'half': True, ...}
                         if value.contains("'half': True")
@@ -166,6 +177,20 @@ impl ModelMetadata {
         }
 
         Ok(metadata)
+    }
+
+    /// Parse a `kpt_shape` value like "[17, 3]" into a tuple.
+    fn parse_kpt_shape(value: &str) -> Option<(usize, usize)> {
+        let inner = value.trim().trim_start_matches('[').trim_end_matches(']');
+        let parts: Vec<usize> = inner
+            .split(',')
+            .filter_map(|s| s.trim().parse().ok())
+            .collect();
+        if parts.len() >= 2 {
+            Some((parts[0], parts[1]))
+        } else {
+            None
+        }
     }
 
     /// Parse the imgsz field which can be a YAML list.
@@ -350,6 +375,8 @@ impl Default for ModelMetadata {
             channels: 3,
             half: false,
             names: HashMap::new(),
+            end2end: false,
+            kpt_shape: None,
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -474,6 +474,8 @@ impl YOLOModel {
             "half",
             "channels",
             "args",
+            "end2end",
+            "kpt_shape",
         ];
 
         for key in &keys {
@@ -766,6 +768,8 @@ impl YOLOModel {
                 path,
                 speed,
                 inference_shape,
+                self.metadata.end2end,
+                self.metadata.kpt_shape,
             );
 
             batch_results.push(vec![result]);

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,7 +40,7 @@ use crate::warn;
 /// ```no_run
 /// use ultralytics_inference::YOLOModel;
 ///
-/// let mut model = YOLOModel::load("yolo11n.onnx").unwrap();
+/// let mut model = YOLOModel::load("yolo26n.onnx").unwrap();
 /// let results = model.predict("image.jpg").unwrap();
 /// println!("Found {} detections", results.len());
 /// ```
@@ -96,7 +96,7 @@ impl YOLOModel {
     /// ```no_run
     /// use ultralytics_inference::YOLOModel;
     ///
-    /// let model = YOLOModel::load("yolo11n.onnx")?;
+    /// let model = YOLOModel::load("yolo26n.onnx")?;
     /// # Ok::<(), ultralytics_inference::InferenceError>(())
     /// ```
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -1016,7 +1016,7 @@ impl YOLOModel {
     ///
     /// ```no_run
     /// use ultralytics_inference::YOLOModel;
-    /// let mut model = YOLOModel::load("yolo11n.onnx")?;
+    /// let mut model = YOLOModel::load("yolo26n.onnx")?;
     /// println!("Model name: {}", model.metadata().model_name());
     /// # Ok::<(), ultralytics_inference::InferenceError>(())
     /// ```
@@ -1079,16 +1079,16 @@ mod tests {
         // Since we can't easily mock YOLOModel (it wraps internal ORT session),
         // we can at least test specific public methods if we had a valid model.
         // But for getters, we need an instance.
-        // We can use the auto-downloaded yolo11n.onnx if available,
+        // We can use the auto-downloaded yolo26n.onnx if available,
         // but unit tests should be hermetic if possible.
-        // However, we rely on yolo11n.onnx for other tests.
+        // However, we rely on yolo26n.onnx for other tests.
 
         // Only run if model exists or can be downloaded
-        if let Ok(model) = YOLOModel::load("yolo11n.onnx") {
+        if let Ok(model) = YOLOModel::load("yolo26n.onnx") {
             assert_eq!(model.task(), Task::Detect);
             assert!(model.num_classes() > 0);
             assert_eq!(model.stride(), 32);
-            assert_eq!(model.imgsz(), (640, 640)); // Default for yolo11n
+            assert_eq!(model.imgsz(), (640, 640)); // Default for yolo26n
             assert!(!model.names().is_empty());
             assert_eq!(model.model_path(), ""); // Placeholder returns empty string
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1412,15 +1412,14 @@ fn postprocess_detect_end2end(
 
     let (oh, ow) = preprocess.orig_shape;
     let (max_w, max_h) = (ow as f32, oh as f32);
-    let conf_thresh = config.confidence_threshold;
     let user_cap = config.max_det.min(max_det);
 
-    let mut rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
+    let mut flat: Vec<f32> = Vec::with_capacity(user_cap * 6);
     for i in 0..max_det {
         let base = i * feats;
         let conf = output[base + 4];
-        if conf < conf_thresh {
-            // End2end outputs are sorted by confidence descending; we can stop.
+        // End2end outputs are sorted by confidence descending; stop on first below threshold.
+        if conf < config.confidence_threshold {
             break;
         }
         let cls = output[base + 5] as usize;
@@ -1434,7 +1433,7 @@ fn postprocess_detect_end2end(
             output[base + 3],
             preprocess,
         );
-        rows.push([
+        flat.extend_from_slice(&[
             x1.clamp(0.0, max_w),
             y1.clamp(0.0, max_h),
             x2.clamp(0.0, max_w),
@@ -1442,21 +1441,16 @@ fn postprocess_detect_end2end(
             conf,
             cls as f32,
         ]);
-        if rows.len() >= user_cap {
+        if flat.len() >= user_cap * 6 {
             break;
         }
     }
 
-    if rows.is_empty() {
-        return results;
+    let n = flat.len() / 6;
+    if n > 0 {
+        let boxes_data = Array2::from_shape_vec((n, 6), flat).expect("flat length matches (n, 6)");
+        results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
     }
-    let mut boxes_data = Array2::zeros((rows.len(), 6));
-    for (i, r) in rows.iter().enumerate() {
-        for (j, v) in r.iter().enumerate() {
-            boxes_data[[i, j]] = *v;
-        }
-    }
-    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
     results
 }
 
@@ -1505,16 +1499,15 @@ fn postprocess_segment_end2end(
 
     let (oh, ow) = preprocess.orig_shape;
     let (max_w, max_h) = (ow as f32, oh as f32);
-    let conf_thresh = config.confidence_threshold;
     let user_cap = config.max_det.min(max_det);
 
-    let mut kept_rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
-    let mut kept_coeffs: Vec<Vec<f32>> = Vec::with_capacity(user_cap);
+    let mut flat_boxes: Vec<f32> = Vec::with_capacity(user_cap * 6);
+    let mut flat_coeffs: Vec<f32> = Vec::with_capacity(user_cap * num_masks);
 
     for i in 0..max_det {
         let base = i * feats;
         let conf = output0[base + 4];
-        if conf < conf_thresh {
+        if conf < config.confidence_threshold {
             break;
         }
         let cls = output0[base + 5] as usize;
@@ -1528,7 +1521,7 @@ fn postprocess_segment_end2end(
             output0[base + 3],
             preprocess,
         );
-        kept_rows.push([
+        flat_boxes.extend_from_slice(&[
             x1.clamp(0.0, max_w),
             y1.clamp(0.0, max_h),
             x2.clamp(0.0, max_w),
@@ -1537,28 +1530,21 @@ fn postprocess_segment_end2end(
             cls as f32,
         ]);
         let coeff_start = base + 6;
-        kept_coeffs.push(output0[coeff_start..coeff_start + num_masks].to_vec());
-        if kept_rows.len() >= user_cap {
+        flat_coeffs.extend_from_slice(&output0[coeff_start..coeff_start + num_masks]);
+        if flat_boxes.len() >= user_cap * 6 {
             break;
         }
     }
 
-    if kept_rows.is_empty() {
+    let num_kept = flat_boxes.len() / 6;
+    if num_kept == 0 {
         return results;
     }
 
-    let num_kept = kept_rows.len();
-    let mut boxes_data = Array2::zeros((num_kept, 6));
-    let mut mask_coeffs = Array2::zeros((num_kept, num_masks));
-    for (i, r) in kept_rows.iter().enumerate() {
-        for (j, v) in r.iter().enumerate() {
-            boxes_data[[i, j]] = *v;
-        }
-        for (m, v) in kept_coeffs[i].iter().enumerate() {
-            mask_coeffs[[i, m]] = *v;
-        }
-    }
-    results.boxes = Some(Boxes::new(boxes_data.clone(), preprocess.orig_shape));
+    let boxes_data =
+        Array2::from_shape_vec((num_kept, 6), flat_boxes).expect("flat length matches (n, 6)");
+    let mask_coeffs = Array2::from_shape_vec((num_kept, num_masks), flat_coeffs)
+        .expect("flat length matches (n, num_masks)");
 
     // Protos -> masks (mirrors standard segment path).
     let mh = shape1[2];
@@ -1637,6 +1623,7 @@ fn postprocess_segment_end2end(
             },
         );
 
+    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
     results.masks = Some(Masks::new(masks_data, preprocess.orig_shape));
     results
 }
@@ -1672,16 +1659,17 @@ fn postprocess_pose_end2end(
 
     let (oh, ow) = preprocess.orig_shape;
     let (max_w, max_h) = (ow as f32, oh as f32);
-    let conf_thresh = config.confidence_threshold;
+    let (scale_y, scale_x) = preprocess.scale;
+    let (pad_top, pad_left) = preprocess.padding;
     let user_cap = config.max_det.min(max_det);
 
-    let mut rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
-    let mut kpts: Vec<Vec<[f32; 3]>> = Vec::with_capacity(user_cap);
+    let mut flat_boxes: Vec<f32> = Vec::with_capacity(user_cap * 6);
+    let mut flat_kpts: Vec<f32> = Vec::with_capacity(user_cap * nk * 3);
 
     for i in 0..max_det {
         let base = i * feats;
         let conf = output[base + 4];
-        if conf < conf_thresh {
+        if conf < config.confidence_threshold {
             break;
         }
         let cls = output[base + 5] as usize;
@@ -1695,7 +1683,7 @@ fn postprocess_pose_end2end(
             output[base + 3],
             preprocess,
         );
-        rows.push([
+        flat_boxes.extend_from_slice(&[
             x1.clamp(0.0, max_w),
             y1.clamp(0.0, max_h),
             x2.clamp(0.0, max_w),
@@ -1704,44 +1692,28 @@ fn postprocess_pose_end2end(
             cls as f32,
         ]);
         let kstart = base + 6;
-        let mut kvec = Vec::with_capacity(nk);
         for k in 0..nk {
             let off = kstart + k * kpt_dim;
-            let kx_raw = output[off];
-            let ky_raw = output[off + 1];
+            let sx = (output[off] - pad_left) / scale_x;
+            let sy = (output[off + 1] - pad_top) / scale_y;
             let kconf = if kpt_dim >= 3 { output[off + 2] } else { 1.0 };
-            let (sx, sy, _, _) = scale_xyxy(kx_raw, ky_raw, kx_raw, ky_raw, preprocess);
-            kvec.push([sx.clamp(0.0, max_w), sy.clamp(0.0, max_h), kconf]);
+            flat_kpts.extend_from_slice(&[sx.clamp(0.0, max_w), sy.clamp(0.0, max_h), kconf]);
         }
-        kpts.push(kvec);
-        if rows.len() >= user_cap {
+        if flat_boxes.len() >= user_cap * 6 {
             break;
         }
     }
 
-    if rows.is_empty() {
-        results.keypoints = Some(Keypoints::new(
-            Array3::zeros((0, nk, 3)),
-            preprocess.orig_shape,
-        ));
-        return results;
-    }
-
-    let n = rows.len();
-    let mut boxes_data = Array2::zeros((n, 6));
-    let mut kdata = Array3::zeros((n, nk, 3));
-    for i in 0..n {
-        for (j, v) in rows[i].iter().enumerate() {
-            boxes_data[[i, j]] = *v;
-        }
-        for k in 0..nk {
-            kdata[[i, k, 0]] = kpts[i][k][0];
-            kdata[[i, k, 1]] = kpts[i][k][1];
-            kdata[[i, k, 2]] = kpts[i][k][2];
-        }
-    }
-    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
+    let n = flat_boxes.len() / 6;
+    // Always emit a keypoints tensor (even empty) to match the non-end2end pose path.
+    let kdata =
+        Array3::from_shape_vec((n, nk, 3), flat_kpts).expect("flat length matches (n, nk, 3)");
     results.keypoints = Some(Keypoints::new(kdata, preprocess.orig_shape));
+    if n > 0 {
+        let boxes_data =
+            Array2::from_shape_vec((n, 6), flat_boxes).expect("flat length matches (n, 6)");
+        results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
+    }
     results
 }
 
@@ -1760,63 +1732,49 @@ fn postprocess_obb_end2end(
     inference_shape: (u32, u32),
 ) -> Results {
     let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
-    if output_shape.len() != 3 || output.is_empty() {
-        return results;
-    }
-    let max_det = output_shape[1];
-    let feats = output_shape[2];
-    if feats < 7 || max_det == 0 {
-        results.obb = Some(Obb::new(Array2::zeros((0, 7)), preprocess.orig_shape));
-        return results;
-    }
+    let mut flat: Vec<f32> = Vec::new();
 
-    let (oh, ow) = preprocess.orig_shape;
-    let (max_w, max_h) = (ow as f32, oh as f32);
-    let conf_thresh = config.confidence_threshold;
-    let user_cap = config.max_det.min(max_det);
-    let (scale_y, scale_x) = preprocess.scale;
-    let (pad_top, pad_left) = preprocess.padding;
+    if output_shape.len() == 3 && !output.is_empty() {
+        let max_det = output_shape[1];
+        let feats = output_shape[2];
+        if feats >= 7 && max_det > 0 {
+            let (oh, ow) = preprocess.orig_shape;
+            let (max_w, max_h) = (ow as f32, oh as f32);
+            let (scale_y, scale_x) = preprocess.scale;
+            let (pad_top, pad_left) = preprocess.padding;
+            let user_cap = config.max_det.min(max_det);
+            flat.reserve(user_cap * 7);
 
-    let mut rows: Vec<[f32; 7]> = Vec::with_capacity(user_cap);
-    for i in 0..max_det {
-        let base = i * feats;
-        let conf = output[base + 4];
-        if conf < conf_thresh {
-            break;
-        }
-        let cls = output[base + 5] as usize;
-        if !config.keep_class(cls) {
-            continue;
-        }
-        let cx = (output[base] - pad_left) / scale_x;
-        let cy = (output[base + 1] - pad_top) / scale_y;
-        let w = output[base + 2] / scale_x;
-        let h = output[base + 3] / scale_y;
-        let angle = output[base + 6];
-        rows.push([
-            cx.clamp(0.0, max_w),
-            cy.clamp(0.0, max_h),
-            w,
-            h,
-            angle,
-            conf,
-            cls as f32,
-        ]);
-        if rows.len() >= user_cap {
-            break;
+            for i in 0..max_det {
+                let base = i * feats;
+                let conf = output[base + 4];
+                if conf < config.confidence_threshold {
+                    break;
+                }
+                let cls = output[base + 5] as usize;
+                if !config.keep_class(cls) {
+                    continue;
+                }
+                let cx = (output[base] - pad_left) / scale_x;
+                let cy = (output[base + 1] - pad_top) / scale_y;
+                flat.extend_from_slice(&[
+                    cx.clamp(0.0, max_w),
+                    cy.clamp(0.0, max_h),
+                    output[base + 2] / scale_x,
+                    output[base + 3] / scale_y,
+                    output[base + 6],
+                    conf,
+                    cls as f32,
+                ]);
+                if flat.len() >= user_cap * 7 {
+                    break;
+                }
+            }
         }
     }
 
-    if rows.is_empty() {
-        results.obb = Some(Obb::new(Array2::zeros((0, 7)), preprocess.orig_shape));
-        return results;
-    }
-    let mut obb_data = Array2::zeros((rows.len(), 7));
-    for (i, r) in rows.iter().enumerate() {
-        for (j, v) in r.iter().enumerate() {
-            obb_data[[i, j]] = *v;
-        }
-    }
+    let n = flat.len() / 7;
+    let obb_data = Array2::from_shape_vec((n, 7), flat).expect("flat length matches (n, 7)");
     results.obb = Some(Obb::new(obb_data, preprocess.orig_shape));
     results
 }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -95,8 +95,12 @@ pub fn postprocess(
             }
         }
         Task::Segment => {
-            let shape0 = &outputs[0].1;
-            if end2end || is_end2end_segment_shape(shape0) {
+            // Derive proto channel count from the second output tensor (shape `[1, nm, mh, mw]`),
+            // so exports with non-default prototype counts are still classified correctly.
+            let proto_channels = outputs
+                .get(1)
+                .and_then(|(_, s)| if s.len() == 4 { Some(s[1]) } else { None });
+            if end2end || is_end2end_segment_shape(&outputs[0].1, proto_channels) {
                 postprocess_segment_end2end(
                     outputs,
                     preprocess,
@@ -122,8 +126,13 @@ pub fn postprocess(
         }
         Task::Pose => {
             let (output, shape) = &outputs[0];
-            let (nk, kpt_dim) = kpt_shape.unwrap_or((17, 3));
-            if end2end || is_end2end_pose_shape(shape, nk, kpt_dim) {
+            // Prefer metadata-provided `kpt_shape`; otherwise infer the keypoint
+            // layout from the tensor shape so non-COCO pose models still work.
+            let resolved_kpt = kpt_shape.or_else(|| infer_end2end_kpt_shape(shape));
+            let is_end2end = end2end
+                || resolved_kpt.is_some_and(|(nk, kd)| is_end2end_pose_shape(shape, nk, kd));
+            if is_end2end {
+                let (nk, kpt_dim) = resolved_kpt.unwrap_or((17, 3));
                 postprocess_pose_end2end(
                     output,
                     shape,
@@ -193,14 +202,35 @@ fn is_end2end_detect_shape(shape: &[usize]) -> bool {
 
 /// Detect if a 3D shape matches YOLO26 end2end segment layout `[1, max_det, 6 + nm]`.
 ///
-/// End2end segment rows are `[x1, y1, x2, y2, conf, cls, 32 mask coeffs]` = 38.
-fn is_end2end_segment_shape(shape: &[usize]) -> bool {
-    shape.len() == 3 && shape[2] == 6 + 32 && shape[1] <= 4096
+/// When the proto tensor's channel count is known (passed via `proto_channels`),
+/// it is used as the authoritative `nm`; otherwise the shape is rejected since
+/// hardcoding `nm=32` would misclassify exports with non-default prototype counts.
+fn is_end2end_segment_shape(shape: &[usize], proto_channels: Option<usize>) -> bool {
+    proto_channels.is_some_and(|nm| shape.len() == 3 && shape[2] == 6 + nm && shape[1] <= 4096)
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end pose layout `[1, max_det, 6 + nk*dim]`.
 fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
     shape.len() == 3 && shape[2] == 6 + nk * kpt_dim && shape[1] <= 4096
+}
+
+/// Infer `(nk, kpt_dim)` from a pose tensor shape assumed to be end-to-end
+/// (`[1, max_det, 6 + nk*kpt_dim]`). Used when `kpt_shape` metadata is absent.
+///
+/// Prefers `kpt_dim=3` (Ultralytics default with visibility); falls back to `kpt_dim=2`.
+/// Returns `None` if the shape doesn't look like the end-to-end layout.
+fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
+    if shape.len() != 3 || shape[1] == 0 || shape[1] > 4096 || shape[2] <= 6 {
+        return None;
+    }
+    let kpt_feats = shape[2] - 6;
+    if kpt_feats.is_multiple_of(3) {
+        Some((kpt_feats / 3, 3))
+    } else if kpt_feats.is_multiple_of(2) {
+        Some((kpt_feats / 2, 2))
+    } else {
+        None
+    }
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end OBB layout `[1, max_det, 7]`.

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -62,45 +62,87 @@ pub fn postprocess(
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
+    end2end: bool,
+    kpt_shape: Option<(usize, usize)>,
 ) -> Results {
     match task {
         Task::Detect => {
             let (output, shape) = &outputs[0];
-            postprocess_detect(
-                output,
-                shape,
-                preprocess,
-                config,
-                names,
-                orig_img,
-                path,
-                speed,
-                inference_shape,
-            )
+            if end2end || is_end2end_detect_shape(shape) {
+                postprocess_detect_end2end(
+                    output, shape, preprocess, config, names, orig_img, path, speed,
+                    inference_shape,
+                )
+            } else {
+                postprocess_detect(
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                )
+            }
         }
-        Task::Segment => postprocess_segment(
-            outputs,
-            preprocess,
-            config,
-            names,
-            orig_img,
-            path,
-            speed,
-            inference_shape,
-        ),
+        Task::Segment => {
+            let shape0 = &outputs[0].1;
+            if end2end || is_end2end_segment_shape(shape0) {
+                postprocess_segment_end2end(
+                    outputs,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                )
+            } else {
+                postprocess_segment(
+                    outputs,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                )
+            }
+        }
         Task::Pose => {
             let (output, shape) = &outputs[0];
-            postprocess_pose(
-                output,
-                shape,
-                preprocess,
-                config,
-                names,
-                orig_img,
-                path,
-                speed,
-                inference_shape,
-            )
+            let (nk, kpt_dim) = kpt_shape.unwrap_or((17, 3));
+            if end2end || is_end2end_pose_shape(shape, nk, kpt_dim) {
+                postprocess_pose_end2end(
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                    nk,
+                    kpt_dim,
+                )
+            } else {
+                postprocess_pose(
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                )
+            }
         }
         Task::Classify => {
             let (output, shape) = &outputs[0];
@@ -108,19 +150,48 @@ pub fn postprocess(
         }
         Task::Obb => {
             let (output, shape) = &outputs[0];
-            postprocess_obb(
-                output,
-                shape,
-                preprocess,
-                config,
-                names,
-                orig_img,
-                path,
-                speed,
-                inference_shape,
-            )
+            if end2end || is_end2end_obb_shape(shape) {
+                postprocess_obb_end2end(
+                    output, shape, preprocess, config, names, orig_img, path, speed,
+                    inference_shape,
+                )
+            } else {
+                postprocess_obb(
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                )
+            }
         }
     }
+}
+
+/// Detect if a 3D shape matches YOLO26 end2end detect layout `[1, max_det, 6]`.
+fn is_end2end_detect_shape(shape: &[usize]) -> bool {
+    shape.len() == 3 && shape[2] == 6 && shape[1] <= 4096
+}
+
+/// Detect if a 3D shape matches YOLO26 end2end segment layout `[1, max_det, 6 + nm]`.
+///
+/// End2end segment rows are `[x1, y1, x2, y2, conf, cls, 32 mask coeffs]` = 38.
+fn is_end2end_segment_shape(shape: &[usize]) -> bool {
+    shape.len() == 3 && shape[2] == 6 + 32 && shape[1] <= 4096
+}
+
+/// Detect if a 3D shape matches YOLO26 end2end pose layout `[1, max_det, 6 + nk*dim]`.
+fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
+    shape.len() == 3 && shape[2] == 6 + nk * kpt_dim && shape[1] <= 4096
+}
+
+/// Detect if a 3D shape matches YOLO26 end2end OBB layout `[1, max_det, 7]`.
+fn is_end2end_obb_shape(shape: &[usize]) -> bool {
+    shape.len() == 3 && shape[2] == 7 && shape[1] <= 4096
 }
 
 /// Post-process detection model output.
@@ -1241,6 +1312,457 @@ fn postprocess_obb(
 
     results.obb = Some(Obb::new(obb_data, preprocess.orig_shape));
 
+    results
+}
+
+// -------- YOLO26 end-to-end (NMS-free) postprocessing --------
+//
+// End-to-end exports bake NMS into the graph and produce a tensor of shape
+// `[B, max_det, 6 + extra]`, where the first 6 columns are always
+// `[x1, y1, x2, y2, conf, cls]` (OBB is the exception — see `postprocess_obb_end2end`).
+// Coordinates are in the letterboxed model-input space, so we still scale/pad-correct
+// them back to original-image space. No NMS, no class-score matrix.
+
+/// Helper: scale a model-space xyxy box to original image coordinates.
+#[inline]
+fn scale_xyxy(
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    preprocess: &PreprocessResult,
+) -> (f32, f32, f32, f32) {
+    let (scale_y, scale_x) = preprocess.scale;
+    let (pad_top, pad_left) = preprocess.padding;
+    (
+        (x1 - pad_left) / scale_x,
+        (y1 - pad_top) / scale_y,
+        (x2 - pad_left) / scale_x,
+        (y2 - pad_top) / scale_y,
+    )
+}
+
+/// Post-process YOLO26 end-to-end detection output `[1, max_det, 6]`.
+#[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+fn postprocess_detect_end2end(
+    output: &[f32],
+    output_shape: &[usize],
+    preprocess: &PreprocessResult,
+    config: &InferenceConfig,
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+) -> Results {
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+
+    if output_shape.len() != 3 || output.is_empty() {
+        return results;
+    }
+    let max_det = output_shape[1];
+    let feats = output_shape[2];
+    if feats < 6 || max_det == 0 {
+        return results;
+    }
+
+    let (oh, ow) = preprocess.orig_shape;
+    let (max_w, max_h) = (ow as f32, oh as f32);
+    let conf_thresh = config.confidence_threshold;
+    let user_cap = config.max_det.min(max_det);
+
+    let mut rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
+    for i in 0..max_det {
+        let base = i * feats;
+        let conf = output[base + 4];
+        if conf < conf_thresh {
+            // End2end outputs are sorted by confidence descending; we can stop.
+            break;
+        }
+        let cls = output[base + 5] as usize;
+        if !config.keep_class(cls) {
+            continue;
+        }
+        let (x1, y1, x2, y2) =
+            scale_xyxy(output[base], output[base + 1], output[base + 2], output[base + 3], preprocess);
+        rows.push([
+            x1.clamp(0.0, max_w),
+            y1.clamp(0.0, max_h),
+            x2.clamp(0.0, max_w),
+            y2.clamp(0.0, max_h),
+            conf,
+            cls as f32,
+        ]);
+        if rows.len() >= user_cap {
+            break;
+        }
+    }
+
+    if rows.is_empty() {
+        return results;
+    }
+    let mut boxes_data = Array2::zeros((rows.len(), 6));
+    for (i, r) in rows.iter().enumerate() {
+        for (j, v) in r.iter().enumerate() {
+            boxes_data[[i, j]] = *v;
+        }
+    }
+    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
+    results
+}
+
+/// Post-process YOLO26 end-to-end segmentation output.
+///
+/// `output0`: `[1, max_det, 6 + nm]`, `output1`: `[1, nm, mh, mw]` (protos).
+#[allow(
+    clippy::too_many_arguments,
+    clippy::cast_precision_loss,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+fn postprocess_segment_end2end(
+    outputs: Vec<(&[f32], Vec<usize>)>,
+    preprocess: &PreprocessResult,
+    config: &InferenceConfig,
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+) -> Results {
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    if outputs.len() < 2 {
+        eprintln!(
+            "WARNING ⚠️ End2end segmentation missing protos output (got {} outputs).",
+            outputs.len()
+        );
+        return results;
+    }
+    let (output0, shape0) = &outputs[0];
+    let (output1, shape1) = &outputs[1];
+
+    if shape0.len() != 3 || shape1.len() != 4 {
+        return results;
+    }
+    let max_det = shape0[1];
+    let feats = shape0[2];
+    let num_masks = shape1[1];
+    if feats < 6 + num_masks {
+        eprintln!(
+            "WARNING ⚠️ End2end segment features ({feats}) < 6 + num_masks ({}).",
+            num_masks
+        );
+        return results;
+    }
+
+    let (oh, ow) = preprocess.orig_shape;
+    let (max_w, max_h) = (ow as f32, oh as f32);
+    let conf_thresh = config.confidence_threshold;
+    let user_cap = config.max_det.min(max_det);
+
+    let mut kept_rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
+    let mut kept_coeffs: Vec<Vec<f32>> = Vec::with_capacity(user_cap);
+
+    for i in 0..max_det {
+        let base = i * feats;
+        let conf = output0[base + 4];
+        if conf < conf_thresh {
+            break;
+        }
+        let cls = output0[base + 5] as usize;
+        if !config.keep_class(cls) {
+            continue;
+        }
+        let (x1, y1, x2, y2) = scale_xyxy(
+            output0[base],
+            output0[base + 1],
+            output0[base + 2],
+            output0[base + 3],
+            preprocess,
+        );
+        kept_rows.push([
+            x1.clamp(0.0, max_w),
+            y1.clamp(0.0, max_h),
+            x2.clamp(0.0, max_w),
+            y2.clamp(0.0, max_h),
+            conf,
+            cls as f32,
+        ]);
+        let coeff_start = base + 6;
+        kept_coeffs.push(output0[coeff_start..coeff_start + num_masks].to_vec());
+        if kept_rows.len() >= user_cap {
+            break;
+        }
+    }
+
+    if kept_rows.is_empty() {
+        return results;
+    }
+
+    let num_kept = kept_rows.len();
+    let mut boxes_data = Array2::zeros((num_kept, 6));
+    let mut mask_coeffs = Array2::zeros((num_kept, num_masks));
+    for (i, r) in kept_rows.iter().enumerate() {
+        for (j, v) in r.iter().enumerate() {
+            boxes_data[[i, j]] = *v;
+        }
+        for (m, v) in kept_coeffs[i].iter().enumerate() {
+            mask_coeffs[[i, m]] = *v;
+        }
+    }
+    results.boxes = Some(Boxes::new(boxes_data.clone(), preprocess.orig_shape));
+
+    // Protos -> masks (mirrors standard segment path).
+    let mh = shape1[2];
+    let mw = shape1[3];
+    let protos = match Array2::from_shape_vec((num_masks, mh * mw), output1.to_vec()) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("WARNING ⚠️ Failed to build protos array: {e}. Skipping masks.");
+            return results;
+        }
+    };
+    let masks_flat = mask_coeffs.dot(&protos);
+
+    let (th, tw) = inference_shape;
+    let (pad_top, pad_left) = preprocess.padding;
+    let scale_w = mw as f32 / tw as f32;
+    let scale_h = mh as f32 / th as f32;
+    let crop_x = pad_left * scale_w;
+    let crop_y = pad_top * scale_h;
+    let crop_w = 2.0f32.mul_add(-crop_x, mw as f32);
+    let crop_h = 2.0f32.mul_add(-crop_y, mh as f32);
+
+    let mut masks_data = Array3::zeros((num_kept, oh as usize, ow as usize));
+    Zip::from(masks_data.outer_iter_mut())
+        .and(masks_flat.outer_iter())
+        .and(boxes_data.outer_iter())
+        .par_for_each(
+            |mut mask_out: ArrayViewMut2<f32>,
+             mask_flat: ArrayView1<f32>,
+             box_data: ArrayView1<f32>| {
+                let mut resizer = Resizer::new();
+                let resize_alg = ResizeAlg::Convolution(FilterType::Bilinear);
+                let f32_data: Vec<f32> = mask_flat
+                    .iter()
+                    .map(|&v| 1.0 / (1.0 + (-v).exp()))
+                    .collect();
+                let src_bytes: &[u8] = bytemuck::cast_slice(&f32_data);
+                let src_image = match Image::from_vec_u8(
+                    mw as u32,
+                    mh as u32,
+                    src_bytes.to_vec(),
+                    PixelType::F32,
+                ) {
+                    Ok(i) => i,
+                    Err(_) => return,
+                };
+                let mut dst_image = Image::new(ow, oh, PixelType::F32);
+                let options = ResizeOptions::new().resize_alg(resize_alg).crop(
+                    f64::from(crop_x.max(0.0)),
+                    f64::from(crop_y.max(0.0)),
+                    f64::from(crop_w.max(1.0).min(mw as f32)),
+                    f64::from(crop_h.max(1.0).min(mh as f32)),
+                );
+                if resizer
+                    .resize(&src_image, &mut dst_image, &options)
+                    .is_err()
+                {
+                    return;
+                }
+                let dst_bytes = dst_image.buffer();
+                let dst_slice: &[f32] = bytemuck::cast_slice(dst_bytes);
+                let x1 = box_data[0].max(0.0).min(ow as f32);
+                let y1 = box_data[1].max(0.0).min(oh as f32);
+                let x2 = box_data[2].max(0.0).min(ow as f32);
+                let y2 = box_data[3].max(0.0).min(oh as f32);
+                for y in 0..oh as usize {
+                    for x in 0..ow as usize {
+                        let val = dst_slice[y * ow as usize + x];
+                        let xf = x as f32;
+                        let yf = y as f32;
+                        if xf >= x1 && xf <= x2 && yf >= y1 && yf <= y2 {
+                            mask_out[[y, x]] = val;
+                        }
+                    }
+                }
+            },
+        );
+
+    results.masks = Some(Masks::new(masks_data, preprocess.orig_shape));
+    results
+}
+
+/// Post-process YOLO26 end-to-end pose output `[1, max_det, 6 + nk*kpt_dim]`.
+#[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+fn postprocess_pose_end2end(
+    output: &[f32],
+    output_shape: &[usize],
+    preprocess: &PreprocessResult,
+    config: &InferenceConfig,
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+    nk: usize,
+    kpt_dim: usize,
+) -> Results {
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    if output_shape.len() != 3 || output.is_empty() || nk == 0 || kpt_dim < 2 {
+        return results;
+    }
+    let max_det = output_shape[1];
+    let feats = output_shape[2];
+    if feats < 6 + nk * kpt_dim || max_det == 0 {
+        return results;
+    }
+
+    let (oh, ow) = preprocess.orig_shape;
+    let (max_w, max_h) = (ow as f32, oh as f32);
+    let conf_thresh = config.confidence_threshold;
+    let user_cap = config.max_det.min(max_det);
+
+    let mut rows: Vec<[f32; 6]> = Vec::with_capacity(user_cap);
+    let mut kpts: Vec<Vec<[f32; 3]>> = Vec::with_capacity(user_cap);
+
+    for i in 0..max_det {
+        let base = i * feats;
+        let conf = output[base + 4];
+        if conf < conf_thresh {
+            break;
+        }
+        let cls = output[base + 5] as usize;
+        if !config.keep_class(cls) {
+            continue;
+        }
+        let (x1, y1, x2, y2) = scale_xyxy(
+            output[base],
+            output[base + 1],
+            output[base + 2],
+            output[base + 3],
+            preprocess,
+        );
+        rows.push([
+            x1.clamp(0.0, max_w),
+            y1.clamp(0.0, max_h),
+            x2.clamp(0.0, max_w),
+            y2.clamp(0.0, max_h),
+            conf,
+            cls as f32,
+        ]);
+        let kstart = base + 6;
+        let mut kvec = Vec::with_capacity(nk);
+        for k in 0..nk {
+            let off = kstart + k * kpt_dim;
+            let kx_raw = output[off];
+            let ky_raw = output[off + 1];
+            let kconf = if kpt_dim >= 3 { output[off + 2] } else { 1.0 };
+            let (sx, sy, _, _) = scale_xyxy(kx_raw, ky_raw, kx_raw, ky_raw, preprocess);
+            kvec.push([sx.clamp(0.0, max_w), sy.clamp(0.0, max_h), kconf]);
+        }
+        kpts.push(kvec);
+        if rows.len() >= user_cap {
+            break;
+        }
+    }
+
+    if rows.is_empty() {
+        results.keypoints = Some(Keypoints::new(Array3::zeros((0, nk, 3)), preprocess.orig_shape));
+        return results;
+    }
+
+    let n = rows.len();
+    let mut boxes_data = Array2::zeros((n, 6));
+    let mut kdata = Array3::zeros((n, nk, 3));
+    for i in 0..n {
+        for (j, v) in rows[i].iter().enumerate() {
+            boxes_data[[i, j]] = *v;
+        }
+        for k in 0..nk {
+            kdata[[i, k, 0]] = kpts[i][k][0];
+            kdata[[i, k, 1]] = kpts[i][k][1];
+            kdata[[i, k, 2]] = kpts[i][k][2];
+        }
+    }
+    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
+    results.keypoints = Some(Keypoints::new(kdata, preprocess.orig_shape));
+    results
+}
+
+/// Post-process YOLO26 end-to-end OBB output `[1, max_det, 7]`
+/// with layout `[cx, cy, w, h, conf, cls, angle]`.
+#[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+fn postprocess_obb_end2end(
+    output: &[f32],
+    output_shape: &[usize],
+    preprocess: &PreprocessResult,
+    config: &InferenceConfig,
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+) -> Results {
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    if output_shape.len() != 3 || output.is_empty() {
+        return results;
+    }
+    let max_det = output_shape[1];
+    let feats = output_shape[2];
+    if feats < 7 || max_det == 0 {
+        results.obb = Some(Obb::new(Array2::zeros((0, 7)), preprocess.orig_shape));
+        return results;
+    }
+
+    let (oh, ow) = preprocess.orig_shape;
+    let (max_w, max_h) = (ow as f32, oh as f32);
+    let conf_thresh = config.confidence_threshold;
+    let user_cap = config.max_det.min(max_det);
+    let (scale_y, scale_x) = preprocess.scale;
+    let (pad_top, pad_left) = preprocess.padding;
+
+    let mut rows: Vec<[f32; 7]> = Vec::with_capacity(user_cap);
+    for i in 0..max_det {
+        let base = i * feats;
+        let conf = output[base + 4];
+        if conf < conf_thresh {
+            break;
+        }
+        let cls = output[base + 5] as usize;
+        if !config.keep_class(cls) {
+            continue;
+        }
+        let cx = (output[base] - pad_left) / scale_x;
+        let cy = (output[base + 1] - pad_top) / scale_y;
+        let w = output[base + 2] / scale_x;
+        let h = output[base + 3] / scale_y;
+        let angle = output[base + 6];
+        rows.push([
+            cx.clamp(0.0, max_w),
+            cy.clamp(0.0, max_h),
+            w,
+            h,
+            angle,
+            conf,
+            cls as f32,
+        ]);
+        if rows.len() >= user_cap {
+            break;
+        }
+    }
+
+    if rows.is_empty() {
+        results.obb = Some(Obb::new(Array2::zeros((0, 7)), preprocess.orig_shape));
+        return results;
+    }
+    let mut obb_data = Array2::zeros((rows.len(), 7));
+    for (i, r) in rows.iter().enumerate() {
+        for (j, v) in r.iter().enumerate() {
+            obb_data[[i, j]] = *v;
+        }
+    }
+    results.obb = Some(Obb::new(obb_data, preprocess.orig_shape));
     results
 }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -70,7 +70,14 @@ pub fn postprocess(
             let (output, shape) = &outputs[0];
             if end2end || is_end2end_detect_shape(shape) {
                 postprocess_detect_end2end(
-                    output, shape, preprocess, config, names, orig_img, path, speed,
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
                     inference_shape,
                 )
             } else {
@@ -152,7 +159,14 @@ pub fn postprocess(
             let (output, shape) = &outputs[0];
             if end2end || is_end2end_obb_shape(shape) {
                 postprocess_obb_end2end(
-                    output, shape, preprocess, config, names, orig_img, path, speed,
+                    output,
+                    shape,
+                    preprocess,
+                    config,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
                     inference_shape,
                 )
             } else {
@@ -1383,8 +1397,13 @@ fn postprocess_detect_end2end(
         if !config.keep_class(cls) {
             continue;
         }
-        let (x1, y1, x2, y2) =
-            scale_xyxy(output[base], output[base + 1], output[base + 2], output[base + 3], preprocess);
+        let (x1, y1, x2, y2) = scale_xyxy(
+            output[base],
+            output[base + 1],
+            output[base + 2],
+            output[base + 3],
+            preprocess,
+        );
         rows.push([
             x1.clamp(0.0, max_w),
             y1.clamp(0.0, max_h),
@@ -1418,7 +1437,9 @@ fn postprocess_detect_end2end(
     clippy::too_many_arguments,
     clippy::cast_precision_loss,
     clippy::too_many_lines,
-    clippy::needless_pass_by_value
+    clippy::needless_pass_by_value,
+    clippy::similar_names,
+    clippy::manual_let_else
 )]
 fn postprocess_segment_end2end(
     outputs: Vec<(&[f32], Vec<usize>)>,
@@ -1448,10 +1469,7 @@ fn postprocess_segment_end2end(
     let feats = shape0[2];
     let num_masks = shape1[1];
     if feats < 6 + num_masks {
-        eprintln!(
-            "WARNING ⚠️ End2end segment features ({feats}) < 6 + num_masks ({}).",
-            num_masks
-        );
+        eprintln!("WARNING ⚠️ End2end segment features ({feats}) < 6 + num_masks ({num_masks}).");
         return results;
     }
 
@@ -1594,7 +1612,11 @@ fn postprocess_segment_end2end(
 }
 
 /// Post-process YOLO26 end-to-end pose output `[1, max_det, 6 + nk*kpt_dim]`.
-#[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::cast_precision_loss,
+    clippy::similar_names
+)]
 fn postprocess_pose_end2end(
     output: &[f32],
     output_shape: &[usize],
@@ -1668,7 +1690,10 @@ fn postprocess_pose_end2end(
     }
 
     if rows.is_empty() {
-        results.keypoints = Some(Keypoints::new(Array3::zeros((0, nk, 3)), preprocess.orig_shape));
+        results.keypoints = Some(Keypoints::new(
+            Array3::zeros((0, nk, 3)),
+            preprocess.orig_shape,
+        ));
         return results;
     }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -215,21 +215,24 @@ fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
 }
 
 /// Infer `(nk, kpt_dim)` from a pose tensor shape assumed to be end-to-end
-/// (`[1, max_det, 6 + nk*kpt_dim]`). Used when `kpt_shape` metadata is absent.
+/// (`[1, max_det, 6 + nk*kpt_dim]`). Used only when `kpt_shape` metadata is absent.
 ///
-/// Prefers `kpt_dim=3` (Ultralytics default with visibility); falls back to `kpt_dim=2`.
-/// Returns `None` if the shape doesn't look like the end-to-end layout.
+/// Returns `None` for shapes that don't match the end-to-end layout, and for
+/// shapes where `kpt_feats` is divisible by both 2 and 3 (e.g. 36, 42) because
+/// the layout is ambiguous — `(12, 3)` and `(18, 2)` both decode the same
+/// tensor. Ambiguous cases fall through to the legacy pose path rather than
+/// silently guessing the wrong dimension.
 fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
     if shape.len() != 3 || shape[1] == 0 || shape[1] > 4096 || shape[2] <= 6 {
         return None;
     }
     let kpt_feats = shape[2] - 6;
-    if kpt_feats.is_multiple_of(3) {
-        Some((kpt_feats / 3, 3))
-    } else if kpt_feats.is_multiple_of(2) {
-        Some((kpt_feats / 2, 2))
-    } else {
-        None
+    let div3 = kpt_feats.is_multiple_of(3);
+    let div2 = kpt_feats.is_multiple_of(2);
+    match (div3, div2) {
+        (true, false) => Some((kpt_feats / 3, 3)),
+        (false, true) => Some((kpt_feats / 2, 2)),
+        _ => None, // not divisible by either, or ambiguous (divisible by 6)
     }
 }
 
@@ -1796,6 +1799,20 @@ mod tests {
         assert_eq!(nc, 80);
         assert_eq!(np, 8400);
         assert!(transposed);
+    }
+
+    #[test]
+    fn test_infer_end2end_kpt_shape() {
+        // COCO pose: 17 kpts × 3 dims -> kpt_feats=51 (only div3) -> (17, 3)
+        assert_eq!(infer_end2end_kpt_shape(&[1, 300, 6 + 51]), Some((17, 3)));
+        // Pure 2D pose: 17 × 2 -> kpt_feats=34 (only div2) -> (17, 2)
+        assert_eq!(infer_end2end_kpt_shape(&[1, 300, 6 + 34]), Some((17, 2)));
+        // Ambiguous (divisible by 6): 12 × 3 vs 18 × 2 both decode to 36 -> None
+        assert_eq!(infer_end2end_kpt_shape(&[1, 300, 6 + 36]), None);
+        // Shape that isn't the end-to-end layout -> None
+        assert_eq!(infer_end2end_kpt_shape(&[1, 56, 8400]), None);
+        // shape[2] <= 6 -> None (no keypoint features)
+        assert_eq!(infer_end2end_kpt_shape(&[1, 300, 6]), None);
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ fn test_run_prediction_e2e() {
     // Basic E2E test for run_prediction
     // This ensures the main CLI entry point runs without panicking on valid input
     let args = PredictArgs {
-        model: Some("yolo11n.onnx".to_string()),
+        model: Some("yolo26n.onnx".to_string()),
         source: None, // Will use default images and download them
         conf: 0.25,
         iou: 0.45,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates `ultralytics/inference` to default to YOLO26 models and adds support for YOLO26 end-to-end ONNX outputs across multiple tasks 🚀

### 📊 Key Changes
- Switched the library’s default model references from `yolo11n.onnx` to `yolo26n.onnx` across the CLI, docs, examples, tests, and README 🆕
- Bumped the crate version from `0.0.9` to `0.0.10` 📦
- Expanded model auto-download support to include both YOLO26 and YOLO11 nano ONNX models for detection, segmentation, pose, OBB, and classification 🌐
- Simplified download handling by using a shared assets base URL plus a supported-model list instead of hardcoded per-model URLs 🛠️
- Added new model metadata parsing for:
  - `end2end` to detect YOLO26-style NMS-free exports
  - `kpt_shape` to better support pose models with different keypoint layouts 🧠
- Introduced YOLO26 end-to-end postprocessing paths for:
  - detection
  - segmentation
  - pose
  - oriented bounding boxes (OBB) ⚡
- Added shape-based fallback detection for end-to-end outputs when metadata is missing, plus tests for keypoint-shape inference ✅
- Updated library docs to clarify supported YOLO versions, now explicitly highlighting YOLO11 and YOLO26 📘

### 🎯 Purpose & Impact
- Makes YOLO26 the new out-of-the-box default, aligning the Rust inference library with Ultralytics’ latest recommended model family 🎯
- Improves compatibility with modern YOLO26 ONNX exports, especially end-to-end models that already include NMS in the graph 🔄
- Reduces setup friction by auto-downloading more supported models and making defaults more predictable for new users 🙌
- Improves robustness for pose and segmentation models by handling more metadata variations and non-default output shapes 🧩
- Helps both developers and end users run inference more smoothly with fewer manual adjustments, especially when working with YOLO26 exports in production 🚀
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
