### PR TITLE
refactor: remove redundant comments from tests in inference and logging modules

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -379,18 +379,13 @@ mod tests {
     #[test]
     fn test_keep_class() {
         let config = InferenceConfig::default();
-        // Default: no filtering -> keep all
         assert!(config.keep_class(0));
         assert!(config.keep_class(100));
 
         let config_filtered = InferenceConfig::new().with_classes(vec![1, 3]);
-        // Class 1 is in list -> keep
         assert!(config_filtered.keep_class(1));
-        // Class 3 is in list -> keep
         assert!(config_filtered.keep_class(3));
-        // Class 0 is NOT in list -> filter out (keep = false)
         assert!(!config_filtered.keep_class(0));
-        // Class 2 is NOT in list -> filter out (keep = false)
         assert!(!config_filtered.keep_class(2));
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -80,7 +80,6 @@ mod tests {
 
     #[test]
     fn test_verbosity_toggle() {
-        // Default is true
         set_verbose(true);
         assert!(is_verbose());
 


### PR DESCRIPTION

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR is a small cleanup that removes redundant inline comments from Rust unit tests without changing any functionality.

### 📊 Key Changes
- Removed explanatory comments from `src/inference.rs` test `test_keep_class`.
- Removed a redundant comment from `src/logging.rs` test `test_verbosity_toggle`.
- Kept all test logic, assertions, and behavior exactly the same ✅

### 🎯 Purpose & Impact
- Improves code readability by reducing clutter in test files.
- Makes the tests easier to scan, since the assertions already clearly describe the expected behavior.
- Has no impact on inference results, logging behavior, APIs, or runtime performance ⚙️
- Low-risk maintenance change that helps keep the codebase cleaner and more maintainable over time 📘