### PR TITLE
refactor: ♻️ remove magic numbers default image sizes for YOLO models

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -107,6 +107,10 @@ impl InferenceConfig {
     pub const DEFAULT_SAVE_FRAMES: bool = false;
     /// Default for rectangular (minimal padding) inference.
     pub const DEFAULT_RECT: bool = true;
+    /// Default input image size for standard YOLO models (height, width).
+    pub const DEFAULT_IMGSZ: (usize, usize) = (640, 640);
+    /// Default input image size for OBB models (height, width).
+    pub const DEFAULT_OBB_IMGSZ: (usize, usize) = (1024, 1024);
 
     /// Create a new configuration with default values.
     ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -343,8 +343,8 @@ impl YOLOModel {
         } else if is_dynamic {
             // Dynamic input without metadata -> apply robust defaults
             match metadata.task {
-                Task::Obb => (1024, 1024),
-                _ => (640, 640),
+                Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
+                _ => InferenceConfig::DEFAULT_IMGSZ,
             }
         } else {
             // Static input without metadata -> try to read from tensor shape
@@ -362,7 +362,7 @@ impl YOLOModel {
                         None
                     }
                 })
-                .unwrap_or((640, 640))
+                .unwrap_or(InferenceConfig::DEFAULT_IMGSZ)
         };
 
         // Update config with resolved values
@@ -491,7 +491,7 @@ impl YOLOModel {
             .config
             .imgsz
             .or(self.metadata.imgsz)
-            .unwrap_or((640, 640));
+            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ);
 
         // Sanity check to prevent huge allocations from invalid imgsz
         if target_size.0 > Self::MAX_IMGSZ || target_size.1 > Self::MAX_IMGSZ {
@@ -686,7 +686,7 @@ impl YOLOModel {
             .config
             .imgsz
             .or(self.metadata.imgsz)
-            .unwrap_or((640, 640));
+            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ);
 
         // Check if target_size is divisible by stride (one-time warning logic per batch call)
         // We only warn if the configured size itself is not divisible.
@@ -1087,7 +1087,9 @@ impl YOLOModel {
     /// Get the model's input size.
     #[must_use]
     pub fn imgsz(&self) -> (usize, usize) {
-        self.metadata.imgsz.unwrap_or((640, 640))
+        self.metadata
+            .imgsz
+            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ)
     }
 
     /// Get the model's stride.

--- a/src/model.rs
+++ b/src/model.rs
@@ -1094,7 +1094,7 @@ impl YOLOModel {
         self.config
             .imgsz
             .or(self.metadata.imgsz)
-            .unwrap_or_else(|| match self.metadata.task {
+            .unwrap_or(match self.metadata.task {
                 Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
                 _ => InferenceConfig::DEFAULT_IMGSZ,
             })

--- a/src/model.rs
+++ b/src/model.rs
@@ -349,6 +349,10 @@ impl YOLOModel {
         } else {
             // Static input without metadata -> try to read from tensor shape
             // Typically [1, 3, H, W]
+            let task_default = match metadata.task {
+                Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
+                _ => InferenceConfig::DEFAULT_IMGSZ,
+            };
             input_info
                 .and_then(|i| {
                     if let ValueType::Tensor { shape, .. } = i.dtype() {
@@ -362,7 +366,7 @@ impl YOLOModel {
                         None
                     }
                 })
-                .unwrap_or(InferenceConfig::DEFAULT_IMGSZ)
+                .unwrap_or(task_default)
         };
 
         // Update config with resolved values
@@ -1087,9 +1091,13 @@ impl YOLOModel {
     /// Get the model's input size.
     #[must_use]
     pub fn imgsz(&self) -> (usize, usize) {
-        self.metadata
+        self.config
             .imgsz
-            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ)
+            .or(self.metadata.imgsz)
+            .unwrap_or_else(|| match self.metadata.task {
+                Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
+                _ => InferenceConfig::DEFAULT_IMGSZ,
+            })
     }
 
     /// Get the model's stride.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR centralizes default image-size handling in the Rust inference code, adding task-aware defaults for standard YOLO and OBB models to make model input sizing more consistent and reliable.

### 📊 Key Changes
- Added shared constants in `InferenceConfig` for default input sizes:
  - `DEFAULT_IMGSZ = (640, 640)` for standard YOLO models
  - `DEFAULT_OBB_IMGSZ = (1024, 1024)` for OBB models 📐
- Replaced hardcoded fallback sizes in `YOLOModel` with these centralized constants.
- Updated dynamic-input fallback logic so OBB models automatically use the larger default size when metadata is missing.
- Improved static-input fallback behavior by using task-specific defaults if tensor shape information cannot be read.
- Updated `imgsz()` so it now checks:
  1. configured image size,
  2. model metadata image size,
  3. task-appropriate default size ✅
- Kept standard inference and batch inference paths aligned by using the same centralized default size logic throughout the codebase.

### 🎯 Purpose & Impact
- Reduces duplicated hardcoded values, making the code easier to maintain and less error-prone 🔧
- Ensures OBB models get a more suitable default input size, which can improve expected behavior when metadata is unavailable.
- Makes image-size resolution more consistent across different inference paths, reducing surprise behavior for developers and users.
- Improves robustness for models with missing or incomplete metadata, helping inference work more reliably out of the box 🚀
- Simplifies future updates, since default image sizes now only need to be changed in one place.