### PR TITLE
refactor: 🛠️ remove MPS parameter and update device documentation to reflect CoreML usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                          | `true`                                  |
 | `--save-frames` |       | Save individual frames for video                                                                         | `false`                                 |
 | `--show`        |       | Display results in a window                                                                              | `false`                                 |
-| `--device`      |       | Device (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, xnnpack)                             | `cpu`                                   |
+| `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                  | `cpu`                                   |
 | `--verbose`     |       | Show verbose output                                                                                      | `true`                                  |
 | `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                              | all classes                             |
 
@@ -321,7 +321,7 @@ if let Some(ref boxes) = result.boxes {
 use ultralytics_inference::{Device, InferenceConfig, YOLOModel};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Select a device (e.g., CUDA, MPS, CPU)
+    // Select a device (e.g., CUDA, CoreML, CPU)
     let device = Device::Cuda(0);
 
     // Configure the model to use this device
@@ -350,7 +350,7 @@ inference/
 │   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb)
 │   ├── inference.rs        # InferenceConfig
 │   ├── batch.rs            # Batch processing pipeline
-│   ├── device.rs           # Device enum (CPU, CUDA, MPS, CoreML, etc.)
+│   ├── device.rs           # Device enum (CPU, CUDA, CoreML, etc.)
 │   ├── download.rs         # Model and asset downloading
 │   ├── annotate.rs         # Image annotation (bounding boxes, masks, keypoints)
 │   ├── io.rs               # Result saving (images, videos)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,7 +23,7 @@ use clap::{Args, Parser, Subcommand};
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
     --show                 Display results in a window [default: false]
-    --device <DEVICE>      Device (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, xnnpack)
+    --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)
     --verbose              Show verbose output [default: true]
     --classes <CLASSES>    Filter by class IDs (e.g., "0", "0,1,2", "[0, 1]")
 

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -188,7 +188,7 @@ pub fn run_prediction(args: &PredictArgs) {
     let device_str = {
         let provider = model.execution_provider();
         if provider.contains("CoreML") {
-            "MPS".to_string()
+            "CoreML".to_string()
         } else if provider.contains("CUDA") {
             "CUDA".to_string()
         } else if provider.contains("TensorRT") {

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,7 @@ pub enum Device {
     /// CUDA (Compute Unified Device Architecture) for NVIDIA GPUs.
     /// The argument specifies the device index (e.g., 0 for the first GPU).
     Cuda(usize),
-    /// CoreML execution provider for Apple Silicon / macOS.
+    /// `CoreML` execution provider for Apple Silicon / macOS.
     CoreMl,
     /// `DirectML` (Direct Machine Learning) for Windows.
     /// The argument specifies the device index.

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,9 +12,7 @@ pub enum Device {
     /// CUDA (Compute Unified Device Architecture) for NVIDIA GPUs.
     /// The argument specifies the device index (e.g., 0 for the first GPU).
     Cuda(usize),
-    /// MPS (Metal Performance Shaders) for Apple Silicon (macOS).
-    Mps,
-    /// `CoreML` (Apple Core Machine Learning).
+    /// CoreML execution provider for Apple Silicon / macOS.
     CoreMl,
     /// `DirectML` (Direct Machine Learning) for Windows.
     /// The argument specifies the device index.
@@ -36,7 +34,6 @@ impl fmt::Display for Device {
         match self {
             Self::Cpu => write!(f, "cpu"),
             Self::Cuda(i) => write!(f, "cuda:{i}"),
-            Self::Mps => write!(f, "mps"),
             Self::CoreMl => write!(f, "coreml"),
             Self::DirectMl(i) => write!(f, "directml:{i}"),
             Self::OpenVino => write!(f, "openvino"),
@@ -66,7 +63,6 @@ impl FromStr for Device {
         }
         match s.as_str() {
             "cpu" => Ok(Self::Cpu),
-            "mps" => Ok(Self::Mps),
             "coreml" => Ok(Self::CoreMl),
             "openvino" => Ok(Self::OpenVino),
             "xnnpack" => Ok(Self::Xnnpack),
@@ -92,7 +88,6 @@ mod tests {
         assert_eq!(Device::from_str("cuda").unwrap(), Device::Cuda(0));
         assert_eq!(Device::from_str("cuda:0").unwrap(), Device::Cuda(0));
         assert_eq!(Device::from_str("cuda:1").unwrap(), Device::Cuda(1));
-        assert_eq!(Device::from_str("mps").unwrap(), Device::Mps);
         assert_eq!(Device::from_str("coreml").unwrap(), Device::CoreMl);
         assert_eq!(Device::from_str("directml").unwrap(), Device::DirectMl(0));
         assert_eq!(Device::from_str("directml:1").unwrap(), Device::DirectMl(1));

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -241,7 +241,7 @@ impl InferenceConfig {
     ///
     /// # Arguments
     ///
-    /// * `device` - The device to use (e.g., CPU, CUDA, CoreML).
+    /// * `device` - The device to use (e.g., CPU, CUDA, `CoreML`).
     ///
     /// # Example
     ///

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -241,7 +241,7 @@ impl InferenceConfig {
     ///
     /// # Arguments
     ///
-    /// * `device` - The device to use (e.g., CPU, CUDA, MPS).
+    /// * `device` - The device to use (e.g., CPU, CUDA, CoreML).
     ///
     /// # Example
     ///
@@ -249,7 +249,7 @@ impl InferenceConfig {
     /// use ultralytics_inference::{InferenceConfig, Device};
     ///
     /// let config = InferenceConfig::new()
-    ///     .with_device(Device::Mps); // Use Apple Metal Performance Shaders
+    ///     .with_device(Device::CoreMl); // Use CoreML on Apple Silicon
     /// ```
     ///
     /// # Returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! | `--save` | | Save annotated results to runs/\<task\>/predict | `true` |
 //! | `--save-frames` | | Save individual frames for video input | `false` |
 //! | `--show` | | Display results in a window | `false` |
-//! | `--device` | | Device (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
+//! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |
 //! | `--classes` | | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"` | all classes |
 //!

--- a/src/model.rs
+++ b/src/model.rs
@@ -154,8 +154,7 @@ impl YOLOModel {
                     provider_name = "CUDAExecutionProvider";
                 }
                 #[cfg(feature = "coreml")]
-                crate::Device::CoreMl | crate::Device::Mps => {
-                    // Map both CoreML and MPS to CoreMLExecutionProvider
+                crate::Device::CoreMl => {
                     eps.push(Self::build_coreml_ep(path));
                     provider_name = "CoreMLExecutionProvider";
                 }


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR removes `mps` as a supported device option and standardizes Apple hardware inference under `coreml` across the Ultralytics Inference CLI, code, and docs.

### 📊 Key Changes
- Removed the `Mps` device variant from the codebase and parsing logic in `src/device.rs`.
- Updated CLI help text and documentation to stop advertising `mps` as a valid `--device` option.
- Standardized Apple device naming so Apple Silicon/macOS inference is now represented as `coreml`.
- Changed prediction output labeling in `src/cli/predict.rs` from `"MPS"` to `"CoreML"` when using the Apple execution provider.
- Simplified model provider selection in `src/model.rs` by removing the old mapping that treated both `Mps` and `CoreMl` the same.
- Refreshed examples and inline docs to use `Device::CoreMl` instead of `Device::Mps`.

### 🎯 Purpose & Impact
- ✅ Reduces confusion by exposing a single Apple-specific device option instead of two names for the same backend.
- 🍎 Makes the user experience clearer for macOS and Apple Silicon users by aligning CLI behavior, logs, and docs with the actual execution provider: CoreML.
- 🛠️ Simplifies the codebase and maintenance by removing duplicate device handling paths.
- ⚠️ Potential breaking change: users who previously passed `--device mps` or used `Device::Mps` in Rust code will need to switch to `coreml` / `Device::CoreMl`.
- 📚 Improves consistency across README, library docs, CLI help, and runtime output, making setup and troubleshooting easier for all users.