### PR TITLE
perf: ⚡️ replace per-inference HashMap clone with Arc in names lookup

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -859,6 +859,7 @@ mod tests {
     use crate::results::Speed;
     use ndarray::Array3;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn test_get_class_color() {
@@ -885,7 +886,7 @@ mod tests {
 
         let orig_img = Array3::<u8>::zeros((100, 100, 3));
         let path = "test.jpg".to_string();
-        let names = HashMap::new();
+        let names = Arc::new(HashMap::new());
         let speed = Speed::new(0.0, 0.0, 0.0);
 
         // Correct constructor matching src/results.rs:101

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -480,14 +480,15 @@ mod tests {
     use crate::results::{Boxes, Obb, Probs, Results, Speed};
     use ndarray::{Array2, Array3};
     use std::collections::HashMap;
+    use std::sync::Arc;
 
-    fn create_names() -> HashMap<usize, String> {
+    fn create_names() -> Arc<HashMap<usize, String>> {
         let mut names = HashMap::new();
         names.insert(0, "person".to_string());
         names.insert(1, "car".to_string());
         names.insert(2, "bus".to_string());
         names.insert(5, "bicycle".to_string());
-        names
+        Arc::new(names)
     }
 
     fn create_dummy_image() -> Array3<u8> {
@@ -614,12 +615,15 @@ mod tests {
         let data = ndarray::Array1::from_vec(vec![0.1, 0.7, 0.15, 0.03, 0.02]);
         let probs = Probs::new(data);
 
-        let mut names = HashMap::new();
-        names.insert(0, "cat".to_string());
-        names.insert(1, "dog".to_string());
-        names.insert(2, "bird".to_string());
-        names.insert(3, "fish".to_string());
-        names.insert(4, "hamster".to_string());
+        let names = Arc::new({
+            let mut n = HashMap::new();
+            n.insert(0, "cat".to_string());
+            n.insert(1, "dog".to_string());
+            n.insert(2, "bird".to_string());
+            n.insert(3, "fish".to_string());
+            n.insert(4, "hamster".to_string());
+            n
+        });
 
         let mut result = Results::new(
             create_dummy_image(),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,6 +6,7 @@
 //! The metadata is stored as YAML in the ONNX model's custom metadata properties.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::error::{InferenceError, Result};
 use crate::task::Task;
@@ -41,7 +42,7 @@ pub struct ModelMetadata {
     /// Whether the model uses FP16 (half precision).
     pub half: bool,
     /// Class ID to class name mapping.
-    pub names: HashMap<usize, String>,
+    pub names: Arc<HashMap<usize, String>>,
     /// Whether the model was exported with end-to-end NMS-free output
     /// (YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
     pub end2end: bool,
@@ -97,6 +98,7 @@ impl ModelMetadata {
     /// Returns an error if the YAML is malformed or missing required fields.
     pub fn from_yaml_str(yaml_str: &str) -> Result<Self> {
         let mut metadata = Self::default();
+        let mut names: HashMap<usize, String> = HashMap::new();
 
         for line in yaml_str.lines() {
             let line = line.trim();
@@ -159,7 +161,7 @@ impl ModelMetadata {
                     _ => {
                         // Check for class name entries (numeric keys)
                         if let Ok(class_id) = key.trim().parse::<usize>() {
-                            metadata.names.insert(class_id, value.to_string());
+                            names.insert(class_id, value.to_string());
                         }
                     }
                 }
@@ -172,10 +174,11 @@ impl ModelMetadata {
         }
 
         // Parse names block if not already parsed inline
-        if metadata.names.is_empty() {
-            metadata.names = Self::parse_names_block(yaml_str);
+        if names.is_empty() {
+            names = Self::parse_names_block(yaml_str);
         }
 
+        metadata.names = Arc::new(names);
         Ok(metadata)
     }
 
@@ -374,7 +377,7 @@ impl Default for ModelMetadata {
             imgsz: None,
             channels: 3,
             half: false,
-            names: HashMap::new(),
+            names: Arc::new(HashMap::new()),
             end2end: false,
             kpt_shape: None,
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use half::f16;
@@ -840,7 +841,7 @@ impl YOLOModel {
                 self.metadata.task,
                 &preprocess_res,
                 &self.config,
-                &self.metadata.names,
+                Arc::clone(&self.metadata.names),
                 orig_img,
                 path,
                 speed,
@@ -1071,8 +1072,8 @@ impl YOLOModel {
 
     /// Get the model's class names.
     #[must_use]
-    pub const fn names(&self) -> &HashMap<usize, String> {
-        &self.metadata.names
+    pub fn names(&self) -> &HashMap<usize, String> {
+        self.metadata.names.as_ref()
     }
 
     /// Get the number of classes.

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -265,8 +265,7 @@ fn postprocess_detect(
     let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     // Parse output shape - handle both [1, 84, 8400] and [1, 8400, 84] formats
-    let (num_classes, num_predictions, is_transposed) =
-        parse_detect_shape(output_shape, nc);
+    let (num_classes, num_predictions, is_transposed) = parse_detect_shape(output_shape, nc);
 
     if output.is_empty() || num_predictions == 0 {
         return results;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -16,6 +16,7 @@
 )]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use wide::{CmpGt, f32x8};
 
@@ -57,7 +58,7 @@ pub fn postprocess(
     task: Task,
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
@@ -254,13 +255,13 @@ fn postprocess_detect(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
 
     // Parse output shape - handle both [1, 84, 8400] and [1, 8400, 84] formats
     let (num_classes, num_predictions, is_transposed) =
@@ -688,13 +689,13 @@ fn postprocess_segment(
     outputs: Vec<(&[f32], Vec<usize>)>,
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
 
     if outputs.len() < 2 {
         // Protos output missing - log warning for user visibility
@@ -913,13 +914,13 @@ fn postprocess_pose(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
 
     // Standard COCO pose has 17 keypoints, each with (x, y, conf)
     let num_keypoints = 17;
@@ -1113,13 +1114,13 @@ fn postprocess_pose(
 /// `Results` struct containing classification probabilities.
 fn postprocess_classify(
     output: &[f32],
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     if output.is_empty() {
         return results;
@@ -1175,13 +1176,13 @@ fn postprocess_obb(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
 
     // OBB format: [xywh, class_scores..., rotation_angle]
     // features = 4 (bbox) + num_classes + 1 (angle)
@@ -1353,13 +1354,13 @@ fn postprocess_detect_end2end(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     if output_shape.len() != 3 || output.is_empty() {
         return results;
@@ -1429,13 +1430,13 @@ fn postprocess_segment_end2end(
     outputs: Vec<(&[f32], Vec<usize>)>,
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
     if outputs.len() < 2 {
         eprintln!(
             "WARNING ⚠️ End2end segmentation missing protos output (got {} outputs).",
@@ -1553,7 +1554,7 @@ fn postprocess_pose_end2end(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
@@ -1561,7 +1562,7 @@ fn postprocess_pose_end2end(
     nk: usize,
     kpt_dim: usize,
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
     if output_shape.len() != 3 || output.is_empty() || nk == 0 || kpt_dim < 2 {
         return results;
     }
@@ -1639,13 +1640,13 @@ fn postprocess_obb_end2end(
     output_shape: &[usize],
     preprocess: &PreprocessResult,
     config: &InferenceConfig,
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
     let mut flat: Vec<f32> = Vec::new();
 
     if output_shape.len() == 3 && !output.is_empty() {
@@ -1753,7 +1754,7 @@ mod tests {
             padding: (0.0, 0.0),
         };
         let config = InferenceConfig::default();
-        let names = HashMap::new();
+        let names = Arc::new(HashMap::new());
         let orig_img = ndarray::Array3::zeros((480, 640, 3));
 
         let results = postprocess_detect(
@@ -1761,7 +1762,7 @@ mod tests {
             &[1, 84, 0],
             &preprocess,
             &config,
-            &names,
+            names,
             orig_img,
             String::new(),
             Speed::default(),
@@ -1792,9 +1793,12 @@ mod tests {
             padding: (0.0, 0.0),
         };
         let config = InferenceConfig::default();
-        let mut names = HashMap::new();
-        names.insert(0, "class0".to_string());
-        names.insert(1, "class1".to_string());
+        let names = Arc::new({
+            let mut n = HashMap::new();
+            n.insert(0, "class0".to_string());
+            n.insert(1, "class1".to_string());
+            n
+        });
         let orig_img = ndarray::Array3::zeros((640, 640, 3));
 
         // This should not panic
@@ -1803,7 +1807,7 @@ mod tests {
             &[1, 84, 1],
             &preprocess,
             &config,
-            &names,
+            names,
             orig_img,
             String::new(),
             Speed::default(),
@@ -1829,7 +1833,7 @@ mod tests {
             padding: (0.0, 0.0),
         };
         let config = InferenceConfig::default();
-        let names = HashMap::new();
+        let names = Arc::new(HashMap::new());
         let orig_img = ndarray::Array3::zeros((640, 640, 3));
 
         // Empty shape should not panic
@@ -1838,7 +1842,7 @@ mod tests {
             &[],
             &preprocess,
             &config,
-            &names,
+            Arc::clone(&names),
             orig_img.clone(),
             String::new(),
             Speed::default(),
@@ -1852,7 +1856,7 @@ mod tests {
             &[100],
             &preprocess,
             &config,
-            &names,
+            Arc::clone(&names),
             orig_img,
             String::new(),
             Speed::default(),
@@ -1894,8 +1898,11 @@ mod tests {
             padding: (0.0, 0.0),
         };
         let config = InferenceConfig::default();
-        let mut names = HashMap::new();
-        names.insert(0, "person".to_string());
+        let names = Arc::new({
+            let mut n = HashMap::new();
+            n.insert(0, "person".to_string());
+            n
+        });
 
         // Shape [1, 56, 100]
         let results = postprocess_pose(
@@ -1903,7 +1910,7 @@ mod tests {
             &[1, num_features, num_preds],
             &preprocess,
             &config,
-            &names,
+            names,
             ndarray::Array3::zeros((640, 640, 3)),
             "test.jpg".to_string(),
             Speed::default(),
@@ -1952,8 +1959,11 @@ mod tests {
             padding: (0.0, 0.0),
         };
         let config = InferenceConfig::default();
-        let mut names = HashMap::new();
-        names.insert(0, "object".to_string());
+        let names = Arc::new({
+            let mut n = HashMap::new();
+            n.insert(0, "object".to_string());
+            n
+        });
 
         // Shape [1, 6, 100]
         let results = postprocess_obb(
@@ -1961,7 +1971,7 @@ mod tests {
             &[1, num_features, num_preds],
             &preprocess,
             &config,
-            &names,
+            names,
             ndarray::Array3::zeros((640, 640, 3)),
             "test.jpg".to_string(),
             Speed::default(),

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -261,11 +261,12 @@ fn postprocess_detect(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
+    let nc = names.len();
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     // Parse output shape - handle both [1, 84, 8400] and [1, 8400, 84] formats
     let (num_classes, num_predictions, is_transposed) =
-        parse_detect_shape(output_shape, names.len());
+        parse_detect_shape(output_shape, nc);
 
     if output.is_empty() || num_predictions == 0 {
         return results;
@@ -920,7 +921,8 @@ fn postprocess_pose(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
+    let num_classes = names.len().max(1);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     // Standard COCO pose has 17 keypoints, each with (x, y, conf)
     let num_keypoints = 17;
@@ -928,7 +930,6 @@ fn postprocess_pose(
     let kpt_features = num_keypoints * kpt_dim; // 51
 
     // Pose typically has 1 class (person), so features = 4 + 1 + 51 = 56
-    let num_classes = names.len().max(1);
     let expected_features = 4 + num_classes + kpt_features;
 
     // Parse output shape
@@ -1182,11 +1183,11 @@ fn postprocess_obb(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img, path, Arc::clone(&names), speed, inference_shape);
+    let num_classes = names.len().max(1);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     // OBB format: [xywh, class_scores..., rotation_angle]
     // features = 4 (bbox) + num_classes + 1 (angle)
-    let num_classes = names.len().max(1);
     let expected_features = 4 + num_classes + 1;
 
     // Parse output shape

--- a/src/results.rs
+++ b/src/results.rs
@@ -6,6 +6,7 @@
 //! the Python API for easy migration and consistent usage patterns.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ndarray::{Array1, Array2, Array3, ArrayView1, ArrayView2, Axis, s};
 
@@ -78,7 +79,7 @@ pub struct Results {
     /// Inference timing information.
     pub speed: Speed,
     /// Class ID to name mapping.
-    pub names: HashMap<usize, String>,
+    pub names: Arc<HashMap<usize, String>>,
     /// Path to the source image/video.
     pub path: String,
 }
@@ -101,7 +102,7 @@ impl Results {
     pub fn new(
         orig_img: Array3<u8>,
         path: String,
-        names: HashMap<usize, String>,
+        names: Arc<HashMap<usize, String>>,
         speed: Speed,
         inference_shape: (u32, u32),
     ) -> Self {
@@ -1002,7 +1003,7 @@ mod tests {
     }
     #[test]
     fn test_results_verbose() {
-        let names = HashMap::from([(0, "person".to_string())]);
+        let names = Arc::new(HashMap::from([(0, "person".to_string())]));
         let speed = Speed::default();
         let orig_img = Array3::zeros((100, 100, 3));
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,6 +6,7 @@
 
 use ndarray::Array3;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tempfile::tempdir;
 use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
@@ -133,7 +134,7 @@ fn test_boxes_conf_and_cls() {
 #[test]
 fn test_results_creation() {
     let orig_img = Array3::zeros((480, 640, 3));
-    let names = HashMap::new();
+    let names = Arc::new(HashMap::new());
     let speed = Speed::default();
 
     let results = Results::new(orig_img, "test.jpg".to_string(), names, speed, (640, 640));
@@ -148,7 +149,7 @@ fn test_results_creation() {
 #[test]
 fn test_results_with_boxes() {
     let orig_img = Array3::zeros((480, 640, 3));
-    let names = HashMap::new();
+    let names = Arc::new(HashMap::new());
     let speed = Speed::default();
 
     let mut results = Results::new(orig_img, "test.jpg".to_string(), names, speed, (640, 640));
@@ -164,7 +165,7 @@ fn test_results_with_boxes() {
 #[test]
 fn test_results_is_empty() {
     let orig_img = Array3::zeros((480, 640, 3));
-    let names = HashMap::new();
+    let names = Arc::new(HashMap::new());
     let speed = Speed::default();
 
     let results = Results::new(orig_img, "test.jpg".to_string(), names, speed, (640, 640));


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refactors class-name handling to use shared ownership (`Arc<HashMap<...>>`) across metadata, postprocessing, and results, improving efficiency and consistency without changing user-facing inference behavior 🚀

### 📊 Key Changes
- Replaced plain `HashMap` class-name storage with `Arc<HashMap<usize, String>>` in core structs like `ModelMetadata` and `Results` 🧠
- Updated postprocessing functions for all major tasks—detection, segmentation, pose, classification, OBB, and end-to-end variants—to accept shared class-name mappings instead of cloning full maps 🔄
- Adjusted model inference flow to pass shared class names with `Arc::clone(...)` where needed, reducing unnecessary copies ⚡
- Updated metadata YAML parsing so class names are first collected normally, then wrapped in `Arc` once parsing is complete 📦
- Modified the `YOLOModel::names()` accessor to return a standard `&HashMap` view from the shared data, preserving convenient read access 👀
- Refreshed unit and integration tests throughout the repo to match the new shared-name structure ✅

### 🎯 Purpose & Impact
- Reduces memory overhead by sharing one class-name map instead of repeatedly cloning it, especially helpful across multiple inference and postprocessing paths 💾
- Makes internal data flow more efficient and scalable for Rust-based inference workloads, particularly when results are passed around often ⚙️
- Keeps external behavior largely the same for users, so this is mainly a performance and maintainability improvement rather than a feature change 🙌
- Improves consistency across the codebase by standardizing how model class names are stored and propagated 🧩
- Lowers the chance of bugs or mismatches caused by duplicated metadata handling in different inference stages 🛡️