### PR TITLE
refactor: remove redundant comments from Results API documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,11 +198,6 @@
 //!
 //! The [`Results`] struct provides access to inference outputs:
 //!
-//!
-//! ## Results API
-//!
-//! The [`Results`] struct provides access to inference outputs:
-//!
 //! - [`Boxes`] - Bounding boxes with `xyxy()`, `xywh()`, `xyxyn()`, `xywhn()`, `conf()`, `cls()` methods
 //! - [`Masks`] - Segmentation masks with `data`, `orig_shape` fields
 //! - [`Keypoints`] - Pose keypoints with `xy()`, `xyn()`, `conf()` methods


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR makes a small documentation cleanup in `src/lib.rs` by removing a duplicated “Results API” section from the crate docs.

### 📊 Key Changes
- Removed a repeated documentation header and duplicate introductory lines for the `Results` API in `src/lib.rs`.
- Kept the existing explanation of the `Results` struct and its related output types:
  - `Boxes`
  - `Masks`
  - `Keypoints`
- No runtime, API, or model inference logic was changed.

### 🎯 Purpose & Impact
- Improves documentation readability by eliminating redundant text ✨
- Makes the Rust crate docs cleaner and easier to navigate for developers
- Has no functional impact on inference behavior, performance, or user-facing APIs ✅