### PR TITLE
Bump taiki-e/install-action from v2.77.5 to v2.77.6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2.77.5
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.5 to v2.77.6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the `taiki-e/install-action` GitHub Action used to install `cargo-llvm-cov` from v2.77.5 to v2.77.6.

### 📊 Key Changes
- Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from commit `fa0dd4c...` to `c070f87...`
- This action is used in CI to install `cargo-llvm-cov` for Rust code coverage tasks 🧪

### 🎯 Purpose & Impact
- Keeps CI dependencies up to date and aligned with the latest patch release 🔄
- May include minor fixes, security improvements, or reliability updates from the action maintainer 🛡️
- No expected changes to product features or user-facing behavior; impact is limited to internal CI stability and maintenance ⚙️