### PR TITLE
Bump taiki-e/install-action from v2.79.0 to v2.79.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        uses: taiki-e/install-action@b550161ef8a7bc4f2a671c0b03a18ac9ccedea1e # v2.79.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.0 to v2.79.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub CI workflow to use a newer patch version of the `taiki-e/install-action` action for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from commit `7be9fd8...` to `b550161...`
- This corresponds to a version bump from `v2.79.0` to `v2.79.1`
- The action is used to install `cargo-llvm-cov` during CI coverage-related jobs

### 🎯 Purpose & Impact
- 🛠️ Keeps CI dependencies current with the latest patch-level fixes
- 🔒 Improves workflow maintainability and can help reduce risk from outdated action versions
- ✅ Likely has no user-facing product changes, but helps keep automated testing and coverage reporting stable and reliable
- 📦 A low-risk infrastructure update that supports healthier development workflows