### PR TITLE
chore: remove unnecessary Clippy lints from multiple files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-#![allow(clippy::multiple_crate_versions)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # Ultralytics YOLO Inference Library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![allow(clippy::multiple_crate_versions)]
 
 //! # Ultralytics YOLO Inference Library
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-#![allow(clippy::multiple_crate_versions)]
-
 //! Ultralytics YOLO Inference CLI
 //!
 //! A command-line interface for running YOLO model inference on images and videos.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@
 //! ultralytics-inference help
 //! ```
 
+#![allow(clippy::multiple_crate_versions)]
+
 use clap::Parser;
 
 use ultralytics_inference::cli::args::{Cli, Commands};

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -9,8 +9,6 @@
     unsafe_code,
     clippy::doc_markdown,
     clippy::too_many_lines,
-    clippy::if_not_else,
-    clippy::ptr_as_ptr,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -380,49 +380,7 @@ fn extract_detect_boxes(
     let mut candidates: Vec<Candidate> = Vec::with_capacity(256);
 
     // Candidate Extraction
-    if !is_transposed {
-        // Layout [feat, pred] - Cache-friendly linear scan
-        let mut max_scores = vec![conf_thresh; num_predictions];
-        let mut max_classes = vec![0usize; num_predictions];
-
-        for c in 0..num_classes {
-            let offset = (4 + c) * num_predictions;
-            let class_scores = &output[offset..offset + num_predictions];
-            for (idx, &score) in class_scores.iter().enumerate() {
-                if score > max_scores[idx] {
-                    max_scores[idx] = score;
-                    max_classes[idx] = c;
-                }
-            }
-        }
-
-        for (idx, &score) in max_scores.iter().enumerate() {
-            if score > conf_thresh {
-                let best_class = max_classes[idx];
-
-                // Filter by class if specified
-                if !config.keep_class(best_class) {
-                    continue;
-                }
-
-                let cx = unsafe { *output.get_unchecked(idx) };
-                let cy = unsafe { *output.get_unchecked(num_predictions + idx) };
-                let w = unsafe { *output.get_unchecked(2 * num_predictions + idx) };
-                let h = unsafe { *output.get_unchecked(3 * num_predictions + idx) };
-
-                let x1 = (cx - w * 0.5 - pad_left) / scale_x;
-                let y1 = (cy - h * 0.5 - pad_top) / scale_y;
-                let x2 = (cx + w * 0.5 - pad_left) / scale_x;
-                let y2 = (cy + h * 0.5 - pad_top) / scale_y;
-
-                candidates.push(Candidate {
-                    bbox: [x1, y1, x2, y2],
-                    score,
-                    class: best_class,
-                });
-            }
-        }
-    } else {
+    if is_transposed {
         // Layout [pred, feat] - Process 8 classes at once
         for idx in 0..num_predictions {
             let base = idx * feat_count;
@@ -433,7 +391,7 @@ fn extract_detect_boxes(
             for c_idx in (0..num_classes).step_by(8) {
                 if num_classes - c_idx >= 8 {
                     let scores: f32x8 =
-                        unsafe { (row_ptr.add(c_idx) as *const f32x8).read_unaligned() };
+                        unsafe { row_ptr.add(c_idx).cast::<f32x8>().read_unaligned() };
                     if scores.simd_gt(conf_v).any() {
                         for i in 0..8 {
                             let s = unsafe { *row_ptr.add(c_idx + i) };
@@ -473,6 +431,47 @@ fn extract_detect_boxes(
                 candidates.push(Candidate {
                     bbox: [x1, y1, x2, y2],
                     score: best_score,
+                    class: best_class,
+                });
+            }
+        }
+    } else {
+        // Layout [feat, pred] - Cache-friendly linear scan
+        let mut max_scores = vec![conf_thresh; num_predictions];
+        let mut max_classes = vec![0usize; num_predictions];
+
+        for c in 0..num_classes {
+            let offset = (4 + c) * num_predictions;
+            let class_scores = &output[offset..offset + num_predictions];
+            for (idx, &score) in class_scores.iter().enumerate() {
+                if score > max_scores[idx] {
+                    max_scores[idx] = score;
+                    max_classes[idx] = c;
+                }
+            }
+        }
+
+        for (idx, &score) in max_scores.iter().enumerate() {
+            if score > conf_thresh {
+                let best_class = max_classes[idx];
+
+                if !config.keep_class(best_class) {
+                    continue;
+                }
+
+                let cx = unsafe { *output.get_unchecked(idx) };
+                let cy = unsafe { *output.get_unchecked(num_predictions + idx) };
+                let w = unsafe { *output.get_unchecked(2 * num_predictions + idx) };
+                let h = unsafe { *output.get_unchecked(3 * num_predictions + idx) };
+
+                let x1 = (cx - w * 0.5 - pad_left) / scale_x;
+                let y1 = (cy - h * 0.5 - pad_top) / scale_y;
+                let x2 = (cx + w * 0.5 - pad_left) / scale_x;
+                let y2 = (cy + h * 0.5 - pad_top) / scale_y;
+
+                candidates.push(Candidate {
+                    bbox: [x1, y1, x2, y2],
+                    score,
                     class: best_class,
                 });
             }
@@ -530,11 +529,11 @@ fn extract_detect_boxes(
         while j < n {
             if n - j >= 8 {
                 if (0..8).any(|k| candidates[j + k].class == ac && !suppressed[j + k]) {
-                    let bx1 = unsafe { (x1.as_ptr().add(j) as *const f32x8).read_unaligned() };
-                    let by1 = unsafe { (y1.as_ptr().add(j) as *const f32x8).read_unaligned() };
-                    let bx2 = unsafe { (x2.as_ptr().add(j) as *const f32x8).read_unaligned() };
-                    let by2 = unsafe { (y2.as_ptr().add(j) as *const f32x8).read_unaligned() };
-                    let ba = unsafe { (areas.as_ptr().add(j) as *const f32x8).read_unaligned() };
+                    let bx1 = unsafe { x1.as_ptr().add(j).cast::<f32x8>().read_unaligned() };
+                    let by1 = unsafe { y1.as_ptr().add(j).cast::<f32x8>().read_unaligned() };
+                    let bx2 = unsafe { x2.as_ptr().add(j).cast::<f32x8>().read_unaligned() };
+                    let by2 = unsafe { y2.as_ptr().add(j).cast::<f32x8>().read_unaligned() };
+                    let ba = unsafe { areas.as_ptr().add(j).cast::<f32x8>().read_unaligned() };
 
                     let ix1 = ax1.max(bx1);
                     let iy1 = ay1.max(by1);

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -13,7 +13,7 @@
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::too_many_arguments,
-    clippy::too_many_lines,
+    clippy::too_many_lines
 )]
 
 use std::cell::RefCell;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -14,12 +14,6 @@
     clippy::cast_possible_truncation,
     clippy::too_many_arguments,
     clippy::too_many_lines,
-    clippy::wildcard_imports,
-    clippy::ptr_as_ptr,
-    clippy::cast_lossless,
-    clippy::single_match_else,
-    clippy::suboptimal_flops,
-    clippy::manual_div_ceil
 )]
 
 use std::cell::RefCell;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -139,9 +139,9 @@ pub fn preprocess_image_with_precision(
         calculate_letterbox_params(orig_width, orig_height, target_size, stride);
 
     // Zero-copy path: avoid to_rgb8() allocation when possible
-    let tensor = match image {
+    let tensor = if let DynamicImage::ImageRgb8(rgb) = image {
         // Fast path: already RGB8, use bytes directly without copy
-        DynamicImage::ImageRgb8(rgb) => fused_zerocopy_preprocess(
+        fused_zerocopy_preprocess(
             rgb.as_raw(),
             orig_width,
             orig_height,
@@ -150,21 +150,20 @@ pub fn preprocess_image_with_precision(
             pad_left,
             new_width,
             new_height,
-        ),
+        )
+    } else {
         // Fallback: convert to RGB8 (allocates)
-        _ => {
-            let src_rgb = image.to_rgb8();
-            fused_zerocopy_preprocess(
-                src_rgb.as_raw(),
-                orig_width,
-                orig_height,
-                target_size,
-                pad_top,
-                pad_left,
-                new_width,
-                new_height,
-            )
-        }
+        let src_rgb = image.to_rgb8();
+        fused_zerocopy_preprocess(
+            src_rgb.as_raw(),
+            orig_width,
+            orig_height,
+            target_size,
+            pad_top,
+            pad_left,
+            new_width,
+            new_height,
+        )
     };
 
     let tensor_f16 = if half {
@@ -209,12 +208,12 @@ fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Vec<XLutEntry> {
 
         let lut: Vec<XLutEntry> = (0..dst_w)
             .map(|dx| {
-                let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
+                let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0);
                 let x0 = sx.floor() as i32;
                 // Match OpenCV: cbuf[0] = saturate_cast<short>((1-fx)*SCALE),
                 //               cbuf[1] = SCALE - cbuf[0]
                 let fx_f = sx - x0 as f32;
-                let fx_inv = ((1.0 - fx_f) * SCALE_INT as f32 + 0.5) as i32;
+                let fx_inv = (1.0 - fx_f).mul_add(SCALE_INT as f32, 0.5) as i32;
                 let fx = SCALE_INT - fx_inv;
                 let x0c = x0.clamp(0, src_w_max) as usize * 3;
                 let x1c = (x0 + 1).clamp(0, src_w_max) as usize * 3;
@@ -241,7 +240,7 @@ fn fused_zerocopy_preprocess(
     new_width: u32,
     new_height: u32,
 ) -> Array4<f32> {
-    use rayon::prelude::*;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
     use std::mem::MaybeUninit;
     use std::sync::atomic::{AtomicPtr, Ordering};
 
@@ -251,7 +250,7 @@ fn fused_zerocopy_preprocess(
 
     // ALLOCATE UNINITIALIZED: Saves ~0.2ms by not zeroing memory
     let mut tensor: Array4<MaybeUninit<f32>> = Array4::uninit((1, 3, dst_h, dst_w));
-    let out_ptr = tensor.as_mut_ptr() as *mut f32;
+    let out_ptr = tensor.as_mut_ptr().cast::<f32>();
 
     // Use AtomicPtr for thread-safe pointer sharing (each thread writes to disjoint rows)
     let atomic_ptr = AtomicPtr::new(out_ptr);
@@ -288,10 +287,10 @@ fn fused_zerocopy_preprocess(
             // Image row calculations - 11-bit fixed-point bilinear matching
             // OpenCV's INTER_LINEAR (INTER_RESIZE_COEF_BITS = 11).
             let img_dy = dy - pad_top_usize;
-            let sy = ((img_dy as f32 + 0.5) * scale_y - 0.5).max(0.0);
+            let sy = (img_dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0);
             let y0 = sy.floor() as i32;
             let fy_f = sy - y0 as f32;
-            let fy_inv = ((1.0 - fy_f) * SCALE_INT as f32 + 0.5) as i32;
+            let fy_inv = (1.0 - fy_f).mul_add(SCALE_INT as f32, 0.5) as i32;
             let fy = SCALE_INT - fy_inv;
 
             let y0c = y0.clamp(0, src_h_max) as usize;
@@ -327,24 +326,24 @@ fn fused_zerocopy_preprocess(
                 let p11 = src_ptr.add(row1_off + x1_off);
 
                 let out_x = pad_left_usize + img_dx;
-                *r_row.add(out_x) = ((*p00 as i32 * w00
-                    + *p10 as i32 * w10
-                    + *p01 as i32 * w01
-                    + *p11 as i32 * w11
+                *r_row.add(out_x) = ((i32::from(*p00) * w00
+                    + i32::from(*p10) * w10
+                    + i32::from(*p01) * w01
+                    + i32::from(*p11) * w11
                     + ROUND_BIAS)
                     >> SCALE_BITS_2X) as f32
                     * INV_255;
-                *g_row.add(out_x) = ((*p00.add(1) as i32 * w00
-                    + *p10.add(1) as i32 * w10
-                    + *p01.add(1) as i32 * w01
-                    + *p11.add(1) as i32 * w11
+                *g_row.add(out_x) = ((i32::from(*p00.add(1)) * w00
+                    + i32::from(*p10.add(1)) * w10
+                    + i32::from(*p01.add(1)) * w01
+                    + i32::from(*p11.add(1)) * w11
                     + ROUND_BIAS)
                     >> SCALE_BITS_2X) as f32
                     * INV_255;
-                *b_row.add(out_x) = ((*p00.add(2) as i32 * w00
-                    + *p10.add(2) as i32 * w10
-                    + *p01.add(2) as i32 * w01
-                    + *p11.add(2) as i32 * w11
+                *b_row.add(out_x) = ((i32::from(*p00.add(2)) * w00
+                    + i32::from(*p10.add(2)) * w10
+                    + i32::from(*p01.add(2)) * w01
+                    + i32::from(*p11.add(2)) * w11
                     + ROUND_BIAS)
                     >> SCALE_BITS_2X) as f32
                     * INV_255;
@@ -414,8 +413,8 @@ pub fn calculate_rect_size(
 
     // Round up to nearest multiple of stride
     let stride = stride as usize;
-    let rect_h = ((new_h + stride - 1) / stride) * stride;
-    let rect_w = ((new_w + stride - 1) / stride) * stride;
+    let rect_h = new_h.div_ceil(stride) * stride;
+    let rect_w = new_w.div_ceil(stride) * stride;
 
     (rect_h, rect_w)
 }


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR mainly cleans up Rust lint issues and modernizes low-level preprocessing/postprocessing code, improving code quality and maintainability without changing the library’s core inference behavior.

### 📊 Key Changes
- ♻️ Reordered and standardized crate-level Clippy lint attributes in `lib.rs` and `main.rs` for cleaner project organization.
- 🧹 Removed several now-unneeded Clippy allow rules in `preprocessing.rs` and `postprocessing.rs`, signaling the code has been updated to satisfy stricter linting.
- 🔀 Refactored detection box extraction logic in `postprocessing.rs`:
  - Kept both tensor layout paths (`[pred, feat]` and `[feat, pred]`)
  - Reorganized the branch order for clarity
  - Preserved the optimized handling for transposed outputs
- ⚡ Updated SIMD pointer casts in postprocessing from raw `as *const ...` style to safer, more idiomatic `.cast::<...>()` usage.
- 🖼️ Simplified image preprocessing in `preprocessing.rs`:
  - Replaced a `match` with a clearer `if let` fast path for RGB images
  - Kept the zero-copy optimization when the input is already RGB8
- 📐 Replaced several floating-point arithmetic expressions with `mul_add()` for cleaner and potentially more efficient interpolation math.
- 🔢 Replaced manual byte-to-integer casts with `i32::from(...)` for safer, clearer conversions during bilinear resize calculations.
- 📦 Narrowed Rayon imports to only the traits actually used, reducing wildcard-style imports.
- ✅ Replaced manual division-round-up logic with Rust’s built-in `div_ceil()` in rectangle size calculation.

### 🎯 Purpose & Impact
- ✅ Improves **code readability and maintainability**, making the inference codebase easier to understand and safer to evolve.
- 🛡️ Reduces reliance on older pointer-casting and conversion patterns, which can help avoid subtle low-level bugs.
- 🚀 Preserves existing **performance-oriented optimizations** like zero-copy preprocessing and SIMD-accelerated postprocessing.
- 🧪 Makes the project more compliant with **strict Clippy linting**, which helps catch issues earlier in development.
- 👥 For users, the practical impact is likely **more stable and maintainable inference internals** rather than visible feature changes or new functionality.