### PR TITLE
fix: 🐞 retry model/image downloads on transient network failures

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -163,87 +163,91 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
             ));
             let _ = fs::remove_file(&temp_path);
 
-            let mut writer = BufWriter::new(File::create(&temp_path).map_err(|e| {
-                (
-                    InferenceError::ModelLoadError(format!(
-                        "Failed to create temp file {}: {e}",
-                        temp_path.display()
-                    )),
-                    false,
-                )
-            })?);
-
-            let mut reader = response.into_body().into_reader();
             let mut downloaded: u64 = 0;
-            let mut buffer = [0u8; 65536];
             let start_time = Instant::now();
-            let mut last_update = Instant::now();
-            let desc = format!("Downloading {url} to '{}'", dest.display());
+            let desc: String = format!("Downloading {url} to '{}'", dest.display());
+            let stream_result: std::result::Result<(), (InferenceError, bool)> = {
+                let mut writer = BufWriter::new(File::create(&temp_path).map_err(|e| {
+                    (
+                        InferenceError::ModelLoadError(format!(
+                            "Failed to create temp file {}: {e}",
+                            temp_path.display()
+                        )),
+                        false,
+                    )
+                })?);
+                let mut reader = response.into_body().into_reader();
+                let mut buffer = [0u8; 65536];
+                let mut last_update = Instant::now();
 
-            let stream_result: std::result::Result<(), (InferenceError, bool)> = (|| {
-                loop {
-                    let bytes_read = reader.read(&mut buffer).map_err(|e| {
-                        (
-                            InferenceError::ModelLoadError(format!(
-                                "Failed to read from network: {e}"
-                            )),
-                            true,
-                        )
-                    })?;
-                    if bytes_read == 0 {
-                        break;
+                (|| {
+                    loop {
+                        let bytes_read = reader.read(&mut buffer).map_err(|e| {
+                            (
+                                InferenceError::ModelLoadError(format!(
+                                    "Failed to read from network: {e}"
+                                )),
+                                true,
+                            )
+                        })?;
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        writer.write_all(&buffer[..bytes_read]).map_err(|e| {
+                            (
+                                InferenceError::ModelLoadError(format!(
+                                    "Failed to write to temp file: {e}"
+                                )),
+                                false,
+                            )
+                        })?;
+                        downloaded += bytes_read as u64;
+
+                        let now = Instant::now();
+                        if now.duration_since(last_update).as_secs_f64() < MIN_UPDATE_INTERVAL {
+                            continue;
+                        }
+                        last_update = now;
+
+                        let elapsed = start_time.elapsed().as_secs_f64();
+                        let rate = if elapsed > 0.0 {
+                            downloaded as f64 / elapsed
+                        } else {
+                            0.0
+                        };
+                        if total_size > 0 {
+                            let progress = (downloaded as f64 / total_size as f64).min(1.0);
+                            let bar = generate_bar(progress, BAR_WIDTH);
+                            eprint!(
+                                "\r\x1b[K{desc}: {}% {bar} {}/{} {}/s {}",
+                                (progress * 100.0) as u8,
+                                format_bytes(downloaded as f64),
+                                format_bytes(total_size as f64),
+                                format_bytes(rate),
+                                format_time(elapsed)
+                            );
+                        } else {
+                            eprint!(
+                                "\r\x1b[K{desc}: {} {}/s {}",
+                                format_bytes(downloaded as f64),
+                                format_bytes(rate),
+                                format_time(elapsed)
+                            );
+                        }
+                        std::io::stderr().flush().ok();
                     }
-                    writer.write_all(&buffer[..bytes_read]).map_err(|e| {
+                    writer.flush().map_err(|e| {
                         (
                             InferenceError::ModelLoadError(format!(
-                                "Failed to write to temp file: {e}"
+                                "Failed to flush temp file: {e}"
                             )),
                             false,
                         )
                     })?;
-                    downloaded += bytes_read as u64;
-
-                    let now = Instant::now();
-                    if now.duration_since(last_update).as_secs_f64() < MIN_UPDATE_INTERVAL {
-                        continue;
-                    }
-                    last_update = now;
-
-                    let elapsed = start_time.elapsed().as_secs_f64();
-                    let rate = if elapsed > 0.0 {
-                        downloaded as f64 / elapsed
-                    } else {
-                        0.0
-                    };
-                    if total_size > 0 {
-                        let progress = (downloaded as f64 / total_size as f64).min(1.0);
-                        let bar = generate_bar(progress, BAR_WIDTH);
-                        eprint!(
-                            "\r\x1b[K{desc}: {}% {bar} {}/{} {}/s {}",
-                            (progress * 100.0) as u8,
-                            format_bytes(downloaded as f64),
-                            format_bytes(total_size as f64),
-                            format_bytes(rate),
-                            format_time(elapsed)
-                        );
-                    } else {
-                        eprint!(
-                            "\r\x1b[K{desc}: {} {}/s {}",
-                            format_bytes(downloaded as f64),
-                            format_bytes(rate),
-                            format_time(elapsed)
-                        );
-                    }
-                    std::io::stderr().flush().ok();
-                }
-                writer.flush().map_err(|e| {
-                    (
-                        InferenceError::ModelLoadError(format!("Failed to flush temp file: {e}")),
-                        false,
-                    )
-                })?;
-                Ok(())
-            })();
+                    Ok(())
+                })()
+                // writer, reader, buffer, last_update dropped here
+            };
 
             if stream_result.is_err() {
                 let _ = fs::remove_file(&temp_path);

--- a/src/download.rs
+++ b/src/download.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 
 use crate::error::{InferenceError, Result};
 
-/// Base URL for Ultralytics ONNX model assets. All downloadable models share this prefix.
 const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/download/v8.4.0";
 
 /// Default YOLO detection model name.
@@ -30,10 +29,8 @@ pub const DEFAULT_OBB_MODEL: &str = "yolo26n-obb.onnx";
 /// Default YOLO classification model name.
 pub const DEFAULT_CLS_MODEL: &str = "yolo26n-cls.onnx";
 
-/// Filenames that can be auto-downloaded from the Ultralytics assets release.
-/// Each entry resolves to `{ASSETS_BASE_URL}/{filename}`.
 const DOWNLOADABLE_MODELS: &[&str] = &[
-    // YOLO26 (end-to-end by default)
+    // YOLO26
     "yolo26n.onnx",
     "yolo26n-seg.onnx",
     "yolo26n-pose.onnx",
@@ -47,40 +44,23 @@ const DOWNLOADABLE_MODELS: &[&str] = &[
     "yolo11n-cls.onnx",
 ];
 
-/// URL for downloading the default Bus.jpg image
 const DEFAULT_BUS_IMAGE_URL: &str = "https://ultralytics.com/images/bus.jpg";
-
-/// URL for downloading the default Zidane.jpg image
 const DEFAULT_ZIDANE_IMAGE_URL: &str = "https://ultralytics.com/images/zidane.jpg";
-
-/// URL for downloading the default Boats.jpg image (for OBB)
 const DEFAULT_BOATS_IMAGE_URL: &str = "https://ultralytics.com/images/boats.jpg";
 
-/// Default image URLs for detection, segmentation, pose, and classification tasks
+/// Default image URLs for detection, segmentation, pose, and classification tasks.
 pub const DEFAULT_IMAGES: &[&str] = &[DEFAULT_BUS_IMAGE_URL, DEFAULT_ZIDANE_IMAGE_URL];
 
-/// Default image URL for OBB (Oriented Bounding Box) tasks
+/// Default image URL for OBB (Oriented Bounding Box) tasks.
 pub const DEFAULT_OBB_IMAGE: &str = DEFAULT_BOATS_IMAGE_URL;
 
-/// Connection timeout in seconds.
 const CONNECT_TIMEOUT: u64 = 30;
-
-/// Read timeout in seconds.
 const READ_TIMEOUT: u64 = 300;
-
-/// Maximum number of download attempts before giving up.
 const MAX_RETRIES: u32 = 3;
-
-/// Base delay in seconds between retry attempts (doubles each retry: 2s, 4s).
 const RETRY_BASE_DELAY_SECS: u64 = 2;
-
-/// Progress bar width in characters.
 const BAR_WIDTH: usize = 12;
-
-/// Minimum interval in seconds between progress bar updates.
 const MIN_UPDATE_INTERVAL: f64 = 0.1;
 
-/// Format bytes as human-readable string (e.g., "10.4MB").
 #[allow(clippy::cast_precision_loss)]
 fn format_bytes(bytes: f64) -> String {
     const KB: f64 = 1024.0;
@@ -98,7 +78,6 @@ fn format_bytes(bytes: f64) -> String {
     }
 }
 
-/// Format time duration.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn format_time(seconds: f64) -> String {
     if seconds < 60.0 {
@@ -115,7 +94,6 @@ fn format_time(seconds: f64) -> String {
     }
 }
 
-/// Generate progress bar string.
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
@@ -137,15 +115,24 @@ fn generate_bar(progress: f64, width: usize) -> String {
     bar
 }
 
+// Timeouts and I/O errors are transient; 4xx and filesystem errors are permanent.
+const fn is_transient(e: &ureq::Error) -> bool {
+    match e {
+        ureq::Error::Timeout(_) | ureq::Error::Io(_) => true,
+        ureq::Error::StatusCode(c) => *c >= 500,
+        _ => false,
+    }
+}
+
 /// Download a file from URL to the specified path with progress bar and retry.
 ///
 /// Retries up to `MAX_RETRIES` times on transient failures with exponential backoff.
+/// Permanent errors (4xx, filesystem) are returned immediately without retrying.
 /// Uses a temp file and atomic rename to prevent corrupted partial downloads.
 #[allow(
     clippy::similar_names,
     clippy::too_many_lines,
     clippy::large_stack_arrays,
-    clippy::items_after_statements,
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
@@ -156,7 +143,8 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
     for attempt in 1..=MAX_RETRIES {
         // Each attempt runs in a closure so `?` propagates to `attempt_result`
         // rather than returning from the outer function, allowing retries.
-        let attempt_result: Result<()> = (|| {
+        // Err((e, true)) = transient, retry; Err((e, false)) = permanent, fail fast.
+        let attempt_result: std::result::Result<(), (InferenceError, bool)> = (|| {
             let config = ureq::Agent::config_builder()
                 .timeout_connect(Some(Duration::from_secs(CONNECT_TIMEOUT)))
                 .timeout_recv_body(Some(Duration::from_secs(READ_TIMEOUT)))
@@ -168,12 +156,10 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                     ureq::Error::Timeout(_) => {
                         format!("Connection timed out while downloading {url}")
                     }
-                    ureq::Error::Io(io_err) => {
-                        format!("Network error downloading {url}: {io_err}")
-                    }
+                    ureq::Error::Io(io_err) => format!("Network error downloading {url}: {io_err}"),
                     _ => format!("Failed to download {url}: {e}"),
                 };
-                InferenceError::ModelLoadError(msg)
+                (InferenceError::ModelLoadError(msg), is_transient(&e))
             })?;
 
             let total_size: u64 = response
@@ -183,21 +169,18 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
 
-            // Unique temp path in same dir as dest for atomic rename
-            let unique_suffix = format!(
-                ".{}.{}",
+            let mut temp_name = dest
+                .file_name()
+                .map_or_else(|| PathBuf::from("download"), PathBuf::from)
+                .into_os_string();
+            temp_name.push(format!(
+                ".part.{}.{}",
                 std::process::id(),
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .subsec_nanos()
-            );
-            let mut temp_name = dest
-                .file_name()
-                .map_or_else(|| PathBuf::from("download"), PathBuf::from)
-                .into_os_string();
-            temp_name.push(".part");
-            temp_name.push(unique_suffix);
+            ));
             let temp_path = dest
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
@@ -205,10 +188,13 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
             let _ = fs::remove_file(&temp_path);
 
             let mut writer = BufWriter::new(File::create(&temp_path).map_err(|e| {
-                InferenceError::ModelLoadError(format!(
-                    "Failed to create temp file {}: {e}",
-                    temp_path.display()
-                ))
+                (
+                    InferenceError::ModelLoadError(format!(
+                        "Failed to create temp file {}: {e}",
+                        temp_path.display()
+                    )),
+                    false,
+                )
             })?);
 
             let mut reader = response.into_body().into_reader();
@@ -218,16 +204,26 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
             let mut last_update = Instant::now();
             let desc = format!("Downloading {url} to '{}'", dest.display());
 
-            let stream_result: Result<()> = (|| {
+            let stream_result: std::result::Result<(), (InferenceError, bool)> = (|| {
                 loop {
                     let bytes_read = reader.read(&mut buffer).map_err(|e| {
-                        InferenceError::ModelLoadError(format!("Failed to read from network: {e}"))
+                        (
+                            InferenceError::ModelLoadError(format!(
+                                "Failed to read from network: {e}"
+                            )),
+                            true,
+                        )
                     })?;
                     if bytes_read == 0 {
                         break;
                     }
                     writer.write_all(&buffer[..bytes_read]).map_err(|e| {
-                        InferenceError::ModelLoadError(format!("Failed to write to temp file: {e}"))
+                        (
+                            InferenceError::ModelLoadError(format!(
+                                "Failed to write to temp file: {e}"
+                            )),
+                            false,
+                        )
                     })?;
                     downloaded += bytes_read as u64;
 
@@ -247,11 +243,11 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                         let progress = (downloaded as f64 / total_size as f64).min(1.0);
                         let percent = (progress * 100.0) as u8;
                         let bar = generate_bar(progress, BAR_WIDTH);
-                        let rate_str = format!("{}/s", format_bytes(rate));
                         eprint!(
-                            "\r\x1b[K{desc}: {percent}% {bar} {}/{} {rate_str} {}",
+                            "\r\x1b[K{desc}: {percent}% {bar} {}/{} {}/s {}",
                             format_bytes(downloaded as f64),
                             format_bytes(total_size as f64),
+                            format_bytes(rate),
                             format_time(elapsed)
                         );
                     } else {
@@ -265,15 +261,18 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                     std::io::stderr().flush().ok();
                 }
                 writer.flush().map_err(|e| {
-                    InferenceError::ModelLoadError(format!("Failed to flush temp file: {e}"))
+                    (
+                        InferenceError::ModelLoadError(format!("Failed to flush temp file: {e}")),
+                        false,
+                    )
                 })?;
                 Ok(())
             })();
 
-            if let Err(e) = stream_result {
+            if stream_result.is_err() {
                 let _ = fs::remove_file(&temp_path);
-                return Err(e);
             }
+            stream_result?;
 
             let elapsed = start_time.elapsed().as_secs_f64();
             let rate = if elapsed > 0.0 {
@@ -300,10 +299,13 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
             fs::rename(&temp_path, dest).map_err(|e| {
                 let _ = fs::remove_file(&temp_path);
-                InferenceError::ModelLoadError(format!(
-                    "Failed to move downloaded file to {}: {e}",
-                    dest.display()
-                ))
+                (
+                    InferenceError::ModelLoadError(format!(
+                        "Failed to move downloaded file to {}: {e}",
+                        dest.display()
+                    )),
+                    false,
+                )
             })?;
 
             Ok(())
@@ -311,7 +313,8 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
         match attempt_result {
             Ok(()) => return Ok(()),
-            Err(e) => {
+            Err((e, false)) => return Err(e),
+            Err((e, true)) => {
                 last_err = e;
                 if attempt < MAX_RETRIES {
                     let delay = RETRY_BASE_DELAY_SECS * (1 << (attempt - 1));
@@ -355,18 +358,12 @@ pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 /// Download an image from a URL to the current directory.
 /// Skips download if the file already exists.
 ///
-/// # Arguments
-/// * `url` - The URL to download from
-///
-/// # Returns
-/// The path to the downloaded (or existing) file, or an error if download fails
 /// # Errors
-/// Returns an error if the download fails or file I/O errors occur
+/// Returns an error if the download fails or file I/O errors occur.
 pub fn download_image(url: &str) -> Result<String> {
     let filename = url.rsplit('/').next().unwrap_or("image.jpg");
     let dest_path = Path::new(filename);
 
-    // Get absolute path for display consistency with Python
     let abs_path = dest_path
         .canonicalize()
         .or_else(|_| std::env::current_dir().map(|p| p.join(filename)))
@@ -375,30 +372,21 @@ pub fn download_image(url: &str) -> Result<String> {
             |p| p.to_string_lossy().to_string(),
         );
 
-    // Skip download if file already exists
     if dest_path.exists() {
         return Ok(abs_path);
     }
 
     eprintln!("Downloading {url}...");
-
     download_file(url, dest_path)?;
 
-    // Get absolute path after download
-    let abs_path = dest_path.canonicalize().map_or_else(
+    Ok(dest_path.canonicalize().map_or_else(
         |_| filename.to_string(),
         |p| p.to_string_lossy().to_string(),
-    );
-
-    Ok(abs_path)
+    ))
 }
 
 /// Download multiple images from URLs to the current directory.
-/// Returns a vector of paths to the successfully downloaded files.
 /// Skips files that already exist.
-///
-/// # Arguments
-/// * `urls` - Slice of URLs to download
 #[must_use]
 pub fn download_images(urls: &[&str]) -> Vec<String> {
     urls.iter()

--- a/src/download.rs
+++ b/src/download.rs
@@ -61,21 +61,17 @@ const RETRY_BASE_DELAY_SECS: u64 = 2;
 const BAR_WIDTH: usize = 12;
 const MIN_UPDATE_INTERVAL: f64 = 0.1;
 
-#[allow(clippy::cast_precision_loss)]
 fn format_bytes(bytes: f64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    const GB: f64 = MB * 1024.0;
-
-    if bytes >= GB {
-        format!("{:.1}GB", bytes / GB)
-    } else if bytes >= MB {
-        format!("{:.1}MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{:.1}KB", bytes / KB)
-    } else {
-        format!("{bytes:.0}B")
+    for (unit, factor) in [
+        ("GB", 1_073_741_824.0_f64),
+        ("MB", 1_048_576.0),
+        ("KB", 1024.0),
+    ] {
+        if bytes >= factor {
+            return format!("{:.1}{unit}", bytes / factor);
+        }
     }
+    format!("{bytes:.0}B")
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -83,14 +79,14 @@ fn format_time(seconds: f64) -> String {
     if seconds < 60.0 {
         format!("{seconds:.1}s")
     } else if seconds < 3600.0 {
-        let mins = (seconds / 60.0) as u32;
-        let secs = seconds % 60.0;
-        format!("{mins}:{secs:04.1}")
+        format!("{}:{:04.1}", (seconds / 60.0) as u32, seconds % 60.0)
     } else {
-        let hours = (seconds / 3600.0) as u32;
-        let mins = ((seconds % 3600.0) / 60.0) as u32;
-        let secs = seconds % 60.0;
-        format!("{hours}:{mins:02}:{secs:04.1}")
+        format!(
+            "{}:{:02}:{:04.1}",
+            (seconds / 3600.0) as u32,
+            ((seconds % 3600.0) / 60.0) as u32,
+            seconds % 60.0
+        )
     }
 }
 
@@ -100,22 +96,10 @@ fn format_time(seconds: f64) -> String {
     clippy::cast_sign_loss
 )]
 fn generate_bar(progress: f64, width: usize) -> String {
-    let filled = (progress * width as f64) as usize;
-    let partial = progress.mul_add(width as f64, -(filled as f64));
-
-    let mut bar = "━".repeat(filled);
-    if filled < width {
-        if partial > 0.5 {
-            bar.push('╸');
-            bar.push_str(&"─".repeat(width - filled - 1));
-        } else {
-            bar.push_str(&"─".repeat(width - filled));
-        }
-    }
-    bar
+    let filled = ((progress * width as f64) as usize).min(width);
+    format!("{}{}", "━".repeat(filled), "─".repeat(width - filled))
 }
 
-// Timeouts and I/O errors are transient; 4xx and filesystem errors are permanent.
 const fn is_transient(e: &ureq::Error) -> bool {
     match e {
         ureq::Error::Timeout(_) | ureq::Error::Io(_) => true,
@@ -141,9 +125,6 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
     let mut last_err = InferenceError::ModelLoadError(String::new());
 
     for attempt in 1..=MAX_RETRIES {
-        // Each attempt runs in a closure so `?` propagates to `attempt_result`
-        // rather than returning from the outer function, allowing retries.
-        // Err((e, true)) = transient, retry; Err((e, false)) = permanent, fail fast.
         let attempt_result: std::result::Result<(), (InferenceError, bool)> = (|| {
             let config = ureq::Agent::config_builder()
                 .timeout_connect(Some(Duration::from_secs(CONNECT_TIMEOUT)))
@@ -169,22 +150,17 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
 
-            let mut temp_name = dest
-                .file_name()
-                .map_or_else(|| PathBuf::from("download"), PathBuf::from)
-                .into_os_string();
-            temp_name.push(format!(
-                ".part.{}.{}",
+            let temp_path = dest.with_file_name(format!(
+                "{}.part.{}.{}",
+                dest.file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("download"),
                 std::process::id(),
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .subsec_nanos()
             ));
-            let temp_path = dest
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .join(temp_name);
             let _ = fs::remove_file(&temp_path);
 
             let mut writer = BufWriter::new(File::create(&temp_path).map_err(|e| {
@@ -241,10 +217,10 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                     };
                     if total_size > 0 {
                         let progress = (downloaded as f64 / total_size as f64).min(1.0);
-                        let percent = (progress * 100.0) as u8;
                         let bar = generate_bar(progress, BAR_WIDTH);
                         eprint!(
-                            "\r\x1b[K{desc}: {percent}% {bar} {}/{} {}/s {}",
+                            "\r\x1b[K{desc}: {}% {bar} {}/{} {}/s {}",
+                            (progress * 100.0) as u8,
                             format_bytes(downloaded as f64),
                             format_bytes(total_size as f64),
                             format_bytes(rate),
@@ -281,9 +257,9 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
                 0.0
             };
             if total_size > 0 {
-                let bar = generate_bar(1.0, BAR_WIDTH);
                 eprintln!(
-                    "\r\x1b[K{desc}: 100% {bar} {} {}/s {}",
+                    "\r\x1b[K{desc}: 100% {} {} {}/s {}",
+                    generate_bar(1.0, BAR_WIDTH),
                     format_bytes(total_size as f64),
                     format_bytes(rate),
                     format_time(elapsed)
@@ -349,10 +325,8 @@ pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
         )));
     }
 
-    let url = format!("{ASSETS_BASE_URL}/{filename}");
-    let dest_path = path.to_path_buf();
-    download_file(&url, &dest_path)?;
-    Ok(dest_path)
+    download_file(&format!("{ASSETS_BASE_URL}/{filename}"), path)?;
+    Ok(path.to_path_buf())
 }
 
 /// Download an image from a URL to the current directory.
@@ -362,27 +336,19 @@ pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 /// Returns an error if the download fails or file I/O errors occur.
 pub fn download_image(url: &str) -> Result<String> {
     let filename = url.rsplit('/').next().unwrap_or("image.jpg");
-    let dest_path = Path::new(filename);
+    let dest = Path::new(filename);
 
-    let abs_path = dest_path
+    if !dest.exists() {
+        download_file(url, dest)?;
+    }
+
+    Ok(dest
         .canonicalize()
         .or_else(|_| std::env::current_dir().map(|p| p.join(filename)))
         .map_or_else(
             |_| filename.to_string(),
-            |p| p.to_string_lossy().to_string(),
-        );
-
-    if dest_path.exists() {
-        return Ok(abs_path);
-    }
-
-    eprintln!("Downloading {url}...");
-    download_file(url, dest_path)?;
-
-    Ok(dest_path.canonicalize().map_or_else(
-        |_| filename.to_string(),
-        |p| p.to_string_lossy().to_string(),
-    ))
+            |p| p.to_string_lossy().into_owned(),
+        ))
 }
 
 /// Download multiple images from URLs to the current directory.

--- a/src/download.rs
+++ b/src/download.rs
@@ -68,6 +68,12 @@ const CONNECT_TIMEOUT: u64 = 30;
 /// Read timeout in seconds.
 const READ_TIMEOUT: u64 = 300;
 
+/// Maximum number of download attempts before giving up.
+const MAX_RETRIES: u32 = 3;
+
+/// Base delay in seconds between retry attempts (doubles each retry: 2s, 4s, 8s).
+const RETRY_BASE_DELAY_SECS: u64 = 2;
+
 /// Format bytes as human-readable string (e.g., "10.4MB").
 #[allow(clippy::cast_precision_loss)]
 fn format_bytes(bytes: f64) -> String {
@@ -125,10 +131,29 @@ fn generate_bar(progress: f64, width: usize) -> String {
     bar
 }
 
-/// Download a file from URL to the specified path with progress bar.
-///
-/// Uses streaming download to a temporary file, then atomic rename to prevent
-/// corrupted files from partial downloads.
+/// Download a file from URL to the specified path, retrying on transient errors.
+fn download_file(url: &str, dest: &Path) -> Result<()> {
+    let mut last_err = InferenceError::ModelLoadError(String::new());
+
+    for attempt in 1..=MAX_RETRIES {
+        match download_file_once(url, dest) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = e;
+                if attempt < MAX_RETRIES {
+                    let delay = RETRY_BASE_DELAY_SECS * (1 << (attempt - 1));
+                    eprintln!(
+                        "Download attempt {attempt}/{MAX_RETRIES} failed: {last_err}. Retrying in {delay}s..."
+                    );
+                    std::thread::sleep(Duration::from_secs(delay));
+                }
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
 #[allow(
     clippy::similar_names,
     clippy::too_many_lines,
@@ -138,7 +163,7 @@ fn generate_bar(progress: f64, width: usize) -> String {
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]
-fn download_file(url: &str, dest: &Path) -> Result<()> {
+fn download_file_once(url: &str, dest: &Path) -> Result<()> {
     // Create ureq agent with timeouts
     let config = ureq::Agent::config_builder()
         .timeout_connect(Some(Duration::from_secs(CONNECT_TIMEOUT)))

--- a/src/download.rs
+++ b/src/download.rs
@@ -71,8 +71,14 @@ const READ_TIMEOUT: u64 = 300;
 /// Maximum number of download attempts before giving up.
 const MAX_RETRIES: u32 = 3;
 
-/// Base delay in seconds between retry attempts (doubles each retry: 2s, 4s, 8s).
+/// Base delay in seconds between retry attempts (doubles each retry: 2s, 4s).
 const RETRY_BASE_DELAY_SECS: u64 = 2;
+
+/// Progress bar width in characters.
+const BAR_WIDTH: usize = 12;
+
+/// Minimum interval in seconds between progress bar updates.
+const MIN_UPDATE_INTERVAL: f64 = 0.1;
 
 /// Format bytes as human-readable string (e.g., "10.4MB").
 #[allow(clippy::cast_precision_loss)]
@@ -131,12 +137,179 @@ fn generate_bar(progress: f64, width: usize) -> String {
     bar
 }
 
-/// Download a file from URL to the specified path, retrying on transient errors.
+/// Download a file from URL to the specified path with progress bar and retry.
+///
+/// Retries up to `MAX_RETRIES` times on transient failures with exponential backoff.
+/// Uses a temp file and atomic rename to prevent corrupted partial downloads.
+#[allow(
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::large_stack_arrays,
+    clippy::items_after_statements,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 fn download_file(url: &str, dest: &Path) -> Result<()> {
     let mut last_err = InferenceError::ModelLoadError(String::new());
 
     for attempt in 1..=MAX_RETRIES {
-        match download_file_once(url, dest) {
+        // Each attempt runs in a closure so `?` propagates to `attempt_result`
+        // rather than returning from the outer function, allowing retries.
+        let attempt_result: Result<()> = (|| {
+            let config = ureq::Agent::config_builder()
+                .timeout_connect(Some(Duration::from_secs(CONNECT_TIMEOUT)))
+                .timeout_recv_body(Some(Duration::from_secs(READ_TIMEOUT)))
+                .build();
+            let agent = ureq::Agent::new_with_config(config);
+
+            let response = agent.get(url).call().map_err(|e| {
+                let msg = match &e {
+                    ureq::Error::Timeout(_) => {
+                        format!("Connection timed out while downloading {url}")
+                    }
+                    ureq::Error::Io(io_err) => {
+                        format!("Network error downloading {url}: {io_err}")
+                    }
+                    _ => format!("Failed to download {url}: {e}"),
+                };
+                InferenceError::ModelLoadError(msg)
+            })?;
+
+            let total_size: u64 = response
+                .headers()
+                .get("content-length")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+
+            // Unique temp path in same dir as dest for atomic rename
+            let unique_suffix = format!(
+                ".{}.{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos()
+            );
+            let mut temp_name = dest
+                .file_name()
+                .map_or_else(|| PathBuf::from("download"), PathBuf::from)
+                .into_os_string();
+            temp_name.push(".part");
+            temp_name.push(unique_suffix);
+            let temp_path = dest
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(temp_name);
+            let _ = fs::remove_file(&temp_path);
+
+            let mut writer = BufWriter::new(File::create(&temp_path).map_err(|e| {
+                InferenceError::ModelLoadError(format!(
+                    "Failed to create temp file {}: {e}",
+                    temp_path.display()
+                ))
+            })?);
+
+            let mut reader = response.into_body().into_reader();
+            let mut downloaded: u64 = 0;
+            let mut buffer = [0u8; 65536];
+            let start_time = Instant::now();
+            let mut last_update = Instant::now();
+            let desc = format!("Downloading {url} to '{}'", dest.display());
+
+            let stream_result: Result<()> = (|| {
+                loop {
+                    let bytes_read = reader.read(&mut buffer).map_err(|e| {
+                        InferenceError::ModelLoadError(format!("Failed to read from network: {e}"))
+                    })?;
+                    if bytes_read == 0 {
+                        break;
+                    }
+                    writer.write_all(&buffer[..bytes_read]).map_err(|e| {
+                        InferenceError::ModelLoadError(format!("Failed to write to temp file: {e}"))
+                    })?;
+                    downloaded += bytes_read as u64;
+
+                    let now = Instant::now();
+                    if now.duration_since(last_update).as_secs_f64() < MIN_UPDATE_INTERVAL {
+                        continue;
+                    }
+                    last_update = now;
+
+                    let elapsed = start_time.elapsed().as_secs_f64();
+                    let rate = if elapsed > 0.0 {
+                        downloaded as f64 / elapsed
+                    } else {
+                        0.0
+                    };
+                    if total_size > 0 {
+                        let progress = (downloaded as f64 / total_size as f64).min(1.0);
+                        let percent = (progress * 100.0) as u8;
+                        let bar = generate_bar(progress, BAR_WIDTH);
+                        let rate_str = format!("{}/s", format_bytes(rate));
+                        eprint!(
+                            "\r\x1b[K{desc}: {percent}% {bar} {}/{} {rate_str} {}",
+                            format_bytes(downloaded as f64),
+                            format_bytes(total_size as f64),
+                            format_time(elapsed)
+                        );
+                    } else {
+                        eprint!(
+                            "\r\x1b[K{desc}: {} {}/s {}",
+                            format_bytes(downloaded as f64),
+                            format_bytes(rate),
+                            format_time(elapsed)
+                        );
+                    }
+                    std::io::stderr().flush().ok();
+                }
+                writer.flush().map_err(|e| {
+                    InferenceError::ModelLoadError(format!("Failed to flush temp file: {e}"))
+                })?;
+                Ok(())
+            })();
+
+            if let Err(e) = stream_result {
+                let _ = fs::remove_file(&temp_path);
+                return Err(e);
+            }
+
+            let elapsed = start_time.elapsed().as_secs_f64();
+            let rate = if elapsed > 0.0 {
+                downloaded as f64 / elapsed
+            } else {
+                0.0
+            };
+            if total_size > 0 {
+                let bar = generate_bar(1.0, BAR_WIDTH);
+                eprintln!(
+                    "\r\x1b[K{desc}: 100% {bar} {} {}/s {}",
+                    format_bytes(total_size as f64),
+                    format_bytes(rate),
+                    format_time(elapsed)
+                );
+            } else {
+                eprintln!(
+                    "\r\x1b[K{desc}: {} {}/s {}",
+                    format_bytes(downloaded as f64),
+                    format_bytes(rate),
+                    format_time(elapsed)
+                );
+            }
+
+            fs::rename(&temp_path, dest).map_err(|e| {
+                let _ = fs::remove_file(&temp_path);
+                InferenceError::ModelLoadError(format!(
+                    "Failed to move downloaded file to {}: {e}",
+                    dest.display()
+                ))
+            })?;
+
+            Ok(())
+        })();
+
+        match attempt_result {
             Ok(()) => return Ok(()),
             Err(e) => {
                 last_err = e;
@@ -152,205 +325,6 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
     }
 
     Err(last_err)
-}
-
-#[allow(
-    clippy::similar_names,
-    clippy::too_many_lines,
-    clippy::large_stack_arrays,
-    clippy::items_after_statements,
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
-fn download_file_once(url: &str, dest: &Path) -> Result<()> {
-    // Create ureq agent with timeouts
-    let config = ureq::Agent::config_builder()
-        .timeout_connect(Some(Duration::from_secs(CONNECT_TIMEOUT)))
-        .timeout_recv_body(Some(Duration::from_secs(READ_TIMEOUT)))
-        .build();
-    let agent = ureq::Agent::new_with_config(config);
-
-    let response = agent.get(url).call().map_err(|e| {
-        let msg = match &e {
-            ureq::Error::Timeout(_) => format!("Connection timed out while downloading {url}"),
-            ureq::Error::Io(io_err) => {
-                format!("Network error downloading {url}: {io_err}")
-            }
-            _ => format!("Failed to download {url}: {e}"),
-        };
-        InferenceError::ModelLoadError(msg)
-    })?;
-
-    // Get content length for progress calculation
-    let content_length: Option<u64> = response
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s: &str| s.parse().ok());
-
-    let total_size = content_length.unwrap_or(0);
-
-    // Create unique temp file for atomic download to prevent race conditions
-    // Format: <filename>.part.<pid>.<timestamp_nanos>
-    let unique_suffix = format!(
-        ".{}.{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos()
-    );
-    let mut temp_path = dest
-        .file_name()
-        .map_or_else(|| PathBuf::from("download"), PathBuf::from)
-        .into_os_string();
-    temp_path.push(".part");
-    temp_path.push(unique_suffix);
-
-    // Create temp path in the same directory as dest to ensure atomic rename works
-    let temp_path = dest
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(temp_path);
-
-    // Clean up any existing partial download
-    let _ = fs::remove_file(&temp_path);
-
-    let temp_file = File::create(&temp_path).map_err(|e| {
-        InferenceError::ModelLoadError(format!(
-            "Failed to create temp file {}: {e}",
-            temp_path.display()
-        ))
-    })?;
-    let mut writer = BufWriter::new(temp_file);
-
-    let mut reader = response.into_body().into_reader();
-    let mut downloaded: u64 = 0;
-    let mut buffer = [0u8; 65536]; // 64KB buffer
-    let start_time = Instant::now();
-    let mut last_update = Instant::now();
-
-    // Progress bar settings
-    const BAR_WIDTH: usize = 12;
-    const MIN_UPDATE_INTERVAL: f64 = 0.1; // Update at most every 100ms
-
-    // Description for progress bar
-    let desc = format!("Downloading {} to '{}'", url, dest.display());
-
-    let download_result: std::result::Result<(), InferenceError> = (|| {
-        loop {
-            let bytes_read = reader.read(&mut buffer).map_err(|e| {
-                InferenceError::ModelLoadError(format!("Failed to read from network: {e}"))
-            })?;
-
-            if bytes_read == 0 {
-                break;
-            }
-
-            // Stream directly to file
-            writer.write_all(&buffer[..bytes_read]).map_err(|e| {
-                InferenceError::ModelLoadError(format!("Failed to write to temp file: {e}"))
-            })?;
-
-            downloaded += bytes_read as u64;
-
-            // Rate-limit progress updates
-            let now = Instant::now();
-            if now.duration_since(last_update).as_secs_f64() < MIN_UPDATE_INTERVAL {
-                continue;
-            }
-            last_update = now;
-
-            // Calculate progress
-            let elapsed = start_time.elapsed().as_secs_f64();
-            let rate = if elapsed > 0.0 {
-                downloaded as f64 / elapsed
-            } else {
-                0.0
-            };
-
-            if total_size > 0 {
-                let progress = (downloaded as f64 / total_size as f64).min(1.0);
-                let percent = (progress * 100.0) as u8;
-                let bar = generate_bar(progress, BAR_WIDTH);
-                let rate_str = format!("{}/s", format_bytes(rate));
-
-                eprint!(
-                    "\r\x1b[K{}: {}% {} {}/{} {} {}",
-                    desc,
-                    percent,
-                    bar,
-                    format_bytes(downloaded as f64),
-                    format_bytes(total_size as f64),
-                    rate_str,
-                    format_time(elapsed)
-                );
-            } else {
-                eprint!(
-                    "\r\x1b[K{}: {} {}/s {}",
-                    desc,
-                    format_bytes(downloaded as f64),
-                    format_bytes(rate),
-                    format_time(elapsed)
-                );
-            }
-            std::io::stderr().flush().ok();
-        }
-
-        // Flush the writer
-        writer.flush().map_err(|e| {
-            InferenceError::ModelLoadError(format!("Failed to flush temp file: {e}"))
-        })?;
-
-        Ok(())
-    })();
-
-    // Handle download failure - clean up temp file
-    if let Err(e) = download_result {
-        let _ = fs::remove_file(&temp_path);
-        return Err(e);
-    }
-
-    // Final progress line
-    let elapsed = start_time.elapsed().as_secs_f64();
-    let rate = if elapsed > 0.0 {
-        downloaded as f64 / elapsed
-    } else {
-        0.0
-    };
-
-    if total_size > 0 {
-        let bar = generate_bar(1.0, BAR_WIDTH);
-        eprintln!(
-            "\r\x1b[K{}: 100% {} {} {}/s {}",
-            desc,
-            bar,
-            format_bytes(total_size as f64),
-            format_bytes(rate),
-            format_time(elapsed)
-        );
-    } else {
-        eprintln!(
-            "\r\x1b[K{}: {} {}/s {}",
-            desc,
-            format_bytes(downloaded as f64),
-            format_bytes(rate),
-            format_time(elapsed)
-        );
-    }
-
-    // Atomic rename from temp file to final destination
-    fs::rename(&temp_path, dest).map_err(|e| {
-        // Clean up temp file on rename failure
-        let _ = fs::remove_file(&temp_path);
-        InferenceError::ModelLoadError(format!(
-            "Failed to move downloaded file to {}: {e}",
-            dest.display()
-        ))
-    })?;
-
-    Ok(())
 }
 
 /// Attempt to download a model if it matches a known downloadable model.


### PR DESCRIPTION
- Added retry logic to `download_file` in `src/download.rs` so transient network failures (timeouts, I/O errors) during CI are automatically retried up to 3 times with exponential backoff (2s → 4s) instead of failing the whole CI run.

## Problem

GitHub Actions CI tests and for users when occasionally fail because model or image downloads time out or hit transient network errors. These failures are not real, restarting CI fixes them 99% of the time.

## Solution

Split `download_file` into two functions:

- `download_file` thin retry loop (up to `MAX_RETRIES = 3` attempts, `RETRY_BASE_DELAY_SECS = 2` exponential backoff)
- `download_file_once` original download logic (unchanged)

On each failed attempt, a diagnostic message is printed to stderr before sleeping:

```bash
Download attempt 1/3 failed: Connection timed out while downloading .... Retrying in 2s...
```

Both `try_download_model` and `download_image` benefit automatically since they both call `download_file`.


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR makes file downloads in `ultralytics/inference` more reliable by adding automatic retries, cleaner progress reporting, and streamlined download code for models and sample images.

### 📊 Key Changes
- ♻️ Added **automatic retry logic** for downloads, with up to 3 attempts and increasing wait times between retries.
- 🌐 Retries now happen only for **temporary network/server issues** like timeouts, I/O errors, or 5xx responses, while permanent failures stop immediately.
- 🛡️ Kept the **safe temp-file + atomic rename** approach, helping prevent corrupted partial downloads from being saved as final files.
- 📈 Simplified and cleaned up the **download progress display**, including more compact byte/time formatting and a simpler progress bar.
- 🧹 Refactored helper functions like byte formatting, time formatting, and progress bar generation to reduce duplication and improve maintainability.
- 🖼️ Simplified image download behavior so existing files are skipped more cleanly, while still returning an absolute path when possible.
- 🚀 Slightly streamlined model download code by removing extra temporary variables and directly downloading known supported model assets.

### 🎯 Purpose & Impact
- ✅ **Improves robustness** for users downloading models or test images on unstable connections.
- ⏱️ **Reduces failed setup attempts** by automatically recovering from transient network problems instead of failing immediately.
- 🔒 **Protects file integrity** by ensuring incomplete downloads are cleaned up and not mistaken for valid files.
- 👀 **Makes CLI feedback clearer** during downloads, so users can better track progress and speed.
- 🛠️ **Simplifies maintenance** for developers by making the download code shorter, cleaner, and easier to reason about.
- 📦 Overall, this should lead to a **smoother first-run experience** when `ultralytics/inference` fetches YOLO26, YOLO11, or sample image assets.