### PR TITLE
`ultralytics-inference 0.0.13` fix: resolve CoreML FP16 crash and warmup GatherElements error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,7 +2692,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "ab_glyph",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88"
 authors = [

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics 0.0.12 🚀 Rust ONNX FP32 CPU
+Ultralytics 0.0.13 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -152,7 +152,7 @@ Results saved to runs/detect/predict1
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics 0.0.12 🚀 Rust ONNX FP32 CPU
+Ultralytics 0.0.13 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -241,7 +241,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.12"
+ultralytics-inference = "0.0.13"
 ```
 
 ```toml

--- a/src/model.rs
+++ b/src/model.rs
@@ -414,8 +414,38 @@ impl YOLOModel {
     }
 
     #[cfg(feature = "coreml")]
+    fn macos_version() -> Option<(u32, u32)> {
+        let out = std::process::Command::new("sw_vers")
+            .arg("-productVersion")
+            .output()
+            .ok()?;
+        let s = std::str::from_utf8(&out.stdout).ok()?.trim();
+        let mut parts = s.split('.');
+        let major: u32 = parts.next()?.parse().ok()?;
+        let minor: u32 = parts.next().unwrap_or("0").parse().ok()?;
+        Some((major, minor))
+    }
+
+    #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
-        let mut ep = ort::execution_providers::CoreMLExecutionProvider::default();
+        use ort::execution_providers::coreml::ModelFormat;
+        let format = match Self::macos_version() {
+            Some((major, _)) if major >= 12 => ModelFormat::MLProgram,
+            Some((major, minor)) => {
+                warn!(
+                    "WARNING ⚠️ macOS {major}.{minor} detected — CoreML MLProgram requires \
+                     macOS 12+. Falling back to NeuralNetwork format. \
+                     FP16 ONNX models may fail; export with half=False to be safe."
+                );
+                ModelFormat::NeuralNetwork
+            }
+            None => {
+                ModelFormat::MLProgram
+            }
+        };
+        let mut ep =
+            ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);
+
         if let Some(cache_base) = dirs::cache_dir() {
             let canonical = model_path
                 .canonicalize()
@@ -430,10 +460,14 @@ impl YOLOModel {
                 .fold(14_695_981_039_346_656_037u64, |h, &b| {
                     h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
                 });
+            let format_suffix = match format {
+                ModelFormat::MLProgram => "mlprogram",
+                ModelFormat::NeuralNetwork => "neuralnet",
+            };
             let cache_dir = cache_base
                 .join("ultralytics-inference")
                 .join("coreml")
-                .join(format!("{stem}_{hash:016x}"));
+                .join(format!("{stem}_{hash:016x}_{format_suffix}"));
             if std::fs::create_dir_all(&cache_dir).is_ok() {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }
@@ -470,14 +504,24 @@ impl YOLOModel {
             )));
         }
 
-        if self.fp16_input {
+        let warmup_result = if self.fp16_input {
             // Use FP16 dummy input if model expects FP16
             let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
-            self.run_inference_f16(&dummy_input)?;
+            self.run_inference_f16(&dummy_input)
         } else {
             let dummy_input = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
-            self.run_inference(&dummy_input)?;
+            self.run_inference(&dummy_input)
+        };
+
+        if let Err(e) = warmup_result {
+            let msg = e.to_string();
+            // GatherElements out-of-range from an all-zeros dummy tensor is benign;
+            // real images produce valid indices. Any other error is a real failure.
+            if !msg.contains("GatherElements") || !msg.contains("Out of range") {
+                return Err(e);
+            }
         }
+
         self.warmed_up = true;
         Ok(())
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -420,10 +420,11 @@ impl YOLOModel {
             .output()
             .ok()?;
         let s = std::str::from_utf8(&out.stdout).ok()?.trim();
-        let mut parts = s.split('.');
-        let major: u32 = parts.next()?.parse().ok()?;
-        let minor: u32 = parts.next().unwrap_or("0").parse().ok()?;
-        Some((major, minor))
+        let mut p = s.split('.');
+        Some((
+            p.next()?.parse().ok()?,
+            p.next().unwrap_or("0").parse().ok()?,
+        ))
     }
 
     #[cfg(feature = "coreml")]
@@ -431,15 +432,13 @@ impl YOLOModel {
         use ort::execution_providers::coreml::ModelFormat;
         let format = match Self::macos_version() {
             Some((major, _)) if major >= 12 => ModelFormat::MLProgram,
-            Some((major, minor)) => {
-                warn!(
-                    "WARNING ⚠️ macOS {major}.{minor} < 12: CoreML using NeuralNetwork format; FP16 models may fail."
+            ver => {
+                let label = ver.map_or_else(
+                    || "unknown".to_owned(),
+                    |(maj, min)| format!("{maj}.{min} < 12"),
                 );
-                ModelFormat::NeuralNetwork
-            }
-            None => {
                 warn!(
-                    "WARNING ⚠️ macOS version unknown: CoreML using NeuralNetwork format; FP16 models may fail."
+                    "WARNING ⚠️ macOS {label}: CoreML using NeuralNetwork format; FP16 models may fail."
                 );
                 ModelFormat::NeuralNetwork
             }
@@ -461,9 +460,10 @@ impl YOLOModel {
                 .fold(14_695_981_039_346_656_037u64, |h, &b| {
                     h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
                 });
-            let format_suffix = match format {
-                ModelFormat::MLProgram => "mlprogram",
-                ModelFormat::NeuralNetwork => "neuralnet",
+            let format_suffix = if matches!(format, ModelFormat::MLProgram) {
+                "mlprogram"
+            } else {
+                "neuralnet"
             };
             let cache_dir = cache_base
                 .join("ultralytics-inference")
@@ -515,11 +515,11 @@ impl YOLOModel {
 
         if let Err(e) = warmup_result {
             let msg = e.to_string();
-            // CoreML + all-zeros input triggers GatherElements out-of-range in the DFL head;
-            // benign for warmup only. Propagate everything else unchanged.
-            let is_coreml = self.execution_provider == "CoreMLExecutionProvider";
-            let is_gather_oob = msg.contains("GatherElements") && msg.contains("Out of range");
-            if !is_coreml || !is_gather_oob {
+            // CoreML + all-zeros input: GatherElements out-of-range in the DFL head is benign.
+            if self.execution_provider != "CoreMLExecutionProvider"
+                || !msg.contains("GatherElements")
+                || !msg.contains("Out of range")
+            {
                 return Err(e);
             }
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -433,13 +433,16 @@ impl YOLOModel {
             Some((major, _)) if major >= 12 => ModelFormat::MLProgram,
             Some((major, minor)) => {
                 warn!(
-                    "WARNING ⚠️ macOS {major}.{minor} detected — CoreML MLProgram requires \
-                     macOS 12+. Falling back to NeuralNetwork format. \
-                     FP16 ONNX models may fail; export with half=False to be safe."
+                    "WARNING ⚠️ macOS {major}.{minor} < 12: CoreML using NeuralNetwork format; FP16 models may fail."
                 );
                 ModelFormat::NeuralNetwork
             }
-            None => ModelFormat::MLProgram,
+            None => {
+                warn!(
+                    "WARNING ⚠️ macOS version unknown: CoreML using NeuralNetwork format; FP16 models may fail."
+                );
+                ModelFormat::NeuralNetwork
+            }
         };
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);
@@ -503,7 +506,6 @@ impl YOLOModel {
         }
 
         let warmup_result = if self.fp16_input {
-            // Use FP16 dummy input if model expects FP16
             let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
             self.run_inference_f16(&dummy_input)
         } else {
@@ -513,9 +515,11 @@ impl YOLOModel {
 
         if let Err(e) = warmup_result {
             let msg = e.to_string();
-            // GatherElements out-of-range from an all-zeros dummy tensor is benign;
-            // real images produce valid indices. Any other error is a real failure.
-            if !msg.contains("GatherElements") || !msg.contains("Out of range") {
+            // CoreML + all-zeros input triggers GatherElements out-of-range in the DFL head;
+            // benign for warmup only. Propagate everything else unchanged.
+            let is_coreml = self.execution_provider == "CoreMLExecutionProvider";
+            let is_gather_oob = msg.contains("GatherElements") && msg.contains("Out of range");
+            if !is_coreml || !is_gather_oob {
                 return Err(e);
             }
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -439,9 +439,7 @@ impl YOLOModel {
                 );
                 ModelFormat::NeuralNetwork
             }
-            None => {
-                ModelFormat::MLProgram
-            }
+            None => ModelFormat::MLProgram,
         };
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);


### PR DESCRIPTION
Issue Fix #148 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps `ultralytics-inference` to `0.0.13` 🚀 and improves CoreML compatibility on macOS by selecting safer model formats, isolating cache files, and making warmup more robust.

### 📊 Key Changes
- Updated the package version from `0.0.12` to `0.0.13` in `Cargo.toml` and `README.md` 🆕
- Added macOS version detection for CoreML execution provider setup on Apple devices 🍎
- CoreML now chooses model format based on macOS version:
  - Uses `MLProgram` on macOS 12+
  - Falls back to `NeuralNetwork` on older or unknown macOS versions
- Added a warning when older macOS versions may have issues with FP16 CoreML models ⚠️
- Improved CoreML cache directory naming by including the selected model format, helping avoid cache collisions and confusion 🗂️
- Made model warmup more fault-tolerant:
  - Warmup now captures inference errors instead of failing immediately
  - Ignores a known benign CoreML `GatherElements` out-of-range error during all-zero dummy input warmup
  - Still surfaces all other real errors normally ✅

### 🎯 Purpose & Impact
- Improves reliability of CoreML inference across different macOS versions, especially on older systems 💻
- Reduces the chance of startup failures caused by format mismatches or harmless warmup-time CoreML errors 🔧
- Makes caching safer and more predictable when switching between CoreML model formats 📦
- Gives users clearer warnings about potential FP16 limitations on older macOS setups, making troubleshooting easier 👀
- Overall, this release should provide a smoother Apple/CoreML experience with fewer false failures while preserving normal error reporting 🚀
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
