### PR TITLE
Bump taiki-e/install-action from v2.75.30 to v2.77.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@db5fb34fa772531a3ece57ca434f579eb334e0fb # v2.75.30
+        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f # v2.77.0
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.75.30 to v2.77.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step used to install `cargo-llvm-cov` in CI, keeping the Rust coverage workflow current and more maintainable.

### 📊 Key Changes
- ⬆️ Updated the pinned `taiki-e/install-action` version in `.github/workflows/ci.yml`
- 🔁 Moved from commit `db5fb34...` (`v2.75.30`) to commit `7ea35f0...` (`v2.77.0`)
- 🛡️ Kept the action pinned to a specific commit, which helps preserve CI security and reproducibility

### 🎯 Purpose & Impact
- ✅ Ensures the CI pipeline uses a newer version of the install action for `cargo-llvm-cov`
- 🔒 Maintains secure, deterministic GitHub Actions behavior by pinning to an exact commit
- 🧰 Helps reduce the chance of CI issues caused by outdated tooling
- 👩‍💻 For most users, this has no direct product-facing change, but it improves development reliability behind the scenes