### PR TITLE
Bump codecov/codecov-action from v6.0.0 to v6.0.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         run: cargo llvm-cov --features annotate,video,visualize --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bump codecov/codecov-action from v6.0.0 to v6.0.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions Codecov step from `codecov-action` v6.0.0 to v6.0.1 in the CI workflow.

### 📊 Key Changes
- 🛠️ Updated `.github/workflows/ci.yml` to use a newer pinned commit of `codecov/codecov-action`
- ⬆️ Bumped the action version comment from `v6.0.0` to `v6.0.1`
- 🔒 Kept the action pinned to a specific commit hash, which helps maintain CI security and reproducibility

### 🎯 Purpose & Impact
- ✅ Ensures the repository uses the latest patch release of the Codecov GitHub Action
- 🧩 May include small fixes, stability improvements, or compatibility updates for coverage uploads
- 🛡️ Maintains secure CI practices by continuing to pin the action to an exact commit
- 👩‍💻 Minimal user-facing impact, but helps keep development workflows reliable and up to date