### PR TITLE
feat: 🚀 add 'yolov8' to supported model families and add auto-download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 - 🔧 **Multiple Backends** - CPU, CUDA, TensorRT, CoreML, OpenVINO, and more via ONNX Runtime
 - 📦 **Dual Use** - Library for Rust projects + standalone CLI application
 - 🏷️ **Auto Metadata** - Automatically reads class names, task type, and input size from ONNX models
-- ⬇️ **Auto Download** - Automatically downloads YOLO11 and YOLO26 ONNX models (all sizes: n/s/m/l/x) when not found locally
+- ⬇️ **Auto Download** - Automatically downloads YOLO26, YOLO11, and YOLOv8 ONNX models (all sizes: n/s/m/l/x) when not found locally
 - 🖼️ **Multiple Sources** - Images, directories, glob patterns, video files, webcams, and streams
 - 🪶 **Lean Runtime** - No PyTorch, TensorFlow, or Python runtime required
 
@@ -103,9 +103,10 @@ ultralytics-inference predict --task classify # downloads yolo26n-cls.onnx
 # With explicit model (task is read from model metadata)
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg
 
-# Auto-download any supported size (n/s/m/l/x)
+# Auto-download any supported size (n/s/m/l/x) across YOLO26, YOLO11, and YOLOv8
 ultralytics-inference predict --model yolo26l.onnx --source image.jpg
 ultralytics-inference predict --model yolo11x-seg.onnx --source image.jpg
+ultralytics-inference predict --model yolov8n.onnx --source image.jpg
 
 # On a directory of images
 ultralytics-inference predict --model yolo26n.onnx --source assets/
@@ -184,7 +185,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 | Option          | Short | Description                                                                                              | Default                                 |
 | --------------- | ----- | -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name                                   | `yolo26n.onnx`                          |
+| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                            | `yolo26n.onnx`                          |
 | `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect`                                |
 | `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                       | `Task dependent Ultralytics URL assets` |
 | `--conf`        |       | Confidence threshold                                                                                     | `0.25`                                  |
@@ -216,12 +217,13 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 **Auto-downloadable models:**
 
-All YOLO11 and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download:
+All YOLOv8, YOLO11, and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download:
 
 | Family | Variants                                                                        |
 | ------ | ------------------------------------------------------------------------------- |
 | YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
 | YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
+| YOLOv8 | `yolov8{n,s,m,l,x}.onnx`, `yolov8{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
 
 **Source Options:**
 
@@ -513,7 +515,7 @@ ONNX Runtime threading is set to auto (`num_threads: 0`) which lets ORT choose o
 - [x] Batch inference support
 - [x] Rectangular inference support and optimization
 - [x] Class filtering support
-- [x] Auto-download all YOLO11 and YOLO26 ONNX models (all sizes n/s/m/l/x, all tasks)
+- [x] Auto-download all YOLO26, YOLO11, and YOLOv8 ONNX models (all sizes n/s/m/l/x, all tasks)
 - [x] `--task` CLI flag: selects and auto-downloads the matching nano model when `--model` is omitted; errors on task/model metadata conflict
 
 ### In Progress

--- a/src/download.rs
+++ b/src/download.rs
@@ -303,7 +303,7 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
 /// Attempt to download a model if it matches a known downloadable model.
 ///
-/// Supports all YOLOv8, YOLO11, and YOLO26 ONNX models across sizes (n/s/m/l/x) and
+/// Supports all `YOLO26`, `YOLO11`, and `YOLOv8` ONNX models across sizes (n/s/m/l/x) and
 /// task variants (detect, segment, pose, obb, classify).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///

--- a/src/download.rs
+++ b/src/download.rs
@@ -303,7 +303,7 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
 /// Attempt to download a model if it matches a known downloadable model.
 ///
-/// Supports all YOLO26 and YOLO11 ONNX models across sizes (n/s/m/l/x) and
+/// Supports all YOLOv8, YOLO11, and YOLO26 ONNX models across sizes (n/s/m/l/x) and
 /// task variants (detect, segment, pose, obb, classify).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///

--- a/src/download.rs
+++ b/src/download.rs
@@ -15,7 +15,7 @@ use crate::error::{InferenceError, Result};
 const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/download/v8.4.0";
 
 /// YOLO Model families, sizes, and variants supported for auto-download.
-const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11"];
+const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11", "yolov8"];
 const MODEL_SIZES: &[&str] = &["n", "s", "m", "l", "x"];
 const MODEL_VARIANTS: &[&str] = &["", "-seg", "-pose", "-obb", "-cls"];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! - **High Performance** - Pure Rust with zero-cost abstractions and SIMD-optimized preprocessing
 //! - **ONNX Runtime** - Leverages ONNX Runtime for cross-platform hardware acceleration
-//! - **Supported YOLO Versions** - `YOLO11` and `YOLO26` (including YOLO26 end-to-end NMS-free exports)
+//! - **Supported YOLO Versions** - `YOLO26`, `YOLO11`, and `YOLOv8` (including YOLO26 end-to-end NMS-free exports)
 //! - **All Tasks** - Detection, segmentation, pose estimation, classification, and OBB
 //! - **Ultralytics API** - Results API matches the Python package for easy migration
 //! - **Multiple Backends** - CPU, CUDA, `TensorRT`, `CoreML`, `OpenVINO`, and more
@@ -115,7 +115,7 @@
 //!
 //! | Option | Short | Description | Default |
 //! |--------|-------|-------------|---------|
-//! | `--model` | `-m` | Path to ONNX model file; auto-downloaded if a known YOLO11/YOLO26 name | `yolo26n.onnx` |
+//! | `--model` | `-m` | Path to ONNX model file; auto-downloaded if a known YOLO26/YOLO11/YOLOv8 name | `yolo26n.onnx` |
 //! | `--task` | | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect` |
 //! | `--source` | `-s` | Input source (image, directory, glob, video, webcam index, or URL) | Task-dependent sample assets |
 //! | `--conf` | | Confidence threshold | `0.25` |

--- a/src/task.rs
+++ b/src/task.rs
@@ -66,10 +66,10 @@ impl Task {
         }
     }
 
-    /// Default nano YOLO26 model filename for this task.
+    /// Default nano `YOLO26` model filename for this task.
     ///
     /// Used by the CLI to auto-pick a model when `--model` is omitted but `--task` is set.
-    /// YOLO26, YOLO11, and YOLOv8 variants are all auto-downloadable.
+    /// `YOLO26`, `YOLO11`, and `YOLOv8` variants are all auto-downloadable.
     ///
     /// ```
     /// use ultralytics_inference::Task;

--- a/src/task.rs
+++ b/src/task.rs
@@ -47,7 +47,8 @@ impl Task {
         }
     }
 
-    /// ONNX filename suffix for this task, used to construct `yolo26n{suffix}.onnx`.
+    /// ONNX filename suffix for this task, used to construct `{family}n{suffix}.onnx`
+    /// (e.g. `yolo26n-seg.onnx`, `yolo11n-pose.onnx`, `yolov8n.onnx`).
     ///
     /// ```
     /// use ultralytics_inference::Task;
@@ -68,6 +69,7 @@ impl Task {
     /// Default nano YOLO26 model filename for this task.
     ///
     /// Used by the CLI to auto-pick a model when `--model` is omitted but `--task` is set.
+    /// YOLO26, YOLO11, and YOLOv8 variants are all auto-downloadable.
     ///
     /// ```
     /// use ultralytics_inference::Task;


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds YOLOv8 to the Rust inference library’s built-in auto-download support, alongside existing YOLO26 and YOLO11 models 🚀

### 📊 Key Changes
- Expanded auto-download support in `src/download.rs` to recognize **YOLOv8** model names in addition to **YOLO26** and **YOLO11** 📥
- Updated supported model family list from:
  - `["yolo26", "yolo11"]`
  - to `["yolo26", "yolo11", "yolov8"]`
- Refreshed documentation across:
  - `README.md`
  - `src/lib.rs`
  - `src/task.rs`
  to clearly state that **YOLOv8, YOLO11, and YOLO26** ONNX models are supported 📝
- Added new CLI usage examples showing YOLOv8 auto-download, such as:
  - `ultralytics-inference predict --model yolov8n.onnx --source image.jpg`
- Updated help text and supported-model tables so users can see that all **n/s/m/l/x** sizes and task variants are available for YOLOv8 too ✅
- Clarified task-related filename documentation to reflect support for multiple model families, not just YOLO26 🔧

### 🎯 Purpose & Impact
- Makes the library more flexible by letting users run **YOLOv8 ONNX models** without manually downloading them first 🌍
- Improves the CLI experience by treating YOLOv8 as a first-class supported family, just like YOLO26 and YOLO11 💡
- Reduces setup friction for existing YOLOv8 users migrating to `ultralytics/inference` or testing Rust-based inference workflows ⚡
- Keeps docs and code aligned, which lowers confusion and makes supported model behavior easier to understand 📚
- Broadens compatibility while preserving **YOLO26** as the default recommended model family for new use cases 🎯