### PR TITLE
Bump taiki-e/install-action from v2.77.1 to v2.77.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.1 to v2.77.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` from v2.77.1 to v2.77.2.

### 📊 Key Changes
- Updated the CI workflow file at `.github/workflows/ci.yml`.
- Changed the pinned version of `taiki-e/install-action` used for installing `cargo-llvm-cov`.
- Moved from action release `v2.77.1` to `v2.77.2` for the Rust coverage tooling setup.

### 🎯 Purpose & Impact
- Improves CI reliability by keeping dependency setup actions slightly more up to date ✅
- Helps ensure Rust coverage tooling installs consistently in automated workflows 🛠️
- Low user-facing impact: this is an internal infrastructure change, with no direct effect on inference features or API behavior 📦
- Reduces maintenance risk by tracking the latest patch-level fixes in the GitHub Action 🔒