### PR TITLE
Bump taiki-e/install-action from v2.77.7 to v2.78.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.7 to v2.78.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, keeping CI tooling current with a newer `taiki-e/install-action` release.

### 📊 Key Changes
- ⬆️ Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- 🔁 Changed `taiki-e/install-action` from `v2.77.7` to `v2.78.1`
- 🛠️ This action is used to install `cargo-llvm-cov` during the CI workflow

### 🎯 Purpose & Impact
- ✅ Keeps the CI pipeline up to date with the latest fixes and improvements from the action maintainers
- 🔒 Helps maintain workflow reliability and security by refreshing a pinned automation dependency
- 🚀 Low-risk infrastructure change with no direct effect on product features, but it can improve CI stability and maintainability for developers