### PR TITLE
refactor: ♻️ clean up unused code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,9 +276,7 @@ pub use task::Task;
 pub use metadata::ModelMetadata;
 
 // Re-export preprocessing utilities
-pub use preprocessing::{
-    PreprocessResult, TensorData, preprocess_image, preprocess_image_with_precision,
-};
+pub use preprocessing::{PreprocessResult, preprocess_image, preprocess_image_with_precision};
 
 /// Library version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/model.rs
+++ b/src/model.rs
@@ -1064,7 +1064,6 @@ impl YOLOModel {
     pub const fn set_task(&mut self, task: crate::task::Task) {
         self.metadata.task = task;
     }
-
 }
 
 #[allow(clippy::missing_fields_in_debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1065,13 +1065,6 @@ impl YOLOModel {
         self.metadata.task = task;
     }
 
-    /// Get the model path.
-    #[must_use]
-    pub const fn model_path(&self) -> &'static str {
-        // Note: ONNX Runtime doesn't expose the original path
-        // This is a placeholder - in practice, users should track the path themselves
-        ""
-    }
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -1130,8 +1123,6 @@ mod tests {
             assert_eq!(model.stride(), 32);
             assert_eq!(model.imgsz(), (640, 640)); // Default for yolo26n
             assert!(!model.names().is_empty());
-            assert_eq!(model.model_path(), ""); // Placeholder returns empty string
-
             // Test Debug impl
             let debug_str = format!("{model:?}");
             assert!(debug_str.contains("YOLOModel"));

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -80,25 +80,6 @@ thread_local! {
 // Types
 // ================================================================================================
 
-/// Tensor data that can be either FP32 or FP16.
-#[derive(Debug, Clone)]
-pub enum TensorData {
-    /// 32-bit floating point tensor.
-    Float32(Array4<f32>),
-    /// 16-bit floating point tensor.
-    Float16(Array4<f16>),
-}
-
-impl TensorData {
-    /// Get the shape of the tensor.
-    #[must_use]
-    pub fn shape(&self) -> &[usize] {
-        match self {
-            Self::Float32(t) => t.shape(),
-            Self::Float16(t) => t.shape(),
-        }
-    }
-}
 
 /// Result of preprocessing an image, containing the tensor and transform info.
 #[derive(Debug, Clone)]

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -80,7 +80,6 @@ thread_local! {
 // Types
 // ================================================================================================
 
-
 /// Result of preprocessing an image, containing the tensor and transform info.
 #[derive(Debug, Clone)]
 pub struct PreprocessResult {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,51 +102,6 @@ pub fn calculate_probiou(box1: &[f32; 5], box2: &[f32; 5]) -> f32 {
     1.0 - hd
 }
 
-/// Non-Maximum Suppression (NMS) for filtering overlapping detections
-///
-/// # Arguments
-///
-/// * `boxes` - Vector of bounding boxes with scores [(bbox, score)]
-/// * `iou_threshold` - `IoU` threshold for suppression
-///
-/// # Returns
-///
-/// Indices of boxes to keep
-///
-/// # Panics
-///
-/// Panics if `partial_cmp` fails for floating point comparisons (e.g. NaN).
-#[must_use]
-pub fn nms(boxes: &[([f32; 4], f32)], iou_threshold: f32) -> Vec<usize> {
-    if boxes.is_empty() {
-        return vec![];
-    }
-
-    // Sort by score (descending)
-    let mut indices: Vec<usize> = (0..boxes.len()).collect();
-    indices.sort_by(|&a, &b| boxes[b].1.partial_cmp(&boxes[a].1).unwrap());
-
-    let mut keep = vec![];
-    let mut suppressed = vec![false; boxes.len()];
-
-    for &i in &indices {
-        if suppressed[i] {
-            continue;
-        }
-        keep.push(i);
-
-        for &j in &indices {
-            if !suppressed[j] && i != j {
-                let iou = calculate_iou(&boxes[i].0, &boxes[j].0);
-                if iou > iou_threshold {
-                    suppressed[j] = true;
-                }
-            }
-        }
-    }
-
-    keep
-}
 
 /// Per-class Non-Maximum Suppression (NMS) for filtering overlapping detections
 ///
@@ -329,19 +284,6 @@ mod tests {
         let box2 = [5.0, 5.0, 15.0, 15.0];
         let iou = calculate_iou(&box1, &box2);
         assert!((iou - 0.142_857).abs() < 0.001); // 25 / (100 + 100 - 25)
-    }
-
-    #[test]
-    fn test_nms() {
-        let boxes = vec![
-            ([0.0, 0.0, 10.0, 10.0], 0.9),
-            ([1.0, 1.0, 11.0, 11.0], 0.8),
-            ([100.0, 100.0, 110.0, 110.0], 0.95),
-        ];
-        let keep = nms(&boxes, 0.5);
-        assert_eq!(keep.len(), 2); // Should keep boxes at indices 2 and 0
-        assert!(keep.contains(&2));
-        assert!(keep.contains(&0));
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,7 +102,6 @@ pub fn calculate_probiou(box1: &[f32; 5], box2: &[f32; 5]) -> f32 {
     1.0 - hd
 }
 
-
 /// Per-class Non-Maximum Suppression (NMS) for filtering overlapping detections
 ///
 /// Only suppresses boxes within the same class, matching Ultralytics behavior.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies the Rust inference library API by removing unused or placeholder functionality, making the codebase cleaner and less confusing for developers.

### 📊 Key Changes
- Removed the `TensorData` enum from preprocessing and stopped re-exporting it from `src/lib.rs`.
- Kept only the active preprocessing exports: `PreprocessResult`, `preprocess_image`, and `preprocess_image_with_precision`.
- Removed the `model_path()` method from `YOLOModel` in `src/model.rs` because it only returned an empty placeholder string.
- Deleted the related unit test that checked the placeholder `model_path()` behavior.
- Removed the generic `nms()` function from `src/utils.rs`.
- Kept the more relevant per-class NMS implementation, which better matches Ultralytics detection behavior.
- Cleaned up tests tied to the removed `nms()` helper.

### 🎯 Purpose & Impact
- ✅ Reduces API clutter by removing functions and types that were unused, redundant, or misleading.
- ✅ Prevents confusion for developers who might expect `model_path()` to return a real file path.
- ✅ Encourages use of the library’s task-specific and Ultralytics-aligned postprocessing instead of a generic NMS helper.
- ✅ Makes the codebase easier to maintain, with fewer legacy or placeholder pieces to document and test.
- ⚠️ Potential breaking change: users relying on `TensorData`, `model_path()`, or the removed `nms()` utility will need to update their code.