### PR TITLE
refactor: ♻️ streamline error handling and return types in prediction and metadata parsing

### DIFF
--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -322,11 +322,10 @@ pub fn run_prediction(args: &PredictArgs) {
                         if save_dir.is_some() {
                             let annotated = annotate_image(img, &result, None);
 
-                            #[allow(clippy::collapsible_if)]
-                            if let Some(saver) = &mut result_saver {
-                                if let Err(e) = saver.save(is_video, meta, &annotated) {
-                                    error!("Failed to save result: {e}");
-                                }
+                            if let Some(saver) = &mut result_saver
+                                && let Err(e) = saver.save(is_video, meta, &annotated)
+                            {
+                                error!("Failed to save result: {e}");
                             }
                         }
 
@@ -385,11 +384,10 @@ pub fn run_prediction(args: &PredictArgs) {
         batch_processor.flush();
     }
 
-    #[allow(clippy::collapsible_if)]
-    if let Some(saver) = result_saver {
-        if let Err(e) = saver.finish() {
-            error!("Failed to finish saving: {e}");
-        }
+    if let Some(saver) = result_saver
+        && let Err(e) = saver.finish()
+    {
+        error!("Failed to finish saving: {e}");
     }
 
     // Print speed summary with inference tensor shape (after letterboxing)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,7 @@ use ultralytics_inference::cli::predict::run_prediction;
 use ultralytics_inference::logging::set_verbose;
 
 /// Entry point for the Ultralytics YOLO Inference CLI.
-#[allow(clippy::unnecessary_wraps)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     ultralytics_inference::io::init_logging();
 
     #[cfg(debug_assertions)]
@@ -47,5 +46,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
     }
-    Ok(())
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -168,12 +168,12 @@ impl ModelMetadata {
 
         // Parse imgsz which can be a list like [640, 640]
         if let Some(imgsz_line) = yaml_str.lines().find(|l| l.contains("imgsz:")) {
-            metadata.imgsz = Self::parse_imgsz(yaml_str, imgsz_line)?;
+            metadata.imgsz = Self::parse_imgsz(yaml_str, imgsz_line);
         }
 
         // Parse names block if not already parsed inline
         if metadata.names.is_empty() {
-            metadata.names = Self::parse_names_block(yaml_str)?;
+            metadata.names = Self::parse_names_block(yaml_str);
         }
 
         Ok(metadata)
@@ -196,8 +196,7 @@ impl ModelMetadata {
     }
 
     /// Parse the imgsz field which can be a YAML list.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_imgsz(yaml_str: &str, imgsz_line: &str) -> Result<Option<(usize, usize)>> {
+    fn parse_imgsz(yaml_str: &str, imgsz_line: &str) -> Option<(usize, usize)> {
         // Check if imgsz is on a single line like "imgsz: [640, 640]"
         if let Some(bracket_start) = imgsz_line.find('[')
             && let Some(bracket_end) = imgsz_line.find(']')
@@ -207,7 +206,7 @@ impl ModelMetadata {
                 .filter_map(|s| s.trim().parse().ok())
                 .collect();
             if values.len() >= 2 {
-                return Ok(Some((values[0], values[1])));
+                return Some((values[0], values[1]));
             }
         }
 
@@ -236,14 +235,14 @@ impl ModelMetadata {
         }
 
         if imgsz_values.len() >= 2 {
-            Ok(Some((imgsz_values[0], imgsz_values[1])))
+            Some((imgsz_values[0], imgsz_values[1]))
         } else {
-            Ok(None)
+            None
         }
     }
 
     /// Parse the names block from YAML or Python dict format.
-    fn parse_names_block(yaml_str: &str) -> Result<HashMap<usize, String>> {
+    fn parse_names_block(yaml_str: &str) -> HashMap<usize, String> {
         let mut names = HashMap::new();
 
         // First, try to find `names: {0: 'person', 1: 'bicycle', ...}` Python dict format
@@ -299,12 +298,11 @@ impl ModelMetadata {
             }
         }
 
-        Ok(names)
+        names
     }
 
     /// Parse a Python dict string like `0: 'person', 1: 'bicycle'`.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_python_dict(dict_str: &str) -> Result<HashMap<usize, String>> {
+    fn parse_python_dict(dict_str: &str) -> HashMap<usize, String> {
         let mut names = HashMap::new();
 
         // Split by comma, but be careful with quotes
@@ -319,7 +317,7 @@ impl ModelMetadata {
             }
         }
 
-        Ok(names)
+        names
     }
 
     /// Get the number of classes in this model.


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR is a small code-cleanup update that simplifies error handling and metadata parsing in the Ultralytics inference CLI without changing core user-facing functionality.

### 📊 Key Changes
- ♻️ Simplified nested `if` statements in `src/cli/predict.rs` using Rust’s combined conditional pattern syntax.
- 🛠️ Kept existing save/finalization error logging intact while making the prediction result-saving code shorter and easier to read.
- 🚪 Updated `src/main.rs` so `main()` no longer returns a `Result`, removing unnecessary wrapping since errors were not being propagated.
- 📄 Simplified metadata parsing in `src/metadata.rs`:
  - `parse_imgsz()` now returns `Option<(usize, usize)>` directly instead of `Result<Option<...>>`
  - `parse_names_block()` now returns a `HashMap` directly
  - `parse_python_dict()` now returns a `HashMap` directly
- ✂️ Removed several `clippy` allow attributes by restructuring code to avoid those lint warnings naturally.

### 🎯 Purpose & Impact
- ✅ Improves code clarity and maintainability, making the inference CLI easier for developers to understand and extend.
- 🔍 Reduces unnecessary `Result` wrappers where parsing logic does not actually produce recoverable errors, leading to cleaner internal APIs.
- 🧪 Helps keep the codebase more idiomatic and lint-friendly by eliminating avoidable Clippy warnings.
- 👥 For end users, impact should be minimal in behavior, but this cleanup can make future fixes and enhancements easier and safer to implement.