### PR TITLE
fix: 🐞 derive num_masks from proto tensor shape

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -708,12 +708,11 @@ fn postprocess_segment(
     let (output0, shape0) = &outputs[0];
     let (output1, shape1) = &outputs[1];
 
-    // output0: [1, 4 + nc + 32, 8400]
-    // output1: [1, 32, 160, 160] (protos)
+    // output0: [1, 4 + nc + nm, 8400]
+    // output1: [1, nm, 160, 160] (protos)
 
-    // 1. Process Detections
-    // Standard segmentation models use 32 mask prototypes
-    let num_masks = 32;
+    // Derive nm from the protos tensor so non-default prototype counts work correctly.
+    let num_masks = if shape1.len() >= 2 { shape1[1] } else { 32 };
     let expected_features = 4 + names.len() + num_masks;
 
     // Manual shape check
@@ -799,7 +798,6 @@ fn postprocess_segment(
     let keep_indices = nms_per_class(&nms_candidates, config.iou_threshold);
     let num_kept = keep_indices.len().min(config.max_det);
 
-    // 2. Extract Box Results
     let mut boxes_data = Array2::zeros((num_kept, 6));
     let mut mask_coeffs = Array2::zeros((num_kept, num_masks));
 
@@ -822,7 +820,6 @@ fn postprocess_segment(
 
     results.boxes = Some(Boxes::new(boxes_data.clone(), preprocess.orig_shape));
 
-    // 3. Process Masks
     // Protos: [1, 32, 160, 160] -> [32, 25600]
     // Validate protos shape before indexing to prevent panic
     if shape1.len() < 4 {

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -712,7 +712,7 @@ fn postprocess_segment(
     // output1: [1, nm, 160, 160] (protos)
 
     // Derive nm from the protos tensor so non-default prototype counts work correctly.
-    let num_masks = if shape1.len() >= 2 { shape1[1] } else { 32 };
+    let num_masks = if shape1.len() == 4 { shape1[1] } else { 32 };
     let expected_features = 4 + names.len() + num_masks;
 
     // Manual shape check


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes segmentation postprocessing more flexible by automatically detecting the number of mask prototypes instead of assuming a fixed value of 32.

### 📊 Key Changes
- Updated segmentation postprocessing in `src/postprocessing.rs` to derive the mask prototype count (`nm`) directly from the model’s proto output tensor shape.
- Replaced the hardcoded assumption of `32` mask prototypes with dynamic logic:
  - If the proto tensor has the expected 4D shape, it uses `shape1[1]`
  - Otherwise, it falls back to `32`
- Adjusted expected feature validation to match the detected number of mask coefficients.
- Updated inline comments to reflect the more general output format for segmentation models.
- Minor cleanup by removing outdated step-number comments, improving readability without changing behavior.

### 🎯 Purpose & Impact
- ✅ Improves compatibility with segmentation models that use non-default mask prototype counts.
- 🔒 Reduces the risk of incorrect parsing when running newer or customized model variants.
- 🚀 Makes the inference pipeline more robust and future-friendly, especially for users deploying diverse segmentation models.
- 👥 Benefits both developers and end users by allowing broader model support with no extra configuration in most cases.