### PR TITLE
chore: update lru dependency to version 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1405,11 +1411,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ fast_image_resize = { version = "^6.0", features = ["image", "rayon"] }
 wide = "^1.3"
 
 # LRU cache for preprocessing LUT
-lru = "^0.16"
+lru = "^0.17"
 
 # Numerical computing (must match ort's ndarray version 0.17)
 ndarray = { version = "^0.17", features = ["rayon"] }


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the Rust `lru` dependency from `0.16` to `0.17`, along with the related lockfile, to keep the project’s caching stack current.

### 📊 Key Changes
- ⬆️ Bumped the `lru` crate version in `Cargo.toml` from `^0.16` to `^0.17`
- 📦 Regenerated dependency resolution in `Cargo.lock`
- 🧠 The updated crate is used for the preprocessing lookup table cache

### 🎯 Purpose & Impact
- 🛠️ Keeps dependencies up to date, which helps maintain compatibility and long-term stability
- ⚡ May bring small internal improvements or fixes from the newer `lru` release, especially around cache behavior
- 🔒 Reduces the risk of falling behind on dependency maintenance
- 👥 For most users, this should be a low-risk housekeeping update with little to no visible change in functionality
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
