### PR TITLE
perf: ⚡ improve speed for CUDA execution provider initialization

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -152,11 +152,7 @@ impl YOLOModel {
                 }
                 #[cfg(feature = "cuda")]
                 crate::Device::Cuda(i) => {
-                    eps.push(
-                        ort::execution_providers::CUDAExecutionProvider::default()
-                            .with_device_id(*i as i32)
-                            .build(),
-                    );
+                    eps.push(Self::build_cuda_ep(*i as i32));
                     provider_name = "CUDAExecutionProvider";
                 }
                 #[cfg(feature = "coreml")]
@@ -224,7 +220,7 @@ impl YOLOModel {
 
             #[cfg(feature = "cuda")]
             {
-                eps.push(ort::execution_providers::CUDAExecutionProvider::default().build());
+                eps.push(Self::build_cuda_ep(0));
                 if provider_name == "CPUExecutionProvider" {
                     provider_name = "CUDAExecutionProvider";
                 }
@@ -404,6 +400,24 @@ impl YOLOModel {
         model.warmup()?;
 
         Ok(model)
+    }
+
+    /// Build the CUDA execution provider.
+    ///
+    /// TF32 is enabled. TF32 is a reduced-precision format available on
+    /// NVIDIA Tensor cores (Ampere and newer) that accelerates FP32
+    /// `MatMul` and `Conv` ops by truncating the mantissa to 10 bits before
+    /// multiplying, while keeping FP32 range for accumulation. It typically
+    /// gives a significant speedup on FP32 models with accuracy loss well
+    /// below detection-threshold sensitivity. On GPUs without TF32
+    /// hardware (pre-Ampere), the flag is a silent no-op cuDNN falls
+    /// back to standard FP32.
+    #[cfg(feature = "cuda")]
+    fn build_cuda_ep(device_id: i32) -> ort::execution_providers::ExecutionProviderDispatch {
+        ort::execution_providers::CUDAExecutionProvider::default()
+            .with_device_id(device_id)
+            .with_tf32(true)
+            .build()
     }
 
     /// Maximum allowed image dimension to prevent OOM during warmup.


### PR DESCRIPTION
This Fix: #87 and Enable TF32 (`use_tf32 = true`) on the CUDA execution provider by default.

ORT's `CUDAExecutionProvider::default()` ships with TF32 **off**. TF32 is a reduced-precision format available on NVIDIA Tensor cores (Ampere and newer) that accelerates FP32 `MatMul` and `Conv` ops by truncating the mantissa to 10 bits before multiplying, while keeping FP32 range for accumulation. On GPUs without TF32 hardware (pre-Ampere), the flag is a silent no-op cuDNN falls back to standard FP32, so this change is safe for all CUDA-capable GPUs.

`yolo26l` FP32 ONNX inference on CUDA went from ~10.3 ms to ~8.0 ms on an RTX 4000 Ada Laptop GPU  a ~22% reduction in end-to-end per-frame latency for no code complexity cost.

### Measurements

Hardware: RTX 4000 Ada Laptop GPU  ·  model: `yolo26l.onnx` (FP32, imgsz=640) source: `people.mp4` (341 frames @ 1920×1080)  ·  `InferenceConfig` with `rect=false`, 10-iter warmup, mean over 341 iters.

| Build | Inference (ms) | Wall (ms) | FPS |
|---|---:|---:|---:|
| CUDA EP (TF32 off baseline) | 10.34 | 11.38 | 88 |
| CUDA EP (TF32 on this PR)   | 7.98  | 9.03  | 111 |

TensorRT Included benchmark vs Pytorch FP16

| Setup | Inference (ms) | Wall (ms) | FPS |
|---|---:|---:|---:|
| Python `.pt` + `half=True` (CUDA)                 | 4.29 | 5.39 | 186 |
| Rust **TensorRT EP**, FP16 ONNX                   | **2.92** | **3.77** | **265** |

### Notes for users

This PR only closes part of the gap versus PyTorch on `.pt` + `half=True`. Two user-side steps remain for best latency:

1. **Export the ONNX as FP16** (`yolo export … half=True`). Runtime FP32 => FP16 conversion is not done by ORT; the file must already be FP16.
2. **Use the TensorRT EP** (`--device tensorrt:0`, built with `--features tensorrt`). Enabling the feature alone does not switch EPs. 

**With FP16 ONNX + TensorRT EP on the same hardware, inference drops to ~2.9 ms / 265 FPS (vs 4.3 ms / 186 FPS for Python `.pt` half=True).**

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves CUDA inference setup in `ultralytics/inference` by centralizing GPU provider creation and enabling TF32 acceleration for supported NVIDIA GPUs.

### 📊 Key Changes
- Added a new internal helper function, `build_cuda_ep(device_id)`, to create the CUDA execution provider in one place.
- Replaced duplicated CUDA provider initialization code with calls to the new helper.
- Enabled `TF32` by default for the CUDA execution provider using `.with_tf32(true)`.
- Preserved device-specific CUDA selection by continuing to pass the configured GPU device ID.
- Added inline documentation explaining what TF32 does and when it helps.

### 🎯 Purpose & Impact
- ⚡ **Faster inference on newer NVIDIA GPUs:** TF32 can speed up FP32-based model execution, especially on Ampere and newer hardware.
- 🧹 **Cleaner, easier-to-maintain code:** Centralizing CUDA setup reduces duplication and makes future changes safer.
- 🛡️ **Low-risk improvement:** On older GPUs that do not support TF32, the setting is effectively ignored, so behavior falls back to standard FP32 execution.
- 🎯 **Better default performance:** Users running inference on CUDA-enabled systems may see improved throughput without changing their code.
- 📚 **More transparent behavior:** The added comments clarify the tradeoff and expected accuracy impact for developers and users.