### PR TITLE
refactor: replace default CoreML execution provider with custom builder

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -156,7 +156,7 @@ impl YOLOModel {
                 #[cfg(feature = "coreml")]
                 crate::Device::CoreMl | crate::Device::Mps => {
                     // Map both CoreML and MPS to CoreMLExecutionProvider
-                    eps.push(ort::execution_providers::CoreMLExecutionProvider::default().build());
+                    eps.push(Self::build_coreml_ep(path));
                     provider_name = "CoreMLExecutionProvider";
                 }
                 #[cfg(feature = "tensorrt")]
@@ -224,7 +224,7 @@ impl YOLOModel {
 
             #[cfg(feature = "coreml")]
             {
-                eps.push(ort::execution_providers::CoreMLExecutionProvider::default().build());
+                eps.push(Self::build_coreml_ep(path));
                 if provider_name == "CPUExecutionProvider" {
                     provider_name = "CoreMLExecutionProvider";
                 }
@@ -411,6 +411,25 @@ impl YOLOModel {
             .with_device_id(device_id)
             .with_tf32(true)
             .build()
+    }
+
+    #[cfg(feature = "coreml")]
+    fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
+        let mut ep = ort::execution_providers::CoreMLExecutionProvider::default();
+        if let Some(cache_base) = dirs::cache_dir() {
+            let stem = model_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("model");
+            let cache_dir = cache_base
+                .join("ultralytics-inference")
+                .join("coreml")
+                .join(stem);
+            if std::fs::create_dir_all(&cache_dir).is_ok() {
+                ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
+            }
+        }
+        ep.build()
     }
 
     /// Maximum allowed image dimension to prevent OOM during warmup.

--- a/src/model.rs
+++ b/src/model.rs
@@ -417,14 +417,24 @@ impl YOLOModel {
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
         let mut ep = ort::execution_providers::CoreMLExecutionProvider::default();
         if let Some(cache_base) = dirs::cache_dir() {
-            let stem = model_path
+            let canonical = model_path
+                .canonicalize()
+                .unwrap_or_else(|_| model_path.to_path_buf());
+            let stem = canonical
                 .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("model");
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "model".to_owned());
+            let hash = canonical
+                .as_os_str()
+                .as_encoded_bytes()
+                .iter()
+                .fold(14_695_981_039_346_656_037u64, |h, &b| {
+                    h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
+                });
             let cache_dir = cache_base
                 .join("ultralytics-inference")
                 .join("coreml")
-                .join(stem);
+                .join(format!("{stem}_{hash:016x}"));
             if std::fs::create_dir_all(&cache_dir).is_ok() {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }


### PR DESCRIPTION
This improves cache handling for faster cold and warm start

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves CoreML model loading by adding a persistent cache directory for compiled CoreML artifacts, helping Apple-device inference start faster and more reliably.

### 📊 Key Changes
- Replaced direct `CoreMLExecutionProvider::default().build()` calls with a new helper: `build_coreml_ep(path)`.
- Added a dedicated `build_coreml_ep()` function for the CoreML execution provider.
- The new helper:
  - Detects the system cache location using `dirs::cache_dir()`
  - Builds a unique cache path based on the model file name and path
  - Creates a per-model cache folder under `ultralytics-inference/coreml`
  - Passes that cache directory into the CoreML execution provider with `with_model_cache_dir(...)`
- Applied this new caching behavior in both places where CoreML is selected, including when using `CoreMl` or `Mps` devices on Apple hardware 🍎

### 🎯 Purpose & Impact
- Speeds up repeated model initialization on CoreML by reusing cached compiled model data ⚡
- Improves the experience on Apple devices, especially for users running inference multiple times with the same model
- Keeps cache entries organized per model, reducing conflicts between different model files
- Makes CoreML and MPS-backed execution more practical for production and local development workflows
- Has minimal impact on non-CoreML users, since the change is gated behind the `coreml` feature ✅