### PR TITLE
Bump taiki-e/install-action from v2.78.1 to v2.78.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        uses: taiki-e/install-action@0e01fba183f89b991766ac4092315c09f1acb55c # v2.78.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.78.1 to v2.78.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the CI workflow to use a newer version of the `taiki-e/install-action` GitHub Action for installing `cargo-llvm-cov`.

### 📊 Key Changes
- ⬆️ Bumped the GitHub Action used in `.github/workflows/ci.yml`:
  - From `taiki-e/install-action` `v2.78.1`
  - To `taiki-e/install-action` `v2.78.3`
- 🛠️ The updated action is specifically used to install `cargo-llvm-cov` during CI runs.
- 🔒 The workflow still pins the action to a commit hash, which helps maintain build security and reproducibility.

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest fixes and improvements from the action maintainer.
- 🧪 Helps ensure reliable installation of `cargo-llvm-cov`, which supports code coverage tooling in the Rust-related CI steps.
- 🛡️ Maintains secure and predictable CI behavior by continuing to use a pinned commit.
- 👥 For most users, this has no direct product-facing change, but it can improve CI stability and reduce maintenance issues for contributors.