### PR TITLE
refactor: ♻️ simplify file stem extraction in YOLOModel

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -422,8 +422,7 @@ impl YOLOModel {
                 .unwrap_or_else(|_| model_path.to_path_buf());
             let stem = canonical
                 .file_stem()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "model".to_owned());
+                .map_or_else(|| "model".to_owned(), |s| s.to_string_lossy().into_owned());
             let hash = canonical
                 .as_os_str()
                 .as_encoded_bytes()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes a small cleanup in `src/model.rs` by simplifying how the model filename stem is derived, without changing behavior.

### 📊 Key Changes
- Refactors the logic used to get a model file’s stem name from its path.
- Replaces a `map(...).unwrap_or_else(...)` pattern with the more compact `map_or_else(...)`.
- Keeps the same fallback behavior: if no valid file stem is found, it still defaults to `"model"`.

### 🎯 Purpose & Impact
- Improves code readability and maintainability ✨ by using a cleaner Rust idiom.
- Reduces minor code verbosity, making this section easier for developers to understand and maintain.
- Has little to no user-facing impact 🚦, since functionality remains the same.
- Helps keep the codebase more consistent and polished for future development.