### PR TITLE
refactor: ♻️ streamline model retrieval logic in download module and include all sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 - 🔧 **Multiple Backends** - CPU, CUDA, TensorRT, CoreML, OpenVINO, and more via ONNX Runtime
 - 📦 **Dual Use** - Library for Rust projects + standalone CLI application
 - 🏷️ **Auto Metadata** - Automatically reads class names, task type, and input size from ONNX models
+- ⬇️ **Auto Download** - Automatically downloads YOLO11 and YOLO26 ONNX models (all sizes: n/s/m/l/x) when not found locally
 - 🖼️ **Multiple Sources** - Images, directories, glob patterns, video files, webcams, and streams
 - 🪶 **Minimal Dependencies** - No PyTorch, no heavy ML frameworks - just 5 core crates
 
@@ -84,17 +85,31 @@ model.export(format="onnx")
 ### Run Inference
 
 ```bash
-# With defaults (auto-downloads model and sample images)
+# With defaults (auto-downloads yolo26n.onnx and sample images)
 cargo run --release -- predict
 
-# With explicit arguments
+# Select task — auto-downloads the nano model for that task
+cargo run --release -- predict --task segment          # downloads yolo26n-seg.onnx
+cargo run --release -- predict --task pose             # downloads yolo26n-pose.onnx
+cargo run --release -- predict --task obb              # downloads yolo26n-obb.onnx
+cargo run --release -- predict --task classify         # downloads yolo26n-cls.onnx
+
+# With explicit model (task is read from model metadata)
 cargo run --release -- predict --model yolo26n.onnx --source image.jpg
+
+# Auto-download any supported size (n/s/m/l/x)
+cargo run --release -- predict --model yolo26l.onnx --source image.jpg
+cargo run --release -- predict --model yolo11x-seg.onnx --source image.jpg
 
 # On a directory of images
 cargo run --release -- predict --model yolo26n.onnx --source assets/
 
 # With custom thresholds
 cargo run --release -- predict -m yolo26n.onnx -s image.jpg --conf 0.5 --iou 0.45
+
+# Filter by class IDs
+cargo run --release -- predict --model yolo26n.onnx --source image.jpg --classes 0
+cargo run --release -- predict --model yolo26n.onnx --source image.jpg --classes "0,1,2"
 
 # With visualization and custom image size
 cargo run --release -- predict --model yolo26n.onnx --source video.mp4 --show --imgsz 1280
@@ -111,9 +126,9 @@ cargo run --release -- predict --model yolo26n.onnx --source image.jpg --rect
 ```
 # ultralytics-inference predict
 
-WARNING ⚠️ 'model' argument is missing. Using default 'model=yolo26n.onnx'.
+WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics 0.0.8 🚀 Rust ONNX FP32 CPU
+Ultralytics 0.0.10 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -121,6 +136,24 @@ image 1/2 /home/ultralytics/inference/bus.jpg: 640x480 640x480 4 persons, 1 bus,
 image 2/2 /home/ultralytics/inference/zidane.jpg: 384x640 2 persons, 1 tie, 28.6ms
 Speed: 1.5ms preprocess, 32.5ms inference, 0.5ms postprocess per image at shape (1, 3, 384, 640)
 Results saved to runs/detect/predict1
+💡 Learn more at https://docs.ultralytics.com/modes/predict
+```
+
+**With `--task` (auto-downloads the matching nano model):**
+
+```
+# ultralytics-inference predict --task segment
+
+WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
+WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
+Ultralytics 0.0.10 🚀 Rust ONNX FP32 CPU
+Using ONNX Runtime CPUExecutionProvider
+YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
+
+image 1/2 /home/ultralytics/inference/bus.jpg: 640x480 4 persons, 1 bus, 48.2ms
+image 2/2 /home/ultralytics/inference/zidane.jpg: 384x640 2 persons, 1 tie, 38.1ms
+Speed: 1.6ms preprocess, 44.3ms inference, 1.2ms postprocess per image at shape (1, 3, 384, 640)
+Results saved to runs/segment/predict1
 💡 Learn more at https://docs.ultralytics.com/modes/predict
 ```
 
@@ -141,22 +174,46 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 
 **CLI Options:**
 
-| Option          | Short | Description                                       | Default                                 |
-| --------------- | ----- | ------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file                           | `yolo26n.onnx`                          |
-| `--source`      | `-s`  | Input source (image, video, webcam index, or URL) | `Task dependent Ultralytics URL assets` |
-| `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)    | `cpu`                                   |
-| `--conf`        |       | Confidence threshold                              | `0.25`                                  |
-| `--iou`         |       | IoU threshold for NMS                             | `0.7`                                   |
-| `--max-det`     |       | Maximum number of detections                      | `300`                                   |
-| `--imgsz`       |       | Inference image size                              | `Model metadata`                        |
-| `--rect`        |       | Enable rectangular inference (minimal padding)    | `true`                                  |
-| `--batch`       |       | Batch size for inference                          | `1`                                     |
-| `--half`        |       | Use FP16 half-precision inference                 | `false`                                 |
-| `--save`        |       | Save annotated results to runs/<task>/predict     | `true`                                  |
-| `--save-frames` |       | Save individual frames for video                  | `false`                                 |
-| `--show`        |       | Display results in a window                       | `false`                                 |
-| `--verbose`     |       | Show verbose output                               | `true`                                  |
+| Option          | Short | Description                                                                   | Default                                 |
+| --------------- | ----- | ----------------------------------------------------------------------------- | --------------------------------------- |
+| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name        | `yolo26n.onnx`                          |
+| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect` |
+| `--source`      | `-s`  | Input source (image, video, webcam index, or URL)                             | `Task dependent Ultralytics URL assets` |
+| `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)                                | `cpu`                                   |
+| `--conf`        |       | Confidence threshold                                                          | `0.25`                                  |
+| `--iou`         |       | IoU threshold for NMS                                                         | `0.7`                                   |
+| `--max-det`     |       | Maximum number of detections                                                  | `300`                                   |
+| `--imgsz`       |       | Inference image size                                                          | `Model metadata`                        |
+| `--rect`        |       | Enable rectangular inference (minimal padding)                                | `true`                                  |
+| `--batch`       |       | Batch size for inference                                                      | `1`                                     |
+| `--half`        |       | Use FP16 half-precision inference                                             | `false`                                 |
+| `--save`        |       | Save annotated results to runs/\<task\>/predict                               | `true`                                  |
+| `--save-frames` |       | Save individual frames for video                                              | `false`                                 |
+| `--show`        |       | Display results in a window                                                   | `false`                                 |
+| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                  | all classes                             |
+| `--verbose`     |       | Show verbose output                                                           | `true`                                  |
+
+**Task and Model Resolution:**
+
+| Invocation                              | Model used                         | Notes                                      |
+| --------------------------------------- | ---------------------------------- | ------------------------------------------ |
+| `predict`                               | `yolo26n.onnx`                     | Default detect model, auto-downloaded      |
+| `predict --task segment`                | `yolo26n-seg.onnx`                 | Nano seg model, auto-downloaded            |
+| `predict --task pose`                   | `yolo26n-pose.onnx`                | Nano pose model, auto-downloaded           |
+| `predict --task obb`                    | `yolo26n-obb.onnx`                 | Nano OBB model, auto-downloaded            |
+| `predict --task classify`               | `yolo26n-cls.onnx`                 | Nano classify model, auto-downloaded       |
+| `predict --model yolo26l-seg.onnx`      | `yolo26l-seg.onnx`                 | Task read from model metadata              |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`     | `--task` matches metadata, no warning      |
+| `predict --task segment --model yolo26n.onnx`     | `yolo26n.onnx`         | Task overridden with warning; results may be empty if architectures differ |
+
+**Auto-downloadable models:**
+
+All YOLO11 and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download:
+
+| Family  | Variants                                                                 |
+| ------- | ------------------------------------------------------------------------ |
+| YOLO26  | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
+| YOLO11  | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
 
 **Source Options:**
 
@@ -441,6 +498,8 @@ ONNX Runtime threading is set to auto (`num_threads: 0`) which lets ORT choose o
 - [x] Batch inference support
 - [x] Rectangular inference support and optimization
 - [x] Class filtering support
+- [x] Auto-download all YOLO11 and YOLO26 ONNX models (all sizes n/s/m/l/x, all tasks)
+- [x] `--task` CLI flag — selects and auto-downloads the matching nano model when `--model` is omitted
 
 ### In Progress
 

--- a/README.md
+++ b/README.md
@@ -178,8 +178,7 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 | --------------- | ----- | -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 | `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name                                   | `yolo26n.onnx`                          |
 | `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect`                                |
-| `--source`      | `-s`  | Input source (image, video, webcam index, or URL)                                                        | `Task dependent Ultralytics URL assets` |
-| `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)                                                           | `cpu`                                   |
+| `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                       | `Task dependent Ultralytics URL assets` |
 | `--conf`        |       | Confidence threshold                                                                                     | `0.25`                                  |
 | `--iou`         |       | IoU threshold for NMS                                                                                    | `0.7`                                   |
 | `--max-det`     |       | Maximum number of detections                                                                             | `300`                                   |
@@ -190,8 +189,9 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                          | `true`                                  |
 | `--save-frames` |       | Save individual frames for video                                                                         | `false`                                 |
 | `--show`        |       | Display results in a window                                                                              | `false`                                 |
-| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                              | all classes                             |
+| `--device`      |       | Device (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, xnnpack)                             | `cpu`                                   |
 | `--verbose`     |       | Show verbose output                                                                                      | `true`                                  |
+| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                              | all classes                             |
 
 **Task and Model Resolution:**
 
@@ -203,8 +203,8 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 | `predict --task obb`                              | `yolo26n-obb.onnx`  | Nano OBB model, auto-downloaded                                            |
 | `predict --task classify`                         | `yolo26n-cls.onnx`  | Nano classify model, auto-downloaded                                       |
 | `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`  | Task read from model metadata                                              |
-| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, no warning                                      |
-| `predict --task segment --model yolo26n.onnx`     | `yolo26n.onnx`      | Task overridden with warning; results may be empty if architectures differ |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, proceeds normally                               |
+| `predict --task segment --model yolo26n.onnx`     | error               | `--task` conflicts with model metadata (`detect`), exits with error        |
 
 **Auto-downloadable models:**
 
@@ -499,7 +499,7 @@ ONNX Runtime threading is set to auto (`num_threads: 0`) which lets ORT choose o
 - [x] Rectangular inference support and optimization
 - [x] Class filtering support
 - [x] Auto-download all YOLO11 and YOLO26 ONNX models (all sizes n/s/m/l/x, all tasks)
-- [x] `--task` CLI flag — selects and auto-downloads the matching nano model when `--model` is omitted
+- [x] `--task` CLI flag: selects and auto-downloads the matching nano model when `--model` is omitted; errors on task/model metadata conflict
 
 ### In Progress
 

--- a/README.md
+++ b/README.md
@@ -195,16 +195,16 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 
 **Task and Model Resolution:**
 
-| Invocation                                        | Model used          | Notes                                                                      |
-| ------------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
-| `predict`                                         | `yolo26n.onnx`      | Default detect model, auto-downloaded                                      |
-| `predict --task segment`                          | `yolo26n-seg.onnx`  | Nano seg model, auto-downloaded                                            |
-| `predict --task pose`                             | `yolo26n-pose.onnx` | Nano pose model, auto-downloaded                                           |
-| `predict --task obb`                              | `yolo26n-obb.onnx`  | Nano OBB model, auto-downloaded                                            |
-| `predict --task classify`                         | `yolo26n-cls.onnx`  | Nano classify model, auto-downloaded                                       |
-| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`  | Task read from model metadata                                              |
-| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, proceeds normally                               |
-| `predict --task segment --model yolo26n.onnx`     | error               | `--task` conflicts with model metadata (`detect`), exits with error        |
+| Invocation                                        | Model used          | Notes                                                               |
+| ------------------------------------------------- | ------------------- | ------------------------------------------------------------------- |
+| `predict`                                         | `yolo26n.onnx`      | Default detect model, auto-downloaded                               |
+| `predict --task segment`                          | `yolo26n-seg.onnx`  | Nano seg model, auto-downloaded                                     |
+| `predict --task pose`                             | `yolo26n-pose.onnx` | Nano pose model, auto-downloaded                                    |
+| `predict --task obb`                              | `yolo26n-obb.onnx`  | Nano OBB model, auto-downloaded                                     |
+| `predict --task classify`                         | `yolo26n-cls.onnx`  | Nano classify model, auto-downloaded                                |
+| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`  | Task read from model metadata                                       |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, proceeds normally                        |
+| `predict --task segment --model yolo26n.onnx`     | error               | `--task` conflicts with model metadata (`detect`), exits with error |
 
 **Auto-downloadable models:**
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ model.export(format="onnx")
 cargo run --release -- predict
 
 # Select task — auto-downloads the nano model for that task
-cargo run --release -- predict --task segment          # downloads yolo26n-seg.onnx
-cargo run --release -- predict --task pose             # downloads yolo26n-pose.onnx
-cargo run --release -- predict --task obb              # downloads yolo26n-obb.onnx
-cargo run --release -- predict --task classify         # downloads yolo26n-cls.onnx
+cargo run --release -- predict --task segment  # downloads yolo26n-seg.onnx
+cargo run --release -- predict --task pose     # downloads yolo26n-pose.onnx
+cargo run --release -- predict --task obb      # downloads yolo26n-obb.onnx
+cargo run --release -- predict --task classify # downloads yolo26n-cls.onnx
 
 # With explicit model (task is read from model metadata)
 cargo run --release -- predict --model yolo26n.onnx --source image.jpg
@@ -174,46 +174,46 @@ cargo run --release -- predict --model <model.onnx> --source <source>
 
 **CLI Options:**
 
-| Option          | Short | Description                                                                   | Default                                 |
-| --------------- | ----- | ----------------------------------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name        | `yolo26n.onnx`                          |
-| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect` |
-| `--source`      | `-s`  | Input source (image, video, webcam index, or URL)                             | `Task dependent Ultralytics URL assets` |
-| `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)                                | `cpu`                                   |
-| `--conf`        |       | Confidence threshold                                                          | `0.25`                                  |
-| `--iou`         |       | IoU threshold for NMS                                                         | `0.7`                                   |
-| `--max-det`     |       | Maximum number of detections                                                  | `300`                                   |
-| `--imgsz`       |       | Inference image size                                                          | `Model metadata`                        |
-| `--rect`        |       | Enable rectangular inference (minimal padding)                                | `true`                                  |
-| `--batch`       |       | Batch size for inference                                                      | `1`                                     |
-| `--half`        |       | Use FP16 half-precision inference                                             | `false`                                 |
-| `--save`        |       | Save annotated results to runs/\<task\>/predict                               | `true`                                  |
-| `--save-frames` |       | Save individual frames for video                                              | `false`                                 |
-| `--show`        |       | Display results in a window                                                   | `false`                                 |
-| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                  | all classes                             |
-| `--verbose`     |       | Show verbose output                                                           | `true`                                  |
+| Option          | Short | Description                                                                                              | Default                                 |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name                                   | `yolo26n.onnx`                          |
+| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect`                                |
+| `--source`      | `-s`  | Input source (image, video, webcam index, or URL)                                                        | `Task dependent Ultralytics URL assets` |
+| `--device`      |       | Device to use (cpu, cuda:0, mps, coreml, etc.)                                                           | `cpu`                                   |
+| `--conf`        |       | Confidence threshold                                                                                     | `0.25`                                  |
+| `--iou`         |       | IoU threshold for NMS                                                                                    | `0.7`                                   |
+| `--max-det`     |       | Maximum number of detections                                                                             | `300`                                   |
+| `--imgsz`       |       | Inference image size                                                                                     | `Model metadata`                        |
+| `--rect`        |       | Enable rectangular inference (minimal padding)                                                           | `true`                                  |
+| `--batch`       |       | Batch size for inference                                                                                 | `1`                                     |
+| `--half`        |       | Use FP16 half-precision inference                                                                        | `false`                                 |
+| `--save`        |       | Save annotated results to runs/\<task\>/predict                                                          | `true`                                  |
+| `--save-frames` |       | Save individual frames for video                                                                         | `false`                                 |
+| `--show`        |       | Display results in a window                                                                              | `false`                                 |
+| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                              | all classes                             |
+| `--verbose`     |       | Show verbose output                                                                                      | `true`                                  |
 
 **Task and Model Resolution:**
 
-| Invocation                              | Model used                         | Notes                                      |
-| --------------------------------------- | ---------------------------------- | ------------------------------------------ |
-| `predict`                               | `yolo26n.onnx`                     | Default detect model, auto-downloaded      |
-| `predict --task segment`                | `yolo26n-seg.onnx`                 | Nano seg model, auto-downloaded            |
-| `predict --task pose`                   | `yolo26n-pose.onnx`                | Nano pose model, auto-downloaded           |
-| `predict --task obb`                    | `yolo26n-obb.onnx`                 | Nano OBB model, auto-downloaded            |
-| `predict --task classify`               | `yolo26n-cls.onnx`                 | Nano classify model, auto-downloaded       |
-| `predict --model yolo26l-seg.onnx`      | `yolo26l-seg.onnx`                 | Task read from model metadata              |
-| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`     | `--task` matches metadata, no warning      |
-| `predict --task segment --model yolo26n.onnx`     | `yolo26n.onnx`         | Task overridden with warning; results may be empty if architectures differ |
+| Invocation                                        | Model used          | Notes                                                                      |
+| ------------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| `predict`                                         | `yolo26n.onnx`      | Default detect model, auto-downloaded                                      |
+| `predict --task segment`                          | `yolo26n-seg.onnx`  | Nano seg model, auto-downloaded                                            |
+| `predict --task pose`                             | `yolo26n-pose.onnx` | Nano pose model, auto-downloaded                                           |
+| `predict --task obb`                              | `yolo26n-obb.onnx`  | Nano OBB model, auto-downloaded                                            |
+| `predict --task classify`                         | `yolo26n-cls.onnx`  | Nano classify model, auto-downloaded                                       |
+| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`  | Task read from model metadata                                              |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, no warning                                      |
+| `predict --task segment --model yolo26n.onnx`     | `yolo26n.onnx`      | Task overridden with warning; results may be empty if architectures differ |
 
 **Auto-downloadable models:**
 
 All YOLO11 and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download:
 
-| Family  | Variants                                                                 |
-| ------- | ------------------------------------------------------------------------ |
-| YOLO26  | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
-| YOLO11  | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
+| Family | Variants                                                                        |
+| ------ | ------------------------------------------------------------------------------- |
+| YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
+| YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
 
 **Source Options:**
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-use crate::task::Task;
 use crate::InferenceConfig;
+use crate::task::Task;
 use clap::{Args, Parser, Subcommand};
 
 /// CLI arguments parser.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -10,18 +10,19 @@ use clap::{Args, Parser, Subcommand};
 #[command(propagate_version = true)]
 #[command(after_help = r#"Predict Options:
     --model, -m <MODEL>    Path to ONNX model file [default: yolo26n.onnx]
-    --task <TASK>          Task type: detect, segment, pose, obb, cls (selects nano model if --model omitted)
+    --task <TASK>          Task type: detect, segment, pose, obb, classify [default: detect]
+                           Selects the matching nano model when --model is omitted
     --source, -s <SOURCE>  Input source (image, directory, glob, video, webcam, or URL)
     --conf <CONF>          Confidence threshold [default: 0.25]
     --iou <IOU>            IoU threshold for NMS [default: 0.7]
     --max-det <MAX_DET>    Maximum number of detections [default: 300]
-    --imgsz <IMGSZ>        Inference image size
+    --imgsz <IMGSZ>        Inference image size [default: model metadata]
     --rect                 Enable rectangular inference (minimal padding) [default: true]
     --batch <BATCH>        Batch size for inference [default: 1]
-    --half                 Use FP16 half-precision inference
+    --half                 Use FP16 half-precision inference [default: false]
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
-    --show                 Display results in a window
+    --show                 Display results in a window [default: false]
     --device <DEVICE>      Device (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, xnnpack)
     --verbose              Show verbose output [default: true]
     --classes <CLASSES>    Filter by class IDs (e.g., "0", "0,1,2", "[0, 1]")
@@ -29,7 +30,9 @@ use clap::{Args, Parser, Subcommand};
 Examples:
     ultralytics-inference predict
     ultralytics-inference predict --task segment
+    ultralytics-inference predict --task pose
     ultralytics-inference predict --task obb --source aerial.jpg
+    ultralytics-inference predict --task classify --source image.jpg
     ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
@@ -58,8 +61,8 @@ pub struct PredictArgs {
     #[arg(short, long)]
     pub model: Option<String>,
 
-    /// Task type — selects nano model for auto-download when --model is omitted
-    /// (detect, segment, pose, obb, cls)
+    /// Task type; selects nano model for auto-download when --model is omitted
+    /// (detect, segment, pose, obb, classify)
     #[arg(long)]
     pub task: Option<Task>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,5 +1,6 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+use crate::task::Task;
 use crate::InferenceConfig;
 use clap::{Args, Parser, Subcommand};
 
@@ -9,6 +10,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(propagate_version = true)]
 #[command(after_help = r#"Predict Options:
     --model, -m <MODEL>    Path to ONNX model file [default: yolo26n.onnx]
+    --task <TASK>          Task type: detect, segment, pose, obb, cls (selects nano model if --model omitted)
     --source, -s <SOURCE>  Input source (image, directory, glob, video, webcam, or URL)
     --conf <CONF>          Confidence threshold [default: 0.25]
     --iou <IOU>            IoU threshold for NMS [default: 0.7]
@@ -26,6 +28,8 @@ use clap::{Args, Parser, Subcommand};
 
 Examples:
     ultralytics-inference predict
+    ultralytics-inference predict --task segment
+    ultralytics-inference predict --task obb --source aerial.jpg
     ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
@@ -53,6 +57,11 @@ pub struct PredictArgs {
     /// Path to ONNX model file
     #[arg(short, long)]
     pub model: Option<String>,
+
+    /// Task type — selects nano model for auto-download when --model is omitted
+    /// (detect, segment, pose, obb, cls)
+    #[arg(long)]
+    pub task: Option<Task>,
 
     /// Input source (image, directory, glob, video, webcam, or URL)
     #[arg(short, long)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -95,7 +95,7 @@ pub struct PredictArgs {
     #[arg(long, default_value_t = InferenceConfig::DEFAULT_HALF)]
     pub half: bool,
 
-    /// Save annotated images to runs/<task>/predict
+    /// Save annotated images to runs/\<task\>/predict
     #[arg(long, default_value_t = InferenceConfig::DEFAULT_SAVE, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub save: bool,
 
@@ -128,7 +128,7 @@ pub struct PredictArgs {
     pub classes: Option<String>,
 }
 
-/// Parse class IDs from various formats: "1,2,3", "[1,2,3]", "(1,2,3)"
+/// Parse class IDs from various formats: `"1,2,3"`, `"[1,2,3]"`, `"(1,2,3)"`
 ///
 /// # Errors
 ///

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -105,13 +105,19 @@ pub fn run_prediction(args: &PredictArgs) {
     };
 
     if let Some(task) = args.task {
-        if !model_is_default && verbose && task != model.task() {
-            warn!(
-                "'--task={task}' overrides task detected from model metadata ('{}').",
+        if model_is_default {
+            // Model was auto-selected from --task, so metadata will always agree.
+            // set_task is a no-op here but kept for explicitness.
+            model.set_task(task);
+        } else if task != model.task() {
+            error!(
+                "'--task={task}' conflicts with task '{}' detected from model metadata. \
+                 Provide a model that matches the requested task, or omit --task.",
                 model.task()
             );
+            process::exit(1);
         }
-        model.set_task(task);
+        // task == model.task(): explicit model, matching task — nothing to do.
     }
 
     // Determine source

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -37,10 +37,13 @@ use crate::{error, verbose, warn};
 pub fn run_prediction(args: &PredictArgs) {
     // Parse arguments - use default model if not specified
     let model_is_default = args.model.is_none();
-    let model_path = args
-        .model
-        .clone()
-        .unwrap_or_else(|| crate::download::DEFAULT_MODEL.to_string());
+    let model_path = args.model.clone().unwrap_or_else(|| {
+        let suffix = args
+            .task
+            .unwrap_or(crate::task::Task::Detect)
+            .model_suffix();
+        format!("yolo26n{suffix}.onnx")
+    });
     let source_path = &args.source;
     let conf_threshold = args.conf;
     let iou_threshold = args.iou;
@@ -56,12 +59,8 @@ pub fn run_prediction(args: &PredictArgs) {
         .map(|d| d.parse().expect("Invalid device"));
     #[cfg(feature = "visualize")]
     let show = args.show;
-    // Warn if using default model
     if model_is_default && verbose {
-        warn!(
-            "'model' argument is missing. Using default '--model={}'.",
-            crate::download::DEFAULT_MODEL
-        );
+        warn!("'model' argument is missing. Using default '--model={model_path}'.");
     }
 
     // Load model first so we can determine appropriate default source based on task
@@ -106,6 +105,16 @@ pub fn run_prediction(args: &PredictArgs) {
             process::exit(1);
         }
     };
+
+    if let Some(task) = args.task {
+        if !model_is_default && verbose && task != model.task() {
+            warn!(
+                "'--task={task}' overrides task detected from model metadata ('{}').",
+                model.task()
+            );
+        }
+        model.set_task(task);
+    }
 
     // Determine source
     let source = source_path.as_ref().map_or_else(

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -117,7 +117,7 @@ pub fn run_prediction(args: &PredictArgs) {
             );
             process::exit(1);
         }
-        // task == model.task(): explicit model, matching task — nothing to do.
+        // task == model.task(): explicit model, matching task; nothing to do.
     }
 
     // Determine source

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -38,11 +38,9 @@ pub fn run_prediction(args: &PredictArgs) {
     // Parse arguments - use default model if not specified
     let model_is_default = args.model.is_none();
     let model_path = args.model.clone().unwrap_or_else(|| {
-        let suffix = args
-            .task
+        args.task
             .unwrap_or(crate::task::Task::Detect)
-            .model_suffix();
-        format!("yolo26n{suffix}.onnx")
+            .default_model()
     });
     let source_path = &args.source;
     let conf_threshold = args.conf;

--- a/src/download.rs
+++ b/src/download.rs
@@ -300,7 +300,8 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
 /// Attempt to download a model if it matches a known downloadable model.
 ///
-/// Supports YOLO26 and YOLO11 ONNX models (n/s/m/l/x) listed in [`DOWNLOADABLE_MODELS`].
+/// Supports all YOLO26 and YOLO11 ONNX models across sizes (n/s/m/l/x) and
+/// task variants (detect, segment, pose, obb, classify).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// Returns the path to the downloaded model.

--- a/src/download.rs
+++ b/src/download.rs
@@ -17,32 +17,23 @@ const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/do
 /// Default YOLO detection model name.
 pub const DEFAULT_MODEL: &str = "yolo26n.onnx";
 
-/// Default YOLO segmentation model name.
-pub const DEFAULT_SEGMENT_MODEL: &str = "yolo26n-seg.onnx";
+/// YOLO Model families, sizes, and variants supported for auto-download.
+const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11"];
+const MODEL_SIZES: &[&str] = &["n", "s", "m", "l", "x"];
+const MODEL_VARIANTS: &[&str] = &["", "-seg", "-pose", "-obb", "-cls"];
 
-/// Default YOLO pose model name.
-pub const DEFAULT_POSE_MODEL: &str = "yolo26n-pose.onnx";
-
-/// Default YOLO OBB model name.
-pub const DEFAULT_OBB_MODEL: &str = "yolo26n-obb.onnx";
-
-/// Default YOLO classification model name.
-pub const DEFAULT_CLS_MODEL: &str = "yolo26n-cls.onnx";
-
-const DOWNLOADABLE_MODELS: &[&str] = &[
-    // YOLO26
-    "yolo26n.onnx",
-    "yolo26n-seg.onnx",
-    "yolo26n-pose.onnx",
-    "yolo26n-obb.onnx",
-    "yolo26n-cls.onnx",
-    // YOLO11
-    "yolo11n.onnx",
-    "yolo11n-seg.onnx",
-    "yolo11n-pose.onnx",
-    "yolo11n-obb.onnx",
-    "yolo11n-cls.onnx",
-];
+fn downloadable_models() -> Vec<String> {
+    MODEL_FAMILIES
+        .iter()
+        .flat_map(|family| {
+            MODEL_SIZES.iter().flat_map(move |size| {
+                MODEL_VARIANTS
+                    .iter()
+                    .map(move |variant| format!("{family}{size}{variant}.onnx"))
+            })
+        })
+        .collect()
+}
 
 const DEFAULT_BUS_IMAGE_URL: &str = "https://ultralytics.com/images/bus.jpg";
 const DEFAULT_ZIDANE_IMAGE_URL: &str = "https://ultralytics.com/images/zidane.jpg";
@@ -312,7 +303,7 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
 /// Attempt to download a model if it matches a known downloadable model.
 ///
-/// Supports the YOLO26 and YOLO11 nano ONNX models listed in [`DOWNLOADABLE_MODELS`].
+/// Supports YOLO26 and YOLO11 ONNX models (n/s/m/l/x) listed in [`DOWNLOADABLE_MODELS`].
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// Returns the path to the downloaded model.
@@ -321,11 +312,12 @@ pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
     let path = path.as_ref();
     let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-    if !DOWNLOADABLE_MODELS.contains(&filename) {
+    let models = downloadable_models();
+    if !models.iter().any(|m| m == filename) {
         return Err(InferenceError::ModelLoadError(format!(
             "Model file not found: {}. Auto-download is supported for: {}",
             path.display(),
-            DOWNLOADABLE_MODELS.join(", "),
+            models.join(", "),
         )));
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -14,9 +14,6 @@ use crate::error::{InferenceError, Result};
 
 const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/download/v8.4.0";
 
-/// Default YOLO detection model name.
-pub const DEFAULT_MODEL: &str = "yolo26n.onnx";
-
 /// YOLO Model families, sizes, and variants supported for auto-download.
 const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11"];
 const MODEL_SIZES: &[&str] = &["n", "s", "m", "l", "x"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@
 //! | [`inference`] | [`InferenceConfig`] for customizing inference settings |
 //! | [`source`] | Input source handling ([`Source`], [`SourceIterator`]) |
 //! | [`task`] | YOLO task types ([`Task`]: Detect, Segment, Pose, etc.) |
-//! | [`error`] | Error types ([`InferenceError`], [`Result`]) |
+//! | [`mod@error`] | Error types ([`InferenceError`], [`Result`]) |
 //! | [`preprocessing`] | Image preprocessing utilities |
 //! | [`postprocessing`] | Detection post-processing (NMS, decode) |
 //! | [`metadata`] | ONNX model metadata parsing |

--- a/src/model.rs
+++ b/src/model.rs
@@ -1033,7 +1033,7 @@ impl YOLOModel {
     }
 
     /// Override the task type read from model metadata.
-    pub fn set_task(&mut self, task: crate::task::Task) {
+    pub const fn set_task(&mut self, task: crate::task::Task) {
         self.metadata.task = task;
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -981,7 +981,19 @@ impl YOLOModel {
         Ok(results)
     }
 
-    /// Get the model's task type.
+    /// Get the model's task type as detected from ONNX metadata.
+    ///
+    /// The task is parsed automatically when the model is loaded. Use
+    /// [`set_task`](Self::set_task) to override it at runtime if needed.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use ultralytics_inference::{Task, YOLOModel};
+    /// let model = YOLOModel::load("yolo26n-seg.onnx")?;
+    /// assert_eq!(model.task(), Task::Segment);
+    /// # Ok::<(), ultralytics_inference::InferenceError>(())
+    /// ```
     #[must_use]
     pub const fn task(&self) -> Task {
         self.metadata.task
@@ -1033,6 +1045,22 @@ impl YOLOModel {
     }
 
     /// Override the task type read from model metadata.
+    ///
+    /// Use this when you want to force a specific post-processing path without
+    /// reloading the model. The model architecture must actually match the target
+    /// task; overriding to a mismatched task will produce empty or incorrect
+    /// results.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use ultralytics_inference::{Task, YOLOModel};
+    /// let mut model = YOLOModel::load("yolo26n-seg.onnx")?;
+    /// // confirm the task before overriding
+    /// assert_eq!(model.task(), Task::Segment);
+    /// model.set_task(Task::Segment); // no-op here, but illustrates the API
+    /// # Ok::<(), ultralytics_inference::InferenceError>(())
+    /// ```
     pub const fn set_task(&mut self, task: crate::task::Task) {
         self.metadata.task = task;
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1032,6 +1032,11 @@ impl YOLOModel {
         &self.metadata
     }
 
+    /// Override the task type read from model metadata.
+    pub fn set_task(&mut self, task: crate::task::Task) {
+        self.metadata.task = task;
+    }
+
     /// Get the model path.
     #[must_use]
     pub const fn model_path(&self) -> &'static str {

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -219,7 +219,7 @@ fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
 ///
 /// Returns `None` for shapes that don't match the end-to-end layout, and for
 /// shapes where `kpt_feats` is divisible by both 2 and 3 (e.g. 36, 42) because
-/// the layout is ambiguous — `(12, 3)` and `(18, 2)` both decode the same
+/// the layout is ambiguous: `(12, 3)` and `(18, 2)` both decode the same
 /// tensor. Ambiguous cases fall through to the legacy pose path rather than
 /// silently guessing the wrong dimension.
 fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
@@ -1366,7 +1366,7 @@ fn postprocess_obb(
 //
 // End-to-end exports bake NMS into the graph and produce a tensor of shape
 // `[B, max_det, 6 + extra]`, where the first 6 columns are always
-// `[x1, y1, x2, y2, conf, cls]` (OBB is the exception — see `postprocess_obb_end2end`).
+// `[x1, y1, x2, y2, conf, cls]` (OBB is the exception; see `postprocess_obb_end2end`).
 // Coordinates are in the letterboxed model-input space, so we still scale/pad-correct
 // them back to original-image space. No NMS, no class-score matrix.
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -50,6 +50,18 @@ impl Task {
         }
     }
 
+    /// Return the ONNX filename suffix for the nano model of this task.
+    #[must_use]
+    pub const fn model_suffix(&self) -> &'static str {
+        match self {
+            Self::Detect => "",
+            Self::Segment => "-seg",
+            Self::Pose => "-pose",
+            Self::Classify => "-cls",
+            Self::Obb => "-obb",
+        }
+    }
+
     /// Check whether this task produces bounding boxes.
     ///
     /// # Returns

--- a/src/task.rs
+++ b/src/task.rs
@@ -50,7 +50,7 @@ impl Task {
         }
     }
 
-    /// Return the ONNX filename suffix for the nano model of this task.
+    /// Return the ONNX filename suffix for this task.
     #[must_use]
     pub const fn model_suffix(&self) -> &'static str {
         match self {
@@ -60,6 +60,12 @@ impl Task {
             Self::Classify => "-cls",
             Self::Obb => "-obb",
         }
+    }
+
+    /// Return the default nano model filename for this task.
+    #[must_use]
+    pub fn default_model(&self) -> String {
+        format!("yolo26n{}.onnx", self.model_suffix())
     }
 
     /// Check whether this task produces bounding boxes.

--- a/src/task.rs
+++ b/src/task.rs
@@ -51,6 +51,24 @@ impl Task {
     }
 
     /// Return the ONNX filename suffix for this task.
+    ///
+    /// Used to construct model filenames: `yolo26n{suffix}.onnx`.
+    ///
+    /// | Task       | Suffix   |
+    /// |------------|----------|
+    /// | Detect     | `""`     |
+    /// | Segment    | `"-seg"` |
+    /// | Pose       | `"-pose"`|
+    /// | Classify   | `"-cls"` |
+    /// | Obb        | `"-obb"` |
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ultralytics_inference::Task;
+    /// assert_eq!(Task::Segment.model_suffix(), "-seg");
+    /// assert_eq!(Task::Detect.model_suffix(), "");
+    /// ```
     #[must_use]
     pub const fn model_suffix(&self) -> &'static str {
         match self {
@@ -62,7 +80,21 @@ impl Task {
         }
     }
 
-    /// Return the default nano model filename for this task.
+    /// Return the default nano YOLO26 model filename for this task.
+    ///
+    /// This is the model that the CLI auto-downloads when `--model` is omitted
+    /// and `--task` is specified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ultralytics_inference::Task;
+    /// assert_eq!(Task::Detect.default_model(),  "yolo26n.onnx");
+    /// assert_eq!(Task::Segment.default_model(), "yolo26n-seg.onnx");
+    /// assert_eq!(Task::Pose.default_model(),    "yolo26n-pose.onnx");
+    /// assert_eq!(Task::Obb.default_model(),     "yolo26n-obb.onnx");
+    /// assert_eq!(Task::Classify.default_model(),"yolo26n-cls.onnx");
+    /// ```
     #[must_use]
     pub fn default_model(&self) -> String {
         format!("yolo26n{}.onnx", self.model_suffix())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,6 +30,7 @@ fn test_run_prediction_e2e() {
         verbose: true,
         rect: false,
         classes: None,
+        task: None,
     };
 
     // This should run successfully (download model/images and predict)


### PR DESCRIPTION

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR makes the Rust CLI much easier to use by adding task-based model selection, broader auto-download support for YOLO11 and YOLO26 ONNX models, and clearer validation and documentation.

### 📊 Key Changes
- ⬇️ Expanded **auto-download support** from a small fixed set of models to **all YOLO11 and YOLO26 ONNX variants** across sizes `n/s/m/l/x` and tasks like detect, segment, pose, OBB, and classify.
- 🎯 Added a new `--task` CLI flag so users can run inference by task alone, such as segmentation or pose, without manually choosing a model file.
- 🤖 Updated default model selection logic so when `--model` is omitted, the CLI now picks the correct **YOLO26 nano model** based on the requested task.
- ✅ Added **task/model consistency checks**: if a user provides both `--task` and `--model` and they do not match, the CLI now exits with a clear error instead of proceeding incorrectly.
- 🧩 Added helper methods in the `Task` and `YOLOModel` code to support task-specific default model names and controlled task overrides.
- 🏷️ Improved CLI help, README examples, and option tables with clearer defaults, new usage examples, class filtering examples, and a full task-to-model resolution guide.
- 🛠️ Included small documentation and wording cleanups, plus test updates to cover the new `task` argument.

### 🎯 Purpose & Impact
- 👍 Makes the CLI more beginner-friendly by reducing setup friction: users can now run the right model with simpler commands like `predict --task segment`.
- ⚡ Speeds up experimentation by letting users automatically fetch supported models instead of locating ONNX files manually.
- 🛡️ Reduces user mistakes through explicit validation when a chosen task conflicts with the model’s embedded metadata.
- 📚 Improves discoverability and usability with clearer docs and examples, which should help both new and experienced users adopt features faster.
- 🌍 Broadens practical coverage for inference workflows by supporting many more downloadable model variants out of the box.