### PR TITLE
Bump taiki-e/install-action from v2.77.0 to v2.77.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f # v2.77.0
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.0 to v2.77.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` from v2.77.0 to v2.77.1.

### 📊 Key Changes
- Updated the `taiki-e/install-action` dependency in `.github/workflows/ci.yml`
- Changed the pinned GitHub Action commit from an older release to the newer `v2.77.1`
- The update affects the CI step that installs `cargo-llvm-cov` for Rust code coverage reporting 🦀

### 🎯 Purpose & Impact
- Improves CI reliability by keeping the install action up to date ✅
- May include minor fixes or compatibility improvements from the newer action release
- Low-risk change with no direct effect on product features or user-facing behavior
- Helps maintain a secure, stable, and current automation setup for developers 🚀