### PR TITLE
fix: 🐞 remove redundant CPUExecutionProvider assignments in model.rs

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -146,10 +146,7 @@ impl YOLOModel {
         if let Some(device) = &config.device {
             // User requested specific device
             match device {
-                crate::Device::Cpu => {
-                    // No specific provider needed, will fall back to CPU
-                    provider_name = "CPUExecutionProvider";
-                }
+                crate::Device::Cpu => {}
                 #[cfg(feature = "cuda")]
                 crate::Device::Cuda(i) => {
                     eps.push(Self::build_cuda_ep(*i as i32));
@@ -210,8 +207,6 @@ impl YOLOModel {
             }
         } else {
             // Default: Register all available providers in preference order
-            provider_name = "CPUExecutionProvider";
-
             #[cfg(feature = "tensorrt")]
             {
                 eps.push(ort::execution_providers::TensorRTExecutionProvider::default().build());

--- a/src/model.rs
+++ b/src/model.rs
@@ -141,6 +141,7 @@ impl YOLOModel {
         // Register execution providers based on features and device config
         #[allow(unused_mut)]
         let mut eps: Vec<ort::execution_providers::ExecutionProviderDispatch> = Vec::new();
+        #[allow(unused_mut)]
         let mut provider_name = "CPUExecutionProvider";
 
         if let Some(device) = &config.device {


### PR DESCRIPTION
- Remove redundant `provider_name = "CPUExecutionProvider"` in `Device::Cpu` match arm — the default initialization already covers this
- Remove redundant `provider_name = "CPUExecutionProvider"` at the top of the `else` branch (auto-detect path) for the same reason
- Collapse `Device::Cpu => { ... }` arm body to an empty `{}`
- `provider_name` is initialized to `"CPUExecutionProvider"` at declaration. Both removed assignments were reassigning the same value unconditionally.
- Feature not compiled in: hits `_ => warn!(...)` arm, `eps` stays empty, ORT uses CPU
- Feature compiled in but hardware unavailable: ORT internally falls back to CPU at session build time
- Neither case panics or returns an error
    

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR simplifies execution provider selection in `YOLOModel`, cleaning up CPU fallback handling without changing overall inference behavior.

### 📊 Key Changes
- Removed redundant assignments of `provider_name = "CPUExecutionProvider"` in `src/model.rs`.
- Simplified the `Device::Cpu` match branch so it now relies on the existing default instead of explicitly reassigning the CPU provider.
- Added `#[allow(unused_mut)]` to `provider_name` initialization, matching the conditional logic where it may or may not be updated depending on enabled features and device choice.
- Kept the provider registration flow intact for accelerated backends like CUDA and TensorRT, while preserving CPU as the default fallback.

### 🎯 Purpose & Impact
- ✅ **Cleaner code:** Reduces unnecessary duplication, making the execution provider setup easier to read and maintain.
- ⚙️ **Safer defaults:** Keeps CPU as the built-in fallback path without requiring repeated manual assignment.
- 🚀 **No expected user-facing behavior change:** Inference should continue working the same way, including automatic fallback to CPU when no accelerator is selected.
- 🧩 **Improves maintainability:** Makes future updates to device/provider selection logic simpler and less error-prone for developers.