### PR TITLE
Bump taiki-e/install-action from v2.77.6 to v2.77.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.6 to v2.77.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust coverage workflow current.

### 📊 Key Changes
- ⬆️ Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- 🔁 Changed the pinned commit from `v2.77.6` to `v2.77.7`
- 🧪 This affects the CI step that installs `cargo-llvm-cov` for Rust code coverage reporting

### 🎯 Purpose & Impact
- 🛠️ Keeps CI dependencies up to date with the latest patch release
- 🔒 Maintains pinned-action security and reproducibility by continuing to use a specific commit hash
- 📈 Helps ensure the Rust coverage setup remains stable and compatible in automated testing
- 👥 Minimal user-facing impact, but beneficial for maintainers through safer and more reliable CI runs