### PR TITLE
Bump taiki-e/install-action from v2.77.2 to v2.77.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2.77.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.2 to v2.77.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` from v2.77.2 to v2.77.3.

### 📊 Key Changes
- Updated the CI workflow in `.github/workflows/ci.yml`
- Changed the pinned `taiki-e/install-action` commit used for installing `cargo-llvm-cov`
- Version comment updated from `v2.77.2` to `v2.77.3`

### 🎯 Purpose & Impact
- Improves CI reliability by keeping a dependency installer action up to date 🛠️
- May include minor fixes or compatibility improvements from the newer action version
- Low-risk change: it does not affect inference code or user-facing features directly ✅
- Helps maintain a healthier and more secure development pipeline over time 🔒