### PR TITLE
`ultralytics-inference  0.0.16` fix: 🐞 resolve CoreML graph_input_cast_0 crash and add regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,25 @@ jobs:
         run: rustup show
 
       - name: Clippy (annotate feature)
+        if: matrix.os != 'macos-latest'
         run: cargo clippy --all-targets --no-default-features --features annotate -- -D warnings
 
       - name: Tests (annotate feature)
+        if: matrix.os != 'macos-latest'
         run: cargo test --no-default-features --features annotate
+
+      # CoreML is macOS-only — covers issue #148 (GatherElements warmup) and graph_input_cast_0 fix
+      - name: Clippy (coreml + annotate)
+        if: matrix.os == 'macos-latest'
+        run: cargo clippy --all-targets --no-default-features --features "coreml,annotate" -- -D warnings
+
+      - name: Tests (coreml + annotate)
+        if: matrix.os == 'macos-latest'
+        run: cargo test --no-default-features --features "coreml,annotate"
+
+      - name: Integration tests (all, including ignored)
+        if: matrix.os == 'macos-latest'
+        run: cargo test --no-default-features --features "coreml,annotate" --test integration_test -- --include-ignored
 
   # Video feature tests for Linux - FFmpeg 7 and 8
   test-video:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: cargo test --no-default-features --features "coreml,annotate"
 
-      - name: Integration tests (all, including ignored)
+      - name: Integration tests (CoreML regression, including ignored)
         if: matrix.os == 'macos-latest'
-        run: cargo test --no-default-features --features "coreml,annotate" --test integration_test -- --include-ignored
+        run: cargo test --no-default-features --features "coreml,annotate" --test integration_test test_coreml_model_loads_and_warms_up -- --ignored --exact
 
   # Video feature tests for Linux - FFmpeg 7 and 8
   test-video:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,7 +2692,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "ab_glyph",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 rust-version = "1.88"
 authors = [

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.15 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.16 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -153,7 +153,7 @@ Results saved to runs/detect/predict1
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.15 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.16 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -243,7 +243,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.15"
+ultralytics-inference = "0.0.16"
 ```
 
 ```toml

--- a/src/model.rs
+++ b/src/model.rs
@@ -433,19 +433,10 @@ impl YOLOModel {
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
         use ort::execution_providers::coreml::ModelFormat;
-        let format = match Self::macos_version() {
-            Some((major, _)) if major >= 12 => ModelFormat::MLProgram,
-            ver => {
-                let label = ver.map_or_else(
-                    || "unknown".to_owned(),
-                    |(maj, min)| format!("{maj}.{min} < 12"),
-                );
-                warn!(
-                    "WARNING ⚠️ macOS {label}: CoreML using NeuralNetwork format; FP16 models may fail."
-                );
-                ModelFormat::NeuralNetwork
-            }
-        };
+        if matches!(Self::macos_version(), Some((major, _)) if major < 11) {
+            warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
+        }
+        let format = ModelFormat::NeuralNetwork;
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);
 
@@ -1211,5 +1202,65 @@ mod tests {
             assert!(debug_str.contains("task"));
             assert!(debug_str.contains("num_classes"));
         }
+    }
+
+    // Mirrors the suppression condition in warmup() so we can test it without a real session.
+    fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {
+        provider == "CoreMLExecutionProvider"
+            && msg.contains("GatherElements")
+            && msg.contains("Out of range")
+    }
+
+    // Issue #148 / PR #149: GatherElements out-of-range on an all-zeros dummy input is benign
+    // during CoreML warmup (the DFL head produces invalid gather indices for zero activations).
+    #[test]
+    fn test_warmup_gather_elements_suppressed_for_coreml() {
+        assert!(is_benign_coreml_warmup_error(
+            "CoreMLExecutionProvider",
+            "GatherElements op: Out of range value in index tensor"
+        ));
+    }
+
+    // The same GatherElements error on CPU/CUDA is a real bug and must not be hidden.
+    #[test]
+    fn test_warmup_gather_elements_propagates_for_other_providers() {
+        assert!(!is_benign_coreml_warmup_error(
+            "CPUExecutionProvider",
+            "GatherElements op: Out of range value in index tensor"
+        ));
+        assert!(!is_benign_coreml_warmup_error(
+            "CUDAExecutionProvider",
+            "GatherElements op: Out of range value in index tensor"
+        ));
+    }
+
+    // graph_input_cast_0 is a real CoreML misconfiguration (MLProgram adds a cast node that
+    // renames the ONNX input). It must propagate so the caller sees the failure.
+    // The fix (NeuralNetwork format) prevents this error from occurring at all, but it must
+    // never be silently swallowed if it somehow reappears.
+    #[test]
+    fn test_warmup_graph_input_cast_error_propagates() {
+        assert!(!is_benign_coreml_warmup_error(
+            "CoreMLExecutionProvider",
+            "Feature graph_input_cast_0 is required but not specified"
+        ));
+    }
+
+    // Any unrecognised CoreML error must propagate.
+    #[test]
+    fn test_warmup_unrecognised_coreml_error_propagates() {
+        assert!(!is_benign_coreml_warmup_error(
+            "CoreMLExecutionProvider",
+            "Some unexpected CoreML error"
+        ));
+    }
+
+    #[cfg(all(feature = "coreml", target_os = "macos"))]
+    #[test]
+    fn test_macos_version_parses_on_macos() {
+        let version = YOLOModel::macos_version();
+        assert!(version.is_some(), "macos_version() must return Some on macOS");
+        let (major, _minor) = version.unwrap();
+        assert!(major >= 10, "macOS major version should be >= 10");
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1149,7 +1149,7 @@ impl std::fmt::Debug for YOLOModel {
     }
 }
 
-/// Returns true if `err` is the benign GatherElements out-of-range error that CoreML produces
+/// Returns true if `err` is the benign `GatherElements` out-of-range error that `CoreML` produces
 /// on all-zeros dummy input (issue #148). All other errors, including `graph_input_cast_0`,
 /// must propagate so callers see real failures.
 fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1246,7 +1246,7 @@ mod tests {
         ));
     }
 
-    // Any unrecognised `CoreML` error must propagate.
+    // Any unrecognized `CoreML` error must propagate.
     #[test]
     fn test_warmup_unrecognised_coreml_error_propagates() {
         assert!(!is_benign_coreml_warmup_error(

--- a/src/model.rs
+++ b/src/model.rs
@@ -1246,7 +1246,7 @@ mod tests {
         ));
     }
 
-    // Any unrecognised CoreML error must propagate.
+    // Any unrecognized CoreML error must propagate.
     #[test]
     fn test_warmup_unrecognised_coreml_error_propagates() {
         assert!(!is_benign_coreml_warmup_error(

--- a/src/model.rs
+++ b/src/model.rs
@@ -437,11 +437,11 @@ impl YOLOModel {
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
         use ort::execution_providers::coreml::ModelFormat;
-        // MLProgram (macOS 12+) causes ORT's CoreML EP to insert a FP32→FP16 cast node at
-        // graph input, renaming it from the ONNX name (e.g. "images") to "graph_input_cast_0".
-        // ORT then feeds the tensor by the original name, which CoreML can't find → crash.
-        // NeuralNetwork (Core ML 3, macOS 10.15+) avoids the rename and supports FP16 inputs
-        // natively — confirmed working with both FP32 and FP16 YOLO ONNX models on macOS 12+.
+        // `MLProgram` (macOS 12+) causes ORT's `CoreML` EP to insert a FP32→FP16 cast node at
+        // graph input, renaming it from the `ONNX` name (e.g. "images") to "graph_input_cast_0".
+        // ORT then feeds the tensor by the original name, which `CoreML` can't find → crash.
+        // `NeuralNetwork` (`CoreML` 3, macOS 10.15+) avoids the rename and supports FP16 inputs
+        // natively — confirmed working with both `FP32` and `FP16` `YOLO` `ONNX` models on macOS 12+.
         let format = ModelFormat::NeuralNetwork;
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);

--- a/src/model.rs
+++ b/src/model.rs
@@ -155,11 +155,11 @@ impl YOLOModel {
                 }
                 #[cfg(feature = "coreml")]
                 crate::Device::CoreMl => {
-                    if matches!(Self::macos_version(), Some((major, _)) if major < 11) {
-                        warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
-                    } else {
+                    if matches!(Self::macos_version(), Some((major, _)) if major >= 11) {
                         eps.push(Self::build_coreml_ep(path));
                         provider_name = "CoreMLExecutionProvider";
+                    } else {
+                        warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
                     }
                 }
                 #[cfg(feature = "tensorrt")]
@@ -226,7 +226,7 @@ impl YOLOModel {
             }
 
             #[cfg(feature = "coreml")]
-            if !matches!(Self::macos_version(), Some((major, _)) if major < 11) {
+            if matches!(Self::macos_version(), Some((major, _)) if major >= 11) {
                 eps.push(Self::build_coreml_ep(path));
                 if provider_name == "CPUExecutionProvider" {
                     provider_name = "CoreMLExecutionProvider";
@@ -437,6 +437,11 @@ impl YOLOModel {
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
         use ort::execution_providers::coreml::ModelFormat;
+        // MLProgram (macOS 12+) causes ORT's CoreML EP to insert a FP32→FP16 cast node at
+        // graph input, renaming it from the ONNX name (e.g. "images") to "graph_input_cast_0".
+        // ORT then feeds the tensor by the original name, which CoreML can't find → crash.
+        // NeuralNetwork (Core ML 3, macOS 10.15+) avoids the rename and supports FP16 inputs
+        // natively — confirmed working with both FP32 and FP16 YOLO ONNX models on macOS 12+.
         let format = ModelFormat::NeuralNetwork;
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);

--- a/src/model.rs
+++ b/src/model.rs
@@ -155,8 +155,12 @@ impl YOLOModel {
                 }
                 #[cfg(feature = "coreml")]
                 crate::Device::CoreMl => {
-                    eps.push(Self::build_coreml_ep(path));
-                    provider_name = "CoreMLExecutionProvider";
+                    if matches!(Self::macos_version(), Some((major, _)) if major < 11) {
+                        warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
+                    } else {
+                        eps.push(Self::build_coreml_ep(path));
+                        provider_name = "CoreMLExecutionProvider";
+                    }
                 }
                 #[cfg(feature = "tensorrt")]
                 crate::Device::TensorRt(i) => {
@@ -222,7 +226,7 @@ impl YOLOModel {
             }
 
             #[cfg(feature = "coreml")]
-            {
+            if !matches!(Self::macos_version(), Some((major, _)) if major < 11) {
                 eps.push(Self::build_coreml_ep(path));
                 if provider_name == "CPUExecutionProvider" {
                     provider_name = "CoreMLExecutionProvider";
@@ -433,9 +437,6 @@ impl YOLOModel {
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
         use ort::execution_providers::coreml::ModelFormat;
-        if matches!(Self::macos_version(), Some((major, _)) if major < 11) {
-            warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
-        }
         let format = ModelFormat::NeuralNetwork;
         let mut ep =
             ort::execution_providers::CoreMLExecutionProvider::default().with_model_format(format);
@@ -509,11 +510,7 @@ impl YOLOModel {
 
         if let Err(e) = warmup_result {
             let msg = e.to_string();
-            // CoreML + all-zeros input: GatherElements out-of-range in the DFL head is benign.
-            if self.execution_provider != "CoreMLExecutionProvider"
-                || !msg.contains("GatherElements")
-                || !msg.contains("Out of range")
-            {
+            if !is_benign_coreml_warmup_error(&self.execution_provider, &msg) {
                 return Err(e);
             }
         }
@@ -1152,6 +1149,15 @@ impl std::fmt::Debug for YOLOModel {
     }
 }
 
+/// Returns true if `err` is the benign GatherElements out-of-range error that CoreML produces
+/// on all-zeros dummy input (issue #148). All other errors, including `graph_input_cast_0`,
+/// must propagate so callers see real failures.
+fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {
+    provider == "CoreMLExecutionProvider"
+        && msg.contains("GatherElements")
+        && msg.contains("Out of range")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1202,13 +1208,6 @@ mod tests {
             assert!(debug_str.contains("task"));
             assert!(debug_str.contains("num_classes"));
         }
-    }
-
-    // Mirrors the suppression condition in warmup() so we can test it without a real session.
-    fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {
-        provider == "CoreMLExecutionProvider"
-            && msg.contains("GatherElements")
-            && msg.contains("Out of range")
     }
 
     // Issue #148 , PR #149: GatherElements out-of-range on an all-zeros dummy input is benign

--- a/src/model.rs
+++ b/src/model.rs
@@ -1211,8 +1211,8 @@ mod tests {
             && msg.contains("Out of range")
     }
 
-    // Issue #148 / PR #149: GatherElements out-of-range on an all-zeros dummy input is benign
-    // during CoreML warmup (the DFL head produces invalid gather indices for zero activations).
+    // Issue #148 , PR #149: GatherElements out-of-range on an all-zeros dummy input is benign
+    // during `CoreML` warmup (the DFL head produces invalid gather indices for zero activations).
     #[test]
     fn test_warmup_gather_elements_suppressed_for_coreml() {
         assert!(is_benign_coreml_warmup_error(

--- a/src/model.rs
+++ b/src/model.rs
@@ -1259,7 +1259,10 @@ mod tests {
     #[test]
     fn test_macos_version_parses_on_macos() {
         let version = YOLOModel::macos_version();
-        assert!(version.is_some(), "macos_version() must return Some on macOS");
+        assert!(
+            version.is_some(),
+            "macos_version() must return Some on macOS"
+        );
         let (major, _minor) = version.unwrap();
         assert!(major >= 10, "macOS major version should be >= 10");
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1234,9 +1234,9 @@ mod tests {
         ));
     }
 
-    // graph_input_cast_0 is a real CoreML misconfiguration (MLProgram adds a cast node that
+    // graph_input_cast_0 is a real `CoreML` misconfiguration (MLProgram adds a cast node that
     // renames the ONNX input). It must propagate so the caller sees the failure.
-    // The fix (NeuralNetwork format) prevents this error from occurring at all, but it must
+    // The fix (`NeuralNetwork` format) prevents this error from occurring at all, but it must
     // never be silently swallowed if it somehow reappears.
     #[test]
     fn test_warmup_graph_input_cast_error_propagates() {
@@ -1246,12 +1246,12 @@ mod tests {
         ));
     }
 
-    // Any unrecognized CoreML error must propagate.
+    // Any unrecognised `CoreML` error must propagate.
     #[test]
     fn test_warmup_unrecognised_coreml_error_propagates() {
         assert!(!is_benign_coreml_warmup_error(
             "CoreMLExecutionProvider",
-            "Some unexpected CoreML error"
+            "Some unexpected `CoreML` error"
         ));
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,6 @@ use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
 #[cfg(feature = "coreml")]
 use ultralytics_inference::{Device, YOLOModel};
 
-
 /// End-to-end CoreML test covering two known regressions:
 ///
 /// 1. **Issue #148 / PR #149** — `GatherElements op: Out of range` during warmup.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
 #[cfg(feature = "coreml")]
 use ultralytics_inference::{Device, YOLOModel};
 
-/// End-to-end CoreML test covering two known regressions:
+/// End-to-end `CoreML` test covering two known regressions:
 ///
 /// 1. **Issue #148 / PR #149** — `GatherElements op: Out of range` during warmup.
 ///    `CoreML`'s DFL head produces out-of-range gather indices on an all-zeros dummy input.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,6 +10,32 @@ use tempfile::tempdir;
 use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
 use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
+#[cfg(feature = "coreml")]
+use ultralytics_inference::{Device, YOLOModel};
+
+
+/// End-to-end CoreML test covering two known regressions:
+///
+/// 1. **Issue #148 / PR #149** — `GatherElements op: Out of range` during warmup.
+///    CoreML's DFL head produces out-of-range gather indices on an all-zeros dummy input.
+///    
+///
+/// 2. **`graph_input_cast_0` crash** — MLProgram format causes ORT's CoreML EP to insert a
+///    cast node, renaming the ONNX input (e.g. `images`) to `graph_input_cast_0`. ORT then
+///    feeds the tensor with the original name, which CoreML can't find.
+///    The fix (NeuralNetwork format) avoids the rename entirely.
+#[cfg(feature = "coreml")]
+#[test]
+#[ignore = "downloads a YOLO model; requires CoreML (macOS only)"]
+fn test_coreml_model_loads_and_warms_up() {
+    let config = InferenceConfig::new().with_device(Device::CoreMl);
+    let mut model =
+        YOLOModel::load_with_config("yolo26n.onnx", config).expect("CoreML model should load");
+
+    // warmup() must succeed: graph_input_cast_0 errors are gone (NeuralNetwork format fix)
+    // and GatherElements out-of-range is tolerated (issue #148 fix).
+    model.warmup().expect("CoreML warmup should not fail");
+}
 
 #[test]
 #[ignore = "downloads a YOLO model and sample image"]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,22 +16,25 @@ use ultralytics_inference::{Device, YOLOModel};
 /// End-to-end CoreML test covering two known regressions:
 ///
 /// 1. **Issue #148 / PR #149** — `GatherElements op: Out of range` during warmup.
-///    CoreML's DFL head produces out-of-range gather indices on an all-zeros dummy input.
+///    `CoreML`'s DFL head produces out-of-range gather indices on an all-zeros dummy input.
 ///    
 ///
-/// 2. **`graph_input_cast_0` crash** — MLProgram format causes ORT's CoreML EP to insert a
+/// 2. **`graph_input_cast_0` crash** — `MLProgram` format causes ORT's `CoreML` EP to insert a
 ///    cast node, renaming the ONNX input (e.g. `images`) to `graph_input_cast_0`. ORT then
-///    feeds the tensor with the original name, which CoreML can't find.
-///    The fix (NeuralNetwork format) avoids the rename entirely.
+///    feeds the tensor with the original name, which `CoreML` can't find.
+///    The fix (`NeuralNetwork` format) avoids the rename entirely.
 #[cfg(feature = "coreml")]
 #[test]
 #[ignore = "downloads a YOLO model; requires CoreML (macOS only)"]
 fn test_coreml_model_loads_and_warms_up() {
-    let config = InferenceConfig::new().with_device(Device::CoreMl);
-    let mut model =
-        YOLOModel::load_with_config("yolo26n.onnx", config).expect("CoreML model should load");
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let model_path = temp_dir.path().join("yolo26n.onnx");
 
-    // warmup() must succeed: graph_input_cast_0 errors are gone (NeuralNetwork format fix)
+    let config = InferenceConfig::new().with_device(Device::CoreMl);
+    let mut model = YOLOModel::load_with_config(model_path.to_string_lossy().as_ref(), config)
+        .expect("CoreML model should load");
+
+    // warmup() must succeed: graph_input_cast_0 errors are gone (`NeuralNetwork` format fix)
     // and GatherElements out-of-range is tolerated (issue #148 fix).
     model.warmup().expect("CoreML warmup should not fail");
 }


### PR DESCRIPTION
MLProgram format on macOS 12+ caused ORT's CoreML EP to insert a cast node at the graph input, renaming it from the ONNX name (e.g. "images") to "graph_input_cast_0". ORT then fed the tensor using the original name, which CoreML could not find. Switch build_coreml_ep to always use NeuralNetwork format to avoid the rename entirely.

Also adds unit tests covering the warmup error filter (issue #148 GatherElements suppression and graph_input_cast_0 propagation), an end-to-end CoreML integration test, and CoreML CI steps gated to macos-latest inside the existing test matrix job.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves CoreML reliability on macOS in `ultralytics/inference`, adds targeted CI coverage ✅, and releases version `0.0.16` 🚀.

### 📊 Key Changes
- Added **macOS-specific CI checks** for the `coreml` + `annotate` feature set, including a dedicated **CoreML regression integration test** 🧪
- Updated the crate version from **`0.0.15` to `0.0.16`** and refreshed README examples/docs accordingly 📝
- Improved **CoreML device handling** so it only enables CoreML on **macOS 11+**, otherwise it cleanly **falls back to CPU** with a warning ⚠️
- Changed CoreML model loading to always use **`NeuralNetwork` format** instead of `MLProgram` to avoid a known input-renaming crash (`graph_input_cast_0`) on macOS 🍎
- Refined warmup error handling so only one **known benign CoreML warmup error** (`GatherElements` out-of-range on dummy input) is ignored, while all real errors still surface clearly 🔍
- Added new **unit tests** for warmup error filtering and macOS version parsing, plus an **end-to-end CoreML warmup test** to prevent regressions 🛡️

### 🎯 Purpose & Impact
- Makes **CoreML inference more stable and predictable** for macOS users, especially during model load and warmup 🙌
- Prevents a known crash caused by CoreML/ONNX Runtime input renaming, improving support for YOLO ONNX models on Apple devices 🍏
- Ensures benign warmup issues do not block inference, while still preserving visibility into **real failures** for easier debugging 🧠
- Improves cross-platform reliability by keeping Linux/Windows CI focused on general features and macOS CI focused on **CoreML-specific behavior** ⚙️
- Gives users a safer fallback path on unsupported macOS versions instead of failing unexpectedly 🔁
- Overall, this release should reduce CoreML-related regressions and make `ultralytics/inference` more dependable for Apple-based deployments 🚀
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
