### PR TITLE
perf: reduce NMS comparisons by half in per-class and rotated NMS

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -131,7 +131,7 @@ pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Ve
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
 
-    for &i in &indices {
+    for (pos, &i) in indices.iter().enumerate() {
         if suppressed[i] {
             continue;
         }
@@ -139,14 +139,11 @@ pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Ve
 
         let class_i = boxes[i].2;
 
-        for &j in &indices {
-            if !suppressed[j] && i != j {
-                // Only suppress boxes of the same class
-                if boxes[j].2 == class_i {
-                    let iou = calculate_iou(&boxes[i].0, &boxes[j].0);
-                    if iou > iou_threshold {
-                        suppressed[j] = true;
-                    }
+        for &j in &indices[pos + 1..] {
+            if !suppressed[j] && boxes[j].2 == class_i {
+                let iou = calculate_iou(&boxes[i].0, &boxes[j].0);
+                if iou > iou_threshold {
+                    suppressed[j] = true;
                 }
             }
         }
@@ -181,7 +178,7 @@ pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f3
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
 
-    for &i in &indices {
+    for (pos, &i) in indices.iter().enumerate() {
         if suppressed[i] {
             continue;
         }
@@ -189,8 +186,8 @@ pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f3
 
         let class_i = boxes[i].2;
 
-        for &j in &indices {
-            if !suppressed[j] && i != j && boxes[j].2 == class_i {
+        for &j in &indices[pos + 1..] {
+            if !suppressed[j] && boxes[j].2 == class_i {
                 let iou = calculate_probiou(&boxes[i].0, &boxes[j].0);
                 if iou > iou_threshold {
                     suppressed[j] = true;


### PR DESCRIPTION
Both nms_per_class and nms_rotated_per_class were iterating all sorted indices in the inner loop, by enumerating the outer loop and slicing indices[pos+1..] for the inner, each pair is compared exactly once cutting IoU calculations by ~50% for large candidate sets.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR optimizes per-class NMS logic in `ultralytics/inference` by avoiding redundant box comparisons while keeping detection results unchanged.

### 📊 Key Changes
- 🔁 Updated `nms_per_class()` to compare each detection only with later entries in the sorted list, instead of rechecking all boxes.
- 📦 Applied the same optimization to `nms_rotated_per_class()` for rotated bounding boxes.
- 🧹 Removed unnecessary self-checks and duplicate pairwise comparisons in both NMS implementations.
- 🎯 Preserved class-aware suppression behavior, so boxes are still only suppressed against others from the same class.

### 🎯 Purpose & Impact
- 🚀 Improves inference efficiency by reducing extra IoU comparisons during non-maximum suppression.
- ⏱️ Can speed up post-processing, especially for images with many detections.
- 🔒 Keeps model output behavior consistent, so users should see the same filtering results with better internal performance.
- 📈 Benefits both standard and rotated object detection workflows, making the inference pipeline leaner overall.