### PR TITLE
refactor: simplify error handling by removing redundant error variants and improving IO error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,13 +19,7 @@ pub enum InferenceError {
     /// Invalid configuration provided.
     ConfigError(String),
     /// IO error (file not found, permission denied, etc.).
-    IoError(String),
-    /// Wrapped `std::io::Error`
     Io(std::io::Error),
-    /// Error parsing model metadata.
-    MetadataError(String),
-    /// Post-processing error.
-    PostProcessingError(String),
     /// Visualizer error.
     VisualizerError(String),
     /// Video/stream processing error.
@@ -41,10 +35,7 @@ impl fmt::Display for InferenceError {
             Self::InferenceError(msg) => write!(f, "Inference error: {msg}"),
             Self::ImageError(msg) => write!(f, "Image error: {msg}"),
             Self::ConfigError(msg) => write!(f, "Config error: {msg}"),
-            Self::IoError(msg) => write!(f, "IO error: {msg}"),
             Self::Io(err) => write!(f, "IO error: {err}"),
-            Self::MetadataError(msg) => write!(f, "Metadata error: {msg}"),
-            Self::PostProcessingError(msg) => write!(f, "Post-processing error: {msg}"),
             Self::VisualizerError(msg) => write!(f, "Visualizer error: {msg}"),
             Self::VideoError(msg) => write!(f, "Video error: {msg}"),
             Self::FeatureNotEnabled(msg) => write!(f, "Feature not enabled: {msg}"),

--- a/src/io.rs
+++ b/src/io.rs
@@ -60,10 +60,8 @@ impl VideoWriter {
         // Ensure parent directory exists
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                std::io::Error::other(format!(
-                    "Failed to create directory {}: {e}",
-                    parent.display()
-                ))
+                let dir = parent.display();
+                std::io::Error::new(e.kind(), format!("Failed to create directory {dir}: {e}"))
             })?;
         }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -60,7 +60,7 @@ impl VideoWriter {
         // Ensure parent directory exists
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                InferenceError::IoError(format!(
+                std::io::Error::other(format!(
                     "Failed to create directory {}: {e}",
                     parent.display()
                 ))
@@ -222,8 +222,7 @@ impl SaveResults {
                     if let Some(parent) = save_path.parent()
                         && !parent.exists()
                     {
-                        std::fs::create_dir_all(parent)
-                            .map_err(|e| InferenceError::IoError(e.to_string()))?;
+                        std::fs::create_dir_all(parent)?;
                     }
 
                     self.video_writer = Some(VideoWriter::new(save_path, width, height, fps)?);
@@ -258,8 +257,7 @@ impl SaveResults {
 
             // Ensure directory exists
             if !save_dir.exists() {
-                std::fs::create_dir_all(&save_dir)
-                    .map_err(|e| InferenceError::IoError(e.to_string()))?;
+                std::fs::create_dir_all(&save_dir)?;
             }
 
             annotated

--- a/src/source.rs
+++ b/src/source.rs
@@ -452,8 +452,7 @@ impl SourceIterator {
             )));
         }
 
-        let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
-            .map_err(|e| InferenceError::IoError(e.to_string()))?
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)?
             .filter_map(std::result::Result::ok)
             .map(|entry| entry.path())
             .filter(|path| Self::is_image_file(path))
@@ -490,8 +489,7 @@ impl SourceIterator {
                 )));
             }
 
-            let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
-                .map_err(|e| InferenceError::IoError(e.to_string()))?
+            let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)?
                 .filter_map(std::result::Result::ok)
                 .map(|entry| entry.path())
                 .filter(|path| {


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies error handling across the inference crate by removing redundant custom IO-related error variants and relying more directly on standard Rust IO errors.

### 📊 Key Changes
- Removed several custom `InferenceError` variants that were overlapping or unused:
  - `IoError(String)`
  - `MetadataError(String)`
  - `PostProcessingError(String)`
- Kept the standard wrapped IO error variant:
  - `Io(std::io::Error)`
- Updated error formatting in `Display` to reflect the slimmer error enum.
- Reworked directory-creation and directory-reading code in `src/io.rs` and `src/source.rs` to use standard `std::io::Error` propagation with `?` instead of manually converting errors into strings.
- Improved one directory creation error path to preserve the original IO error kind while adding clearer context about which directory failed.

### 🎯 Purpose & Impact
- ✅ **Cleaner error system:** Reduces duplication and makes the error model easier to maintain.
- 🔍 **Better debugging:** Preserving native `std::io::Error` details can provide more accurate error information than converting everything to plain strings.
- 🧱 **More idiomatic Rust:** The code now uses simpler and more standard error propagation patterns.
- 🚀 **Lower maintenance burden:** Fewer custom error cases mean less code to keep in sync as the project evolves.
- 👤 **User impact:** Most end users should see no behavior change, but developers may get clearer and more consistent IO error reporting when file or directory operations fail.