### PR TITLE
refactor: simplify device parsing logic in FromStr implementation

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -50,47 +50,36 @@ impl fmt::Display for Device {
 impl FromStr for Device {
     type Err = String;
 
-    #[allow(clippy::option_if_let_else)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_lowercase();
+        if let Some(rest) = s.strip_prefix("cuda") {
+            return Ok(Self::Cuda(parse_device_index(rest)));
+        }
+        if let Some(rest) = s.strip_prefix("directml") {
+            return Ok(Self::DirectMl(parse_device_index(rest)));
+        }
+        if let Some(rest) = s.strip_prefix("tensorrt") {
+            return Ok(Self::TensorRt(parse_device_index(rest)));
+        }
+        if let Some(rest) = s.strip_prefix("rocm") {
+            return Ok(Self::Rocm(parse_device_index(rest)));
+        }
         match s.as_str() {
             "cpu" => Ok(Self::Cpu),
             "mps" => Ok(Self::Mps),
             "coreml" => Ok(Self::CoreMl),
             "openvino" => Ok(Self::OpenVino),
             "xnnpack" => Ok(Self::Xnnpack),
-            _ => s.strip_prefix("cuda").map_or_else(
-                || {
-                    if let Some(rest) = s.strip_prefix("directml") {
-                        let index = parse_device_index(rest).unwrap_or(0);
-                        Ok(Self::DirectMl(index))
-                    } else if let Some(rest) = s.strip_prefix("tensorrt") {
-                        let index = parse_device_index(rest).unwrap_or(0);
-                        Ok(Self::TensorRt(index))
-                    } else if let Some(rest) = s.strip_prefix("rocm") {
-                        let index = parse_device_index(rest).unwrap_or(0);
-                        Ok(Self::Rocm(index))
-                    } else {
-                        Err(format!("Unknown device: {s}"))
-                    }
-                },
-                |rest| {
-                    let index = parse_device_index(rest).unwrap_or(0);
-                    Ok(Self::Cuda(index))
-                },
-            ),
+            _ => Err(format!("Unknown device: {s}")),
         }
     }
 }
 
-/// Helper to parse device index from string (e.g. ":0")
-fn parse_device_index(s: &str) -> Option<usize> {
-    if s.is_empty() {
-        return None;
-    }
-    // Handle ":0", ":1" etc.
+/// Parse a trailing device index like `":0"`, defaulting to `0` when absent.
+fn parse_device_index(s: &str) -> usize {
     s.strip_prefix(':')
-        .and_then(|index_str| index_str.parse::<usize>().ok())
+        .and_then(|i| i.parse().ok())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR simplifies device string parsing in `src/device.rs`, making GPU/backend selection cleaner, more consistent, and easier to maintain.

### 📊 Key Changes
- 🔧 Refactored `Device::from_str()` to handle prefixed devices early using `strip_prefix()` for:
  - `cuda`
  - `directml`
  - `tensorrt`
  - `rocm`
- 🧹 Removed the older nested parsing logic and `clippy` allow annotation, resulting in cleaner and more readable code.
- ✅ Updated `parse_device_index()` to always return a `usize` instead of `Option<usize>`.
- 🎯 Standardized device index handling so missing or invalid indices now default to `0`.
- 💬 Improved the helper function comment to clearly describe expected input like `":0"`.

### 🎯 Purpose & Impact
- 🚀 Makes device parsing logic easier for developers to understand and maintain.
- 🛠️ Reduces branching and special-case handling, which lowers the chance of bugs in device selection.
- 🤝 Ensures consistent behavior across supported backends like CUDA, DirectML, TensorRT, and ROCm.
- 📦 For users, device strings such as `cuda`, `cuda:0`, `directml`, or `rocm:1` should behave more predictably.
- ⚠️ Invalid or missing device indices now quietly fall back to device `0`, which improves robustness but may mask malformed input in some cases.