### PR TITLE
`ultralytics-inference 0.0.17` YOLO Semantic Segmentation models support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,7 +2692,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "ab_glyph",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 rust-version = "1.88"
 authors = [

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ ultralytics-inference predict --task segment  # downloads yolo26n-seg.onnx
 ultralytics-inference predict --task pose     # downloads yolo26n-pose.onnx
 ultralytics-inference predict --task obb      # downloads yolo26n-obb.onnx
 ultralytics-inference predict --task classify # downloads yolo26n-cls.onnx
+ultralytics-inference predict --task semseg   # downloads yolo26n-semseg.onnx (YOLO26 only)
 
 # With explicit model (task is read from model metadata)
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg
@@ -183,47 +184,52 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 **CLI Options:**
 
-| Option          | Short | Description                                                                                              | Default                                 |
-| --------------- | ----- | -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                            | `yolo26n.onnx`                          |
-| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect`                                |
-| `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                       | `Task dependent Ultralytics URL assets` |
-| `--conf`        |       | Confidence threshold                                                                                     | `0.25`                                  |
-| `--iou`         |       | IoU threshold for NMS                                                                                    | `0.7`                                   |
-| `--max-det`     |       | Maximum number of detections                                                                             | `300`                                   |
-| `--imgsz`       |       | Inference image size                                                                                     | `Model metadata`                        |
-| `--rect`        |       | Enable rectangular inference (minimal padding)                                                           | `true`                                  |
-| `--batch`       |       | Batch size for inference                                                                                 | `1`                                     |
-| `--half`        |       | Use FP16 half-precision inference                                                                        | `false`                                 |
-| `--save`        |       | Save annotated results to runs/\<task\>/predict                                                          | `true`                                  |
-| `--save-frames` |       | Save individual frames for video                                                                         | `false`                                 |
-| `--show`        |       | Display results in a window                                                                              | `false`                                 |
-| `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                  | `cpu`                                   |
-| `--verbose`     |       | Show verbose output                                                                                      | `true`                                  |
-| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                              | all classes                             |
+| Option          | Short | Description                                                                                                          | Default                                 |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                                        | `yolo26n.onnx`                          |
+| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semseg`\*); selects nano model when `--model` is omitted | `detect`                                |
+| `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                                   | `Task dependent Ultralytics URL assets` |
+| `--conf`        |       | Confidence threshold                                                                                                 | `0.25`                                  |
+| `--iou`         |       | IoU threshold for NMS                                                                                                | `0.7`                                   |
+| `--max-det`     |       | Maximum number of detections                                                                                         | `300`                                   |
+| `--imgsz`       |       | Inference image size                                                                                                 | `Model metadata`                        |
+| `--rect`        |       | Enable rectangular inference (minimal padding)                                                                       | `true`                                  |
+| `--batch`       |       | Batch size for inference                                                                                             | `1`                                     |
+| `--half`        |       | Use FP16 half-precision inference                                                                                    | `false`                                 |
+| `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                      | `true`                                  |
+| `--save-frames` |       | Save individual frames for video                                                                                     | `false`                                 |
+| `--show`        |       | Display results in a window                                                                                          | `false`                                 |
+| `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                              | `cpu`                                   |
+| `--verbose`     |       | Show verbose output                                                                                                  | `true`                                  |
+| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                                          | all classes                             |
 
 **Task and Model Resolution:**
 
-| Invocation                                        | Model used          | Notes                                                               |
-| ------------------------------------------------- | ------------------- | ------------------------------------------------------------------- |
-| `predict`                                         | `yolo26n.onnx`      | Default detect model, auto-downloaded                               |
-| `predict --task segment`                          | `yolo26n-seg.onnx`  | Nano seg model, auto-downloaded                                     |
-| `predict --task pose`                             | `yolo26n-pose.onnx` | Nano pose model, auto-downloaded                                    |
-| `predict --task obb`                              | `yolo26n-obb.onnx`  | Nano OBB model, auto-downloaded                                     |
-| `predict --task classify`                         | `yolo26n-cls.onnx`  | Nano classify model, auto-downloaded                                |
-| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`  | Task read from model metadata                                       |
-| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`  | `--task` matches metadata, proceeds normally                        |
-| `predict --task segment --model yolo26n.onnx`     | error               | `--task` conflicts with model metadata (`detect`), exits with error |
+| Invocation                                        | Model used              | Notes                                                               |
+| ------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
+| `predict`                                         | `yolo26n.onnx`          | Default detect model, auto-downloaded                               |
+| `predict --task segment`                          | `yolo26n-seg.onnx`      | Nano seg model, auto-downloaded                                     |
+| `predict --task pose`                             | `yolo26n-pose.onnx`     | Nano pose model, auto-downloaded                                    |
+| `predict --task obb`                              | `yolo26n-obb.onnx`      | Nano OBB model, auto-downloaded                                     |
+| `predict --task classify`                         | `yolo26n-cls.onnx`      | Nano classify model, auto-downloaded                                |
+| `predict --task semseg`                           | `yolo26n-semseg.onnx`\* | Nano semseg model, auto-downloaded (YOLO26 only)                    |
+| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`      | Task read from model metadata                                       |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`      | `--task` matches metadata, proceeds normally                        |
+| `predict --task segment --model yolo26n.onnx`     | error                   | `--task` conflicts with model metadata (`detect`), exits with error |
+
+\* `semseg` (semantic segmentation) is YOLO26-only.
 
 **Auto-downloadable models:**
 
-All YOLOv8, YOLO11, and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download:
+All YOLOv8, YOLO11, and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download. YOLO26 also includes a sixth variant, `-semseg`, for semantic segmentation (YOLO26 only):
 
-| Family | Variants                                                                        |
-| ------ | ------------------------------------------------------------------------------- |
-| YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
-| YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
-| YOLOv8 | `yolov8{n,s,m,l,x}.onnx`, `yolov8{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls` |
+| Family | Variants                                                                                     |
+| ------ | -------------------------------------------------------------------------------------------- |
+| YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`, `-semseg`\* |
+| YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`              |
+| YOLOv8 | `yolov8{n,s,m,l,x}.onnx`, `yolov8{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`              |
+
+\* `-semseg` (semantic segmentation) is YOLO26-only.
 
 **Source Options:**
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ inference/
 │   ├── postprocessing.rs   # Detection post-processing (NMS, decode, SIMD)
 │   ├── metadata.rs         # ONNX model metadata parsing
 │   ├── source.rs           # Input source handling (images, video, webcam)
-│   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb)
+│   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb, SemSeg)
 │   ├── inference.rs        # InferenceConfig
 │   ├── batch.rs            # Batch processing pipeline
 │   ├── device.rs           # Device enum (CPU, CUDA, CoreML, etc.)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--half`        |       | Use FP16 half-precision inference                                                                                      | `false`                                 |
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                        | `true`                                  |
 | `--save-frames` |       | Save individual frames for video                                                                                       | `false`                                 |
-| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation                        | `false`                                 |
+| `--save-json`   |       | Save semantic segmentation class-map PNGs for external evaluation                                                      | `false`                                 |
 | `--show`        |       | Display results in a window                                                                                            | `false`                                 |
 | `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                                | `cpu`                                   |
 | `--verbose`     |       | Show verbose output                                                                                                    | `true`                                  |

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ inference/
 │   ├── model.rs            # YOLOModel - ONNX session and inference
 │   ├── results.rs          # Results, Boxes, Masks, Keypoints, Probs, Obb, SemanticMask
 │   ├── preprocessing.rs    # Image preprocessing (letterbox, normalize, SIMD)
-│   ├── postprocessing.rs   # Detection post-processing (NMS, decode, SIMD)
+│   ├── postprocessing.rs   # Post-processing for all tasks (NMS/decode for detection, argmax for semantic segmentation)
 │   ├── metadata.rs         # ONNX model metadata parsing
 │   ├── source.rs           # Input source handling (images, video, webcam)
 │   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb, Semantic)
@@ -362,7 +362,7 @@ inference/
 │   ├── batch.rs            # Batch processing pipeline
 │   ├── device.rs           # Device enum (CPU, CUDA, CoreML, etc.)
 │   ├── download.rs         # Model and asset downloading
-│   ├── annotate.rs         # Image annotation (bounding boxes, masks, keypoints)
+│   ├── annotate.rs         # Image annotation (bounding boxes, instance masks, keypoints, semantic overlay)
 │   ├── io.rs               # Result saving (images, videos)
 │   ├── logging.rs          # Logging macros
 │   ├── error.rs            # Error types
@@ -514,10 +514,10 @@ ONNX Runtime threading is set to auto (`num_threads: 0`) which lets ORT choose o
 
 ### Completed
 
-- [x] Detection, Segmentation, Pose, Classification, OBB inference
+- [x] Detection, Segmentation, Pose, Classification, OBB, and Semantic Segmentation inference
 - [x] ONNX model metadata parsing (auto-detect classes, task, imgsz)
 - [x] Hardware acceleration support (CUDA, TensorRT, CoreML, OpenVINO, XNNPACK)
-- [x] Ultralytics-compatible Results API (`Boxes`, `Masks`, `Keypoints`, `Probs`, `Obb`)
+- [x] Ultralytics-compatible Results API (`Boxes`, `Masks`, `Keypoints`, `Probs`, `Obb`, `SemanticMask`)
 - [x] Multiple input sources (images, directories, globs, URLs)
 - [x] Video file support and webcam/RTSP streaming
 - [x] Image annotation and visualization

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ model.export(format="onnx")
 # With defaults (auto-downloads yolo26n.onnx and sample images)
 ultralytics-inference predict
 
-# Select task — auto-downloads the nano model for that task
+# Select task: auto-downloads the nano model for that task
 ultralytics-inference predict --task segment  # downloads yolo26n-seg.onnx
 ultralytics-inference predict --task pose     # downloads yolo26n-pose.onnx
 ultralytics-inference predict --task obb      # downloads yolo26n-obb.onnx
@@ -127,6 +127,9 @@ ultralytics-inference predict --model yolo26n.onnx --source video.mp4 --save-fra
 
 # Rectangular inference
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
+
+# Semantic segmentation: write per-image PNG class maps to runs/semseg/predictN/results/
+ultralytics-inference predict --task semseg --source cityscapes/ --save-json
 ```
 
 ### Example Output
@@ -198,6 +201,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--half`        |       | Use FP16 half-precision inference                                                                                    | `false`                                 |
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                      | `true`                                  |
 | `--save-frames` |       | Save individual frames for video                                                                                     | `false`                                 |
+| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation                        | `false`                                 |
 | `--show`        |       | Display results in a window                                                                                          | `false`                                 |
 | `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                              | `cpu`                                   |
 | `--verbose`     |       | Show verbose output                                                                                                  | `true`                                  |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ultralytics-inference predict --task segment  # downloads yolo26n-seg.onnx
 ultralytics-inference predict --task pose     # downloads yolo26n-pose.onnx
 ultralytics-inference predict --task obb      # downloads yolo26n-obb.onnx
 ultralytics-inference predict --task classify # downloads yolo26n-cls.onnx
-ultralytics-inference predict --task semseg   # downloads yolo26n-semseg.onnx (YOLO26 only)
+ultralytics-inference predict --task semseg   # downloads yolo26n-sem.onnx (YOLO26 only)
 
 # With explicit model (task is read from model metadata)
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg
@@ -216,7 +216,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `predict --task pose`                             | `yolo26n-pose.onnx`     | Nano pose model, auto-downloaded                                    |
 | `predict --task obb`                              | `yolo26n-obb.onnx`      | Nano OBB model, auto-downloaded                                     |
 | `predict --task classify`                         | `yolo26n-cls.onnx`      | Nano classify model, auto-downloaded                                |
-| `predict --task semseg`                           | `yolo26n-semseg.onnx`\* | Nano semseg model, auto-downloaded (YOLO26 only)                    |
+| `predict --task semseg`                           | `yolo26n-sem.onnx`\*    | Nano semseg model, auto-downloaded (YOLO26 only)                    |
 | `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`      | Task read from model metadata                                       |
 | `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`      | `--task` matches metadata, proceeds normally                        |
 | `predict --task segment --model yolo26n.onnx`     | error                   | `--task` conflicts with model metadata (`detect`), exits with error |
@@ -225,15 +225,15 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 **Auto-downloadable models:**
 
-All YOLOv8, YOLO11, and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download. YOLO26 also includes a sixth variant, `-semseg`, for semantic segmentation (YOLO26 only):
+All YOLOv8, YOLO11, and YOLO26 ONNX models in sizes **n / s / m / l / x** across all five task variants are supported for auto-download. YOLO26 also includes a sixth variant, `-sem`, for semantic segmentation (YOLO26 only):
 
-| Family | Variants                                                                                     |
-| ------ | -------------------------------------------------------------------------------------------- |
-| YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`, `-semseg`\* |
-| YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`              |
-| YOLOv8 | `yolov8{n,s,m,l,x}.onnx`, `yolov8{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`              |
+| Family | Variants                                                                                  |
+| ------ | ----------------------------------------------------------------------------------------- |
+| YOLO26 | `yolo26{n,s,m,l,x}.onnx`, `yolo26{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`, `-sem`\* |
+| YOLO11 | `yolo11{n,s,m,l,x}.onnx`, `yolo11{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`           |
+| YOLOv8 | `yolov8{n,s,m,l,x}.onnx`, `yolov8{n,s,m,l,x}-seg.onnx`, `-pose`, `-obb`, `-cls`           |
 
-\* `-semseg` (semantic segmentation) is YOLO26-only.
+\* `-sem` (semantic segmentation) is YOLO26-only.
 
 **Source Options:**
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 ## ✨ Features
 
 - 🚀 **High Performance** - Pure Rust implementation with zero-cost abstractions
-- 🎯 **Ultralytics API Compatible** - `Results`, `Boxes`, `Masks`, `Keypoints`, `Probs` classes matching Python
+- 🎯 **Ultralytics API Compatible** - `Results`, `Boxes`, `Masks`, `Keypoints`, `Probs`, `SemanticMask` classes matching Python
 - 🔧 **Multiple Backends** - CPU, CUDA, TensorRT, CoreML, OpenVINO, and more via ONNX Runtime
 - 📦 **Dual Use** - Library for Rust projects + standalone CLI application
 - 🏷️ **Auto Metadata** - Automatically reads class names, task type, and input size from ONNX models

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`      | `--task` matches metadata, proceeds normally                        |
 | `predict --task segment --model yolo26n.onnx`     | error                   | `--task` conflicts with model metadata (`detect`), exits with error |
 
-\* `semantic` (semantic segmentation) is YOLO26-only. The alias `semseg` is also accepted for backward compatibility.
+\* `semantic` (semantic segmentation) is YOLO26-only.
 
 **Auto-downloadable models:**
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ultralytics-inference predict --task segment  # downloads yolo26n-seg.onnx
 ultralytics-inference predict --task pose     # downloads yolo26n-pose.onnx
 ultralytics-inference predict --task obb      # downloads yolo26n-obb.onnx
 ultralytics-inference predict --task classify # downloads yolo26n-cls.onnx
-ultralytics-inference predict --task semseg   # downloads yolo26n-sem.onnx (YOLO26 only)
+ultralytics-inference predict --task semantic  # downloads yolo26n-sem.onnx (YOLO26 only)
 
 # With explicit model (task is read from model metadata)
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg
@@ -128,8 +128,8 @@ ultralytics-inference predict --model yolo26n.onnx --source video.mp4 --save-fra
 # Rectangular inference
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
 
-# Semantic segmentation: write per-image PNG class maps to runs/semseg/predictN/results/
-ultralytics-inference predict --task semseg --source cityscapes/ --save-json
+# Semantic segmentation: write per-image PNG class maps to runs/semantic/predictN/results/
+ultralytics-inference predict --task semantic --source cityscapes/ --save-json
 ```
 
 ### Example Output
@@ -190,7 +190,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | Option          | Short | Description                                                                                                          | Default                                 |
 | --------------- | ----- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 | `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                                        | `yolo26n.onnx`                          |
-| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semseg`\*); selects nano model when `--model` is omitted | `detect`                                |
+| `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semantic`\*); selects nano model when `--model` is omitted | `detect`                                |
 | `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                                   | `Task dependent Ultralytics URL assets` |
 | `--conf`        |       | Confidence threshold                                                                                                 | `0.25`                                  |
 | `--iou`         |       | IoU threshold for NMS                                                                                                | `0.7`                                   |
@@ -201,7 +201,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--half`        |       | Use FP16 half-precision inference                                                                                    | `false`                                 |
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                      | `true`                                  |
 | `--save-frames` |       | Save individual frames for video                                                                                     | `false`                                 |
-| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation                        | `false`                                 |
+| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation                      | `false`                                 |
 | `--show`        |       | Display results in a window                                                                                          | `false`                                 |
 | `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                              | `cpu`                                   |
 | `--verbose`     |       | Show verbose output                                                                                                  | `true`                                  |
@@ -216,12 +216,12 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `predict --task pose`                             | `yolo26n-pose.onnx`     | Nano pose model, auto-downloaded                                    |
 | `predict --task obb`                              | `yolo26n-obb.onnx`      | Nano OBB model, auto-downloaded                                     |
 | `predict --task classify`                         | `yolo26n-cls.onnx`      | Nano classify model, auto-downloaded                                |
-| `predict --task semseg`                           | `yolo26n-sem.onnx`\*    | Nano semseg model, auto-downloaded (YOLO26 only)                    |
+| `predict --task semantic`                         | `yolo26n-sem.onnx`\*    | Nano semantic segmentation model, auto-downloaded (YOLO26 only)     |
 | `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`      | Task read from model metadata                                       |
 | `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`      | `--task` matches metadata, proceeds normally                        |
 | `predict --task segment --model yolo26n.onnx`     | error                   | `--task` conflicts with model metadata (`detect`), exits with error |
 
-\* `semseg` (semantic segmentation) is YOLO26-only.
+\* `semantic` (semantic segmentation) is YOLO26-only. The alias `semseg` is also accepted for backward compatibility.
 
 **Auto-downloadable models:**
 
@@ -357,7 +357,7 @@ inference/
 │   ├── postprocessing.rs   # Detection post-processing (NMS, decode, SIMD)
 │   ├── metadata.rs         # ONNX model metadata parsing
 │   ├── source.rs           # Input source handling (images, video, webcam)
-│   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb, SemSeg)
+│   ├── task.rs             # Task enum (Detect, Segment, Pose, Classify, Obb, Semantic)
 │   ├── inference.rs        # InferenceConfig
 │   ├── batch.rs            # Batch processing pipeline
 │   ├── device.rs           # Device enum (CPU, CUDA, CoreML, etc.)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ ultralytics-inference predict --task semantic --source cityscapes/ --save-json
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.16 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.17 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -157,7 +157,7 @@ Results saved to runs/detect/predict1
 
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.16 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.17 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -253,7 +253,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.16"
+ultralytics-inference = "0.0.17"
 ```
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ inference/
 │   ├── lib.rs              # Library entry point and public exports
 │   ├── main.rs             # CLI application
 │   ├── model.rs            # YOLOModel - ONNX session and inference
-│   ├── results.rs          # Results, Boxes, Masks, Keypoints, Probs, Obb
+│   ├── results.rs          # Results, Boxes, Masks, Keypoints, Probs, Obb, SemanticMask
 │   ├── preprocessing.rs    # Image preprocessing (letterbox, normalize, SIMD)
 │   ├── postprocessing.rs   # Detection post-processing (NMS, decode, SIMD)
 │   ├── metadata.rs         # ONNX model metadata parsing

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ultralytics-inference predict --task segment  # downloads yolo26n-seg.onnx
 ultralytics-inference predict --task pose     # downloads yolo26n-pose.onnx
 ultralytics-inference predict --task obb      # downloads yolo26n-obb.onnx
 ultralytics-inference predict --task classify # downloads yolo26n-cls.onnx
-ultralytics-inference predict --task semantic  # downloads yolo26n-sem.onnx (YOLO26 only)
+ultralytics-inference predict --task semantic # downloads yolo26n-sem.onnx (YOLO26 only)
 
 # With explicit model (task is read from model metadata)
 ultralytics-inference predict --model yolo26n.onnx --source image.jpg
@@ -187,39 +187,39 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 **CLI Options:**
 
-| Option          | Short | Description                                                                                                          | Default                                 |
-| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                                        | `yolo26n.onnx`                          |
+| Option          | Short | Description                                                                                                            | Default                                 |
+| --------------- | ----- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `--model`       | `-m`  | Path to ONNX model file; auto-downloaded if a known YOLOv8/YOLO11/YOLO26 name                                          | `yolo26n.onnx`                          |
 | `--task`        |       | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semantic`\*); selects nano model when `--model` is omitted | `detect`                                |
-| `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                                   | `Task dependent Ultralytics URL assets` |
-| `--conf`        |       | Confidence threshold                                                                                                 | `0.25`                                  |
-| `--iou`         |       | IoU threshold for NMS                                                                                                | `0.7`                                   |
-| `--max-det`     |       | Maximum number of detections                                                                                         | `300`                                   |
-| `--imgsz`       |       | Inference image size                                                                                                 | `Model metadata`                        |
-| `--rect`        |       | Enable rectangular inference (minimal padding)                                                                       | `true`                                  |
-| `--batch`       |       | Batch size for inference                                                                                             | `1`                                     |
-| `--half`        |       | Use FP16 half-precision inference                                                                                    | `false`                                 |
-| `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                      | `true`                                  |
-| `--save-frames` |       | Save individual frames for video                                                                                     | `false`                                 |
-| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation                      | `false`                                 |
-| `--show`        |       | Display results in a window                                                                                          | `false`                                 |
-| `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                              | `cpu`                                   |
-| `--verbose`     |       | Show verbose output                                                                                                  | `true`                                  |
-| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                                          | all classes                             |
+| `--source`      | `-s`  | Input source (image, directory, glob, video, webcam index, or URL)                                                     | `Task dependent Ultralytics URL assets` |
+| `--conf`        |       | Confidence threshold                                                                                                   | `0.25`                                  |
+| `--iou`         |       | IoU threshold for NMS                                                                                                  | `0.7`                                   |
+| `--max-det`     |       | Maximum number of detections                                                                                           | `300`                                   |
+| `--imgsz`       |       | Inference image size                                                                                                   | `Model metadata`                        |
+| `--rect`        |       | Enable rectangular inference (minimal padding)                                                                         | `true`                                  |
+| `--batch`       |       | Batch size for inference                                                                                               | `1`                                     |
+| `--half`        |       | Use FP16 half-precision inference                                                                                      | `false`                                 |
+| `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                        | `true`                                  |
+| `--save-frames` |       | Save individual frames for video                                                                                       | `false`                                 |
+| `--save-json`   |       | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation                        | `false`                                 |
+| `--show`        |       | Display results in a window                                                                                            | `false`                                 |
+| `--device`      |       | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)                                                | `cpu`                                   |
+| `--verbose`     |       | Show verbose output                                                                                                    | `true`                                  |
+| `--classes`     |       | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"`                                                            | all classes                             |
 
 **Task and Model Resolution:**
 
-| Invocation                                        | Model used              | Notes                                                               |
-| ------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- |
-| `predict`                                         | `yolo26n.onnx`          | Default detect model, auto-downloaded                               |
-| `predict --task segment`                          | `yolo26n-seg.onnx`      | Nano seg model, auto-downloaded                                     |
-| `predict --task pose`                             | `yolo26n-pose.onnx`     | Nano pose model, auto-downloaded                                    |
-| `predict --task obb`                              | `yolo26n-obb.onnx`      | Nano OBB model, auto-downloaded                                     |
-| `predict --task classify`                         | `yolo26n-cls.onnx`      | Nano classify model, auto-downloaded                                |
-| `predict --task semantic`                         | `yolo26n-sem.onnx`\*    | Nano semantic segmentation model, auto-downloaded (YOLO26 only)     |
-| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`      | Task read from model metadata                                       |
-| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`      | `--task` matches metadata, proceeds normally                        |
-| `predict --task segment --model yolo26n.onnx`     | error                   | `--task` conflicts with model metadata (`detect`), exits with error |
+| Invocation                                        | Model used           | Notes                                                               |
+| ------------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
+| `predict`                                         | `yolo26n.onnx`       | Default detect model, auto-downloaded                               |
+| `predict --task segment`                          | `yolo26n-seg.onnx`   | Nano seg model, auto-downloaded                                     |
+| `predict --task pose`                             | `yolo26n-pose.onnx`  | Nano pose model, auto-downloaded                                    |
+| `predict --task obb`                              | `yolo26n-obb.onnx`   | Nano OBB model, auto-downloaded                                     |
+| `predict --task classify`                         | `yolo26n-cls.onnx`   | Nano classify model, auto-downloaded                                |
+| `predict --task semantic`                         | `yolo26n-sem.onnx`\* | Nano semantic segmentation model, auto-downloaded (YOLO26 only)     |
+| `predict --model yolo26l-seg.onnx`                | `yolo26l-seg.onnx`   | Task read from model metadata                                       |
+| `predict --task segment --model yolo26l-seg.onnx` | `yolo26l-seg.onnx`   | `--task` matches metadata, proceeds normally                        |
+| `predict --task segment --model yolo26n.onnx`     | error                | `--task` conflicts with model metadata (`detect`), exits with error |
 
 \* `semantic` (semantic segmentation) is YOLO26-only.
 

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -261,11 +261,11 @@ fn draw_semantic_mask(img: &mut image::RgbImage, result: &Results) {
         return;
     };
     let (width, height) = img.dimensions();
-    for y in 0..height as usize {
-        for x in 0..width as usize {
-            let class_id = semantic_mask.data[[y, x]] as usize;
+    for y in 0..height {
+        for x in 0..width {
+            let class_id = semantic_mask.data[[y as usize, x as usize]] as usize;
             let color = COLORS[class_id % COLORS.len()];
-            let pixel = img.get_pixel_mut(x as u32, y as u32);
+            let pixel = img.get_pixel_mut(x, y);
             pixel[0] = (pixel[0] / 2).saturating_add(color[0] / 2);
             pixel[1] = (pixel[1] / 2).saturating_add(color[1] / 2);
             pixel[2] = (pixel[2] / 2).saturating_add(color[2] / 2);

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -29,24 +29,7 @@ pub const fn get_class_color(class_id: usize) -> Rgb<u8> {
 /// Find the next available run directory (predict, predict2, predict3, etc.)
 #[must_use]
 pub fn find_next_run_dir(base: &str, prefix: &str) -> String {
-    let base_path = Path::new(base);
-
-    // First try without number
-    let first = base_path.join(prefix);
-    if !first.exists() {
-        return first.to_string_lossy().to_string();
-    }
-
-    // Try with incrementing numbers
-    for i in 2.. {
-        let numbered = base_path.join(format!("{prefix}{i}"));
-        if !numbered.exists() {
-            return numbered.to_string_lossy().to_string();
-        }
-    }
-
-    // Fallback (should never reach here)
-    base_path.join(prefix).to_string_lossy().to_string()
+    crate::io::find_next_run_dir(base, prefix)
 }
 
 /// Load image helper to bypass zune-jpeg stride issues

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -162,6 +162,7 @@ pub fn annotate_image(
         .and_then(|data| FontRef::try_from_slice(data).ok());
 
     // Draw all annotations using helpers
+    draw_semantic_mask(&mut img, result);
     draw_detection(&mut img, result, font.as_ref());
     draw_pose(&mut img, result, None, None, None);
     draw_obb(&mut img, result, font.as_ref());
@@ -250,6 +251,24 @@ fn draw_filled_circle(img: &mut image::RgbImage, cx: i32, cy: i32, radius: i32, 
             {
                 img.put_pixel(x as u32, y as u32, color);
             }
+        }
+    }
+}
+
+/// Overlay semantic segmentation class colors at 50% alpha.
+fn draw_semantic_mask(img: &mut image::RgbImage, result: &Results) {
+    let Some(ref semantic_mask) = result.semantic_mask else {
+        return;
+    };
+    let (width, height) = img.dimensions();
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let class_id = semantic_mask.data[[y, x]] as usize;
+            let color = COLORS[class_id % COLORS.len()];
+            let pixel = img.get_pixel_mut(x as u32, y as u32);
+            pixel[0] = (pixel[0] / 2).saturating_add(color[0] / 2);
+            pixel[1] = (pixel[1] / 2).saturating_add(color[1] / 2);
+            pixel[2] = (pixel[2] / 2).saturating_add(color[2] / 2);
         }
     }
 }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -133,7 +133,8 @@ pub fn check_font(font: &str) -> Option<PathBuf> {
     }
 }
 
-/// Annotate an image with detection boxes and labels
+/// Annotate an image with detection boxes, instance masks, keypoints, OBB boxes, classification
+/// labels, or a semantic segmentation overlay depending on the result type.
 #[must_use]
 pub fn annotate_image(
     image: &DynamicImage,
@@ -255,7 +256,10 @@ fn draw_filled_circle(img: &mut image::RgbImage, cx: i32, cy: i32, radius: i32, 
     }
 }
 
-/// Overlay semantic segmentation class colors at 50% alpha.
+/// Overlay semantic segmentation class colors at 50% alpha onto `img`.
+///
+/// Each pixel is colorized using `COLORS[class_id % COLORS.len()]` blended 50/50 with
+/// the original pixel. A no-op when `result.semantic_mask` is `None`.
 fn draw_semantic_mask(img: &mut image::RgbImage, result: &Results) {
     let Some(ref semantic_mask) = result.semantic_mask else {
         return;

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -248,14 +248,24 @@ fn draw_semantic_mask(img: &mut image::RgbImage, result: &Results) {
         return;
     };
     let (width, height) = img.dimensions();
-    for y in 0..height {
-        for x in 0..width {
-            let class_id = semantic_mask.data[[y as usize, x as usize]] as usize;
-            let color = COLORS[class_id % COLORS.len()];
-            let pixel = img.get_pixel_mut(x, y);
-            pixel[0] = (pixel[0] / 2).saturating_add(color[0] / 2);
-            pixel[1] = (pixel[1] / 2).saturating_add(color[1] / 2);
-            pixel[2] = (pixel[2] / 2).saturating_add(color[2] / 2);
+    let w = width as usize;
+    let mask_data = semantic_mask
+        .data
+        .as_slice()
+        .expect("semantic mask must be contiguous");
+    let pixels = img.as_flat_samples_mut();
+    let buf = pixels.samples;
+    let n_colors = COLORS.len();
+    for y in 0..height as usize {
+        let mask_row = y * w;
+        let img_row = y * w * 3;
+        for x in 0..w {
+            let class_id = mask_data[mask_row + x] as usize;
+            let color = COLORS[class_id % n_colors];
+            let p = img_row + x * 3;
+            buf[p] = (buf[p] / 2).saturating_add(color[0] / 2);
+            buf[p + 1] = (buf[p + 1] / 2).saturating_add(color[1] / 2);
+            buf[p + 2] = (buf[p + 2] / 2).saturating_add(color[2] / 2);
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -10,7 +10,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(propagate_version = true)]
 #[command(after_help = r#"Predict Options:
     --model, -m <MODEL>    Path to ONNX model file [default: yolo26n.onnx]
-    --task <TASK>          Task type: detect, segment, pose, obb, classify [default: detect]
+    --task <TASK>          Task type: detect, segment, pose, obb, classify, semseg [default: detect]
                            Selects the matching nano model when --model is omitted
     --source, -s <SOURCE>  Input source (image, directory, glob, video, webcam, or URL)
     --conf <CONF>          Confidence threshold [default: 0.25]
@@ -34,6 +34,7 @@ Examples:
     ultralytics-inference predict --task pose
     ultralytics-inference predict --task obb --source aerial.jpg
     ultralytics-inference predict --task classify --source image.jpg
+    ultralytics-inference predict --task semseg --source image.jpg
     ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
@@ -65,7 +66,7 @@ pub struct PredictArgs {
     pub model: Option<String>,
 
     /// Task type; selects nano model for auto-download when --model is omitted
-    /// (detect, segment, pose, obb, classify)
+    /// (detect, segment, pose, obb, classify, semseg)
     #[arg(long)]
     pub task: Option<Task>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -22,7 +22,7 @@ use clap::{Args, Parser, Subcommand};
     --half                 Use FP16 half-precision inference [default: false]
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
-    --save-json            Save semantic segmentation masks (PNG) / detect/segment/pose (COCO JSON) for eval
+    --save-json            Save semantic segmentation class-map PNGs for external evaluation
     --show                 Display results in a window [default: false]
     --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)
     --verbose              Show verbose output [default: true]
@@ -110,7 +110,7 @@ pub struct PredictArgs {
     #[arg(long, default_value_t = InferenceConfig::DEFAULT_SAVE_FRAMES)]
     pub save_frames: bool,
 
-    /// Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation
+    /// Save semantic segmentation class-map PNGs for external evaluation
     #[arg(long, default_value_t = false)]
     pub save_json: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -10,7 +10,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(propagate_version = true)]
 #[command(after_help = r#"Predict Options:
     --model, -m <MODEL>    Path to ONNX model file [default: yolo26n.onnx]
-    --task <TASK>          Task type: detect, segment, pose, obb, classify, semseg [default: detect]
+    --task <TASK>          Task type: detect, segment, pose, obb, classify, semantic [default: detect]
                            Selects the matching nano model when --model is omitted
     --source, -s <SOURCE>  Input source (image, directory, glob, video, webcam, or URL)
     --conf <CONF>          Confidence threshold [default: 0.25]
@@ -22,7 +22,7 @@ use clap::{Args, Parser, Subcommand};
     --half                 Use FP16 half-precision inference [default: false]
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
-    --save-json            Save semseg masks (PNG) / detect/segment/pose (COCO JSON) for eval
+    --save-json            Save semantic segmentation masks (PNG) / detect/segment/pose (COCO JSON) for eval
     --show                 Display results in a window [default: false]
     --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)
     --verbose              Show verbose output [default: true]
@@ -34,7 +34,7 @@ Examples:
     ultralytics-inference predict --task pose
     ultralytics-inference predict --task obb --source aerial.jpg
     ultralytics-inference predict --task classify --source image.jpg
-    ultralytics-inference predict --task semseg --source image.jpg
+    ultralytics-inference predict --task semantic --source image.jpg
     ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
@@ -66,7 +66,7 @@ pub struct PredictArgs {
     pub model: Option<String>,
 
     /// Task type; selects nano model for auto-download when --model is omitted
-    /// (detect, segment, pose, obb, classify, semseg)
+    /// (detect, segment, pose, obb, classify, semantic)
     #[arg(long)]
     pub task: Option<Task>,
 
@@ -110,7 +110,7 @@ pub struct PredictArgs {
     #[arg(long, default_value_t = InferenceConfig::DEFAULT_SAVE_FRAMES)]
     pub save_frames: bool,
 
-    /// Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation
+    /// Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation
     #[arg(long, default_value_t = false)]
     pub save_json: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -22,6 +22,7 @@ use clap::{Args, Parser, Subcommand};
     --half                 Use FP16 half-precision inference [default: false]
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
+    --save-json            Save semseg masks (PNG) / detect/segment/pose (COCO JSON) for eval
     --show                 Display results in a window [default: false]
     --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)
     --verbose              Show verbose output [default: true]
@@ -107,6 +108,10 @@ pub struct PredictArgs {
     /// Save individual frames for video input (instead of video file)
     #[arg(long, default_value_t = InferenceConfig::DEFAULT_SAVE_FRAMES)]
     pub save_frames: bool,
+
+    /// Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation
+    #[arg(long, default_value_t = false)]
+    pub save_json: bool,
 
     /// Display results in a window
     #[arg(long, default_value_t = false)]

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -6,7 +6,6 @@ use std::process;
 #[cfg(feature = "visualize")]
 use std::time::Duration;
 
-#[cfg(feature = "annotate")]
 use std::fs;
 
 #[cfg(feature = "annotate")]
@@ -48,6 +47,8 @@ pub fn run_prediction(args: &PredictArgs) {
     let imgsz = args.imgsz;
     let save = args.save;
     let save_frames = args.save_frames;
+    let save_semantic_mask = args.save_semantic_mask;
+    let semantic_mask_dir_override = args.semantic_mask_dir.clone();
     let half = args.half;
     let verbose = args.verbose;
     let batch_size = args.batch as usize;
@@ -173,6 +174,32 @@ pub fn run_prediction(args: &PredictArgs) {
             process::exit(1);
         }
         Some(std::path::PathBuf::from(dir))
+    } else {
+        None
+    };
+
+    let semantic_mask_dir: Option<std::path::PathBuf> = if save_semantic_mask {
+        let dir = semantic_mask_dir_override.map_or_else(
+            || {
+                #[cfg(feature = "annotate")]
+                {
+                    save_dir.as_ref().map_or_else(
+                        || std::path::PathBuf::from("runs/semseg/semantic_masks"),
+                        |d| d.join("semantic_masks"),
+                    )
+                }
+                #[cfg(not(feature = "annotate"))]
+                {
+                    std::path::PathBuf::from("runs/semseg/semantic_masks")
+                }
+            },
+            std::path::PathBuf::from,
+        );
+        if let Err(e) = fs::create_dir_all(&dir) {
+            error!("Failed to create semantic-mask directory '{}': {e}", dir.display());
+            process::exit(1);
+        }
+        Some(dir)
     } else {
         None
     };
@@ -317,6 +344,25 @@ pub fn run_prediction(args: &PredictArgs) {
                                 detection_summary,
                                 result.speed.inference.unwrap_or(0.0)
                             );
+                        }
+
+                        if let Some(ref cdir) = semantic_mask_dir
+                            && let Some(ref sm) = result.semantic_mask
+                        {
+                            let stem = std::path::Path::new(image_path).file_stem().map_or_else(
+                                || format!("frame_{}", meta.frame_idx),
+                                |s| s.to_string_lossy().into_owned(),
+                            );
+                            let out_path = cdir.join(format!("{stem}.png"));
+                            let (h, w) = (sm.data.shape()[0], sm.data.shape()[1]);
+                            let buf: Vec<u8> =
+                                sm.data.iter().map(|v| (*v).min(255) as u8).collect();
+                            if let Some(gray) =
+                                image::GrayImage::from_raw(w as u32, h as u32, buf)
+                                && let Err(e) = gray.save(&out_path)
+                            {
+                                error!("Failed to save semantic mask '{}': {e}", out_path.display());
+                            }
                         }
 
                         #[cfg(feature = "annotate")]

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -165,13 +165,13 @@ pub fn run_prediction(args: &PredictArgs) {
         );
     }
 
-    // Determine whether we need an incremented predict dir. `--save` always needs one;
-    // `--save-json` for semantic segmentation also needs one so PNG class maps land in <predictN>/results/
+    // Determine whether we need an incremented predict dir. `--save` always needs one
+    // when annotation support is compiled in; semantic class-map export also needs one.
+    #[cfg(feature = "annotate")]
+    let need_predict_dir = save || (save_json && model.task() == crate::task::Task::Semantic);
+    #[cfg(not(feature = "annotate"))]
     let need_predict_dir = save_json && model.task() == crate::task::Task::Semantic;
-    #[cfg(feature = "annotate")]
-    let need_predict_dir = save || need_predict_dir;
 
-    #[cfg(feature = "annotate")]
     let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
         let parent_dir = match model.task() {
             crate::task::Task::Detect => "runs/detect",
@@ -187,18 +187,6 @@ pub fn run_prediction(args: &PredictArgs) {
             process::exit(1);
         }
         Some(std::path::PathBuf::from(dir))
-    } else {
-        None
-    };
-    // Without the `annotate` feature, `--save` is rejected below; classmap save still works.
-    #[cfg(not(feature = "annotate"))]
-    let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
-        let dir = std::path::PathBuf::from(find_next_run_dir("runs/semantic", "predict"));
-        if let Err(e) = fs::create_dir_all(&dir) {
-            error!("Failed to create save directory '{}': {e}", dir.display());
-            process::exit(1);
-        }
-        Some(dir)
     } else {
         None
     };
@@ -386,7 +374,7 @@ pub fn run_prediction(args: &PredictArgs) {
                                     "Semantic class IDs exceed 255 (max={max_id}); saving 16-bit PNG: {}",
                                     out_path.display()
                                 );
-                                let buf: Vec<u16> = sm.data.iter().map(|&v| v as u16).collect();
+                                let buf: Vec<u16> = sm.data.iter().copied().collect();
                                 if let Some(img16) =
                                     image::ImageBuffer::<image::Luma<u16>, Vec<u16>>::from_raw(
                                         w as u32, h as u32, buf,
@@ -545,11 +533,7 @@ fn format_class_counts(
 fn format_detection_summary(result: &Results) -> String {
     // Semantic segmentation: report unique class count present in the mask.
     if let Some(ref sm) = result.semantic_mask {
-        let mut seen = std::collections::HashSet::new();
-        for &v in &sm.data {
-            seen.insert(v);
-        }
-        let n = seen.len();
+        let n = sm.classes_present();
         return format!("{n} {}", if n == 1 { "class" } else { "classes" });
     }
 
@@ -581,7 +565,7 @@ fn format_detection_summary(result: &Results) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::results::{Boxes, Obb, Probs, Results, Speed};
+    use crate::results::{Boxes, Obb, Probs, Results, SemanticMask, Speed};
     use ndarray::{Array2, Array3};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -665,6 +649,24 @@ mod tests {
 
         let summary = format_detection_summary(&result);
         assert_eq!(summary, "(no detections)");
+    }
+
+    #[test]
+    fn test_format_summary_semantic_mask() {
+        let mut result = Results::new(
+            create_dummy_image(),
+            "test.jpg".to_string(),
+            create_names(),
+            Speed::default(),
+            (640, 640),
+        );
+        result.semantic_mask = Some(SemanticMask::new(
+            Array2::from_shape_vec((2, 3), vec![0u16, 1, 1, 2, 2, 2]).unwrap(),
+            (2, 3),
+        ));
+
+        let summary = format_detection_summary(&result);
+        assert_eq!(summary, "3 classes");
     }
 
     /// Test `format_detection_summary` with OBB detections.

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -535,6 +535,16 @@ fn format_class_counts(
 /// Format detection summary like "4 persons, 1 bus".
 #[allow(clippy::option_if_let_else)]
 fn format_detection_summary(result: &Results) -> String {
+    // Semantic segmentation: report unique class count present in the mask.
+    if let Some(ref sm) = result.semantic_mask {
+        let mut seen = std::collections::HashSet::new();
+        for &v in &sm.data {
+            seen.insert(v);
+        }
+        let n = seen.len();
+        return format!("{n} {}", if n == 1 { "class" } else { "classes" });
+    }
+
     let summary = if let Some(ref boxes) = result.boxes {
         format_class_counts(&boxes.cls(), boxes.len(), &result.names)
     } else if let Some(ref obb) = result.obb {

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -159,7 +159,7 @@ pub fn run_prediction(args: &PredictArgs) {
 
     // Determine whether we need an incremented predict dir. `--save` always needs one;
     // `--save-json` for semseg also needs one so PNG class maps land in <predictN>/results/
-    let need_predict_dir = save_json && model.task() == crate::task::Task::SemSeg;
+    let need_predict_dir = save_json && model.task() == crate::task::Task::Semantic;
     #[cfg(feature = "annotate")]
     let need_predict_dir = save || need_predict_dir;
 
@@ -171,7 +171,7 @@ pub fn run_prediction(args: &PredictArgs) {
             crate::task::Task::Pose => "runs/pose",
             crate::task::Task::Classify => "runs/classify",
             crate::task::Task::Obb => "runs/obb",
-            crate::task::Task::SemSeg => "runs/semseg",
+            crate::task::Task::Semantic => "runs/semseg",
         };
         let dir = find_next_run_dir(parent_dir, "predict");
         if let Err(e) = fs::create_dir_all(&dir) {
@@ -197,7 +197,7 @@ pub fn run_prediction(args: &PredictArgs) {
 
     // Per-image PNG class maps go in `<save_dir>/results/<stem>.png`.
     let results_dir: Option<std::path::PathBuf> = save_dir.as_ref().and_then(|d| {
-        if !save_json || model.task() != crate::task::Task::SemSeg {
+        if !save_json || model.task() != crate::task::Task::Semantic {
             return None;
         }
         let dir = d.join("results");

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -405,7 +405,7 @@ pub fn run_prediction(args: &PredictArgs) {
                         }
 
                         #[cfg(feature = "annotate")]
-                        if save_dir.is_some() {
+                        if save {
                             let annotated = annotate_image(img, &result, None);
 
                             if let Some(saver) = &mut result_saver

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -47,8 +47,7 @@ pub fn run_prediction(args: &PredictArgs) {
     let imgsz = args.imgsz;
     let save = args.save;
     let save_frames = args.save_frames;
-    let save_semantic_mask = args.save_semantic_mask;
-    let semantic_mask_dir_override = args.semantic_mask_dir.clone();
+    let save_json = args.save_json;
     let half = args.half;
     let verbose = args.verbose;
     let batch_size = args.batch as usize;
@@ -178,25 +177,32 @@ pub fn run_prediction(args: &PredictArgs) {
         None
     };
 
-    let semantic_mask_dir: Option<std::path::PathBuf> = if save_semantic_mask {
-        let dir = semantic_mask_dir_override.map_or_else(
-            || {
-                #[cfg(feature = "annotate")]
-                {
-                    save_dir.as_ref().map_or_else(
-                        || std::path::PathBuf::from("runs/semseg/semantic_masks"),
-                        |d| d.join("semantic_masks"),
-                    )
-                }
-                #[cfg(not(feature = "annotate"))]
-                {
-                    std::path::PathBuf::from("runs/semseg/semantic_masks")
-                }
-            },
-            std::path::PathBuf::from,
-        );
+    // Matches Ultralytics' val.py for semseg: when --save-json is set, write per-image
+    // PNG class maps into `<save_dir>/results/<image_stem>.png`. Requires --save (which
+    // creates save_dir) and task == SemSeg; ignored otherwise.
+    #[cfg(feature = "annotate")]
+    let results_dir: Option<std::path::PathBuf> = if save_json
+        && model.task() == crate::task::Task::SemSeg
+    {
+        let dir = save_dir
+            .as_ref()
+            .map(|d| d.join("results"))
+            .unwrap_or_else(|| std::path::PathBuf::from("runs/semseg/results"));
         if let Err(e) = fs::create_dir_all(&dir) {
-            error!("Failed to create semantic-mask directory '{}': {e}", dir.display());
+            error!("Failed to create results directory '{}': {e}", dir.display());
+            process::exit(1);
+        }
+        Some(dir)
+    } else {
+        None
+    };
+    #[cfg(not(feature = "annotate"))]
+    let results_dir: Option<std::path::PathBuf> = if save_json
+        && model.task() == crate::task::Task::SemSeg
+    {
+        let dir = std::path::PathBuf::from("runs/semseg/results");
+        if let Err(e) = fs::create_dir_all(&dir) {
+            error!("Failed to create results directory '{}': {e}", dir.display());
             process::exit(1);
         }
         Some(dir)
@@ -346,7 +352,7 @@ pub fn run_prediction(args: &PredictArgs) {
                             );
                         }
 
-                        if let Some(ref cdir) = semantic_mask_dir
+                        if let Some(ref cdir) = results_dir
                             && let Some(ref sm) = result.semantic_mask
                         {
                             let stem = std::path::Path::new(image_path).file_stem().map_or_else(

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -362,15 +362,38 @@ pub fn run_prediction(args: &PredictArgs) {
                             );
                             let out_path = cdir.join(format!("{stem}.png"));
                             let (h, w) = (sm.data.shape()[0], sm.data.shape()[1]);
-                            let buf: Vec<u8> =
-                                sm.data.iter().map(|v| (*v).min(255) as u8).collect();
-                            if let Some(gray) = image::GrayImage::from_raw(w as u32, h as u32, buf)
-                                && let Err(e) = gray.save(&out_path)
-                            {
-                                error!(
-                                    "Failed to save semantic mask '{}': {e}",
+                            let max_id = sm.data.iter().copied().max().unwrap_or(0);
+                            if max_id > 255 {
+                                // Class IDs exceed 8-bit range; save as 16-bit grayscale PNG.
+                                warn!(
+                                    "Semantic class IDs exceed 255 (max={max_id}); saving 16-bit PNG: {}",
                                     out_path.display()
                                 );
+                                let buf: Vec<u16> =
+                                    sm.data.iter().map(|&v| v as u16).collect();
+                                if let Some(img16) = image::ImageBuffer::<
+                                    image::Luma<u16>,
+                                    Vec<u16>,
+                                >::from_raw(w as u32, h as u32, buf)
+                                    && let Err(e) = img16.save(&out_path)
+                                {
+                                    error!(
+                                        "Failed to save semantic mask '{}': {e}",
+                                        out_path.display()
+                                    );
+                                }
+                            } else {
+                                let buf: Vec<u8> =
+                                    sm.data.iter().map(|&v| v as u8).collect();
+                                if let Some(gray) =
+                                    image::GrayImage::from_raw(w as u32, h as u32, buf)
+                                    && let Err(e) = gray.save(&out_path)
+                                {
+                                    error!(
+                                        "Failed to save semantic mask '{}': {e}",
+                                        out_path.display()
+                                    );
+                                }
                             }
                         }
 

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -165,6 +165,7 @@ pub fn run_prediction(args: &PredictArgs) {
             crate::task::Task::Pose => "runs/pose",
             crate::task::Task::Classify => "runs/classify",
             crate::task::Task::Obb => "runs/obb",
+            crate::task::Task::SemSeg => "runs/semseg",
         };
         let dir = find_next_run_dir(parent_dir, "predict");
         if let Err(e) = fs::create_dir_all(&dir) {

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -158,7 +158,7 @@ pub fn run_prediction(args: &PredictArgs) {
     );
 
     // Determine whether we need an incremented predict dir. `--save` always needs one;
-    // `--save-json` for semseg also needs one so PNG class maps land in <predictN>/results/
+    // `--save-json` for semantic segmentation also needs one so PNG class maps land in <predictN>/results/
     let need_predict_dir = save_json && model.task() == crate::task::Task::Semantic;
     #[cfg(feature = "annotate")]
     let need_predict_dir = save || need_predict_dir;
@@ -171,7 +171,7 @@ pub fn run_prediction(args: &PredictArgs) {
             crate::task::Task::Pose => "runs/pose",
             crate::task::Task::Classify => "runs/classify",
             crate::task::Task::Obb => "runs/obb",
-            crate::task::Task::Semantic => "runs/semseg",
+            crate::task::Task::Semantic => "runs/semantic",
         };
         let dir = find_next_run_dir(parent_dir, "predict");
         if let Err(e) = fs::create_dir_all(&dir) {
@@ -185,7 +185,7 @@ pub fn run_prediction(args: &PredictArgs) {
     // Without the `annotate` feature, `--save` is rejected below; classmap save still works.
     #[cfg(not(feature = "annotate"))]
     let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
-        let dir = std::path::PathBuf::from("runs/semseg/predict");
+        let dir = std::path::PathBuf::from("runs/semantic/predict");
         if let Err(e) = fs::create_dir_all(&dir) {
             error!("Failed to create save directory '{}': {e}", dir.display());
             process::exit(1);

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -369,12 +369,11 @@ pub fn run_prediction(args: &PredictArgs) {
                                     "Semantic class IDs exceed 255 (max={max_id}); saving 16-bit PNG: {}",
                                     out_path.display()
                                 );
-                                let buf: Vec<u16> =
-                                    sm.data.iter().map(|&v| v as u16).collect();
-                                if let Some(img16) = image::ImageBuffer::<
-                                    image::Luma<u16>,
-                                    Vec<u16>,
-                                >::from_raw(w as u32, h as u32, buf)
+                                let buf: Vec<u16> = sm.data.iter().map(|&v| v as u16).collect();
+                                if let Some(img16) =
+                                    image::ImageBuffer::<image::Luma<u16>, Vec<u16>>::from_raw(
+                                        w as u32, h as u32, buf,
+                                    )
                                     && let Err(e) = img16.save(&out_path)
                                 {
                                     error!(
@@ -383,8 +382,7 @@ pub fn run_prediction(args: &PredictArgs) {
                                     );
                                 }
                             } else {
-                                let buf: Vec<u8> =
-                                    sm.data.iter().map(|&v| v as u8).collect();
+                                let buf: Vec<u8> = sm.data.iter().map(|&v| v as u8).collect();
                                 if let Some(gray) =
                                     image::GrayImage::from_raw(w as u32, h as u32, buf)
                                     && let Err(e) = gray.save(&out_path)

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -158,6 +158,13 @@ pub fn run_prediction(args: &PredictArgs) {
         |s| crate::source::Source::from(s.as_str()),
     );
 
+    if save_json && model.task() != crate::task::Task::Semantic {
+        warn!(
+            "--save-json is currently supported only for semantic segmentation; ignoring for task '{}'.",
+            model.task()
+        );
+    }
+
     // Determine whether we need an incremented predict dir. `--save` always needs one;
     // `--save-json` for semantic segmentation also needs one so PNG class maps land in <predictN>/results/
     let need_predict_dir = save_json && model.task() == crate::task::Task::Semantic;
@@ -196,7 +203,7 @@ pub fn run_prediction(args: &PredictArgs) {
         None
     };
 
-    // Per-image PNG class maps go in `<save_dir>/results/<stem>.png`.
+    // Per-image semantic class maps go in `<save_dir>/results/<stem>.png`.
     let results_dir: Option<std::path::PathBuf> = save_dir.as_ref().and_then(|d| {
         if !save_json || model.task() != crate::task::Task::Semantic {
             return None;
@@ -276,6 +283,7 @@ pub fn run_prediction(args: &PredictArgs) {
     #[cfg(feature = "annotate")]
     let mut result_saver = save_dir
         .as_ref()
+        .filter(|_| save)
         .map(|d| crate::io::SaveResults::new(d.clone(), save_frames));
     #[cfg(not(feature = "annotate"))]
     let mut result_saver: Option<crate::io::SaveResults> = None;

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -195,7 +195,7 @@ pub fn run_prediction(args: &PredictArgs) {
         None
     };
 
-    // `<save_dir>/results/<stem>.png` — matches `ops.scale_masks`-driven layout in val.py.
+    // Per-image PNG class maps go in `<save_dir>/results/<stem>.png`.
     let results_dir: Option<std::path::PathBuf> = save_dir.as_ref().and_then(|d| {
         if !save_json || model.task() != crate::task::Task::SemSeg {
             return None;

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use std::fs;
 
 #[cfg(feature = "annotate")]
-use crate::annotate::{annotate_image, find_next_run_dir};
+use crate::annotate::annotate_image;
+use crate::io::find_next_run_dir;
 
 #[cfg(feature = "visualize")]
 use crate::visualizer::Viewer;
@@ -185,7 +186,7 @@ pub fn run_prediction(args: &PredictArgs) {
     // Without the `annotate` feature, `--save` is rejected below; classmap save still works.
     #[cfg(not(feature = "annotate"))]
     let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
-        let dir = std::path::PathBuf::from("runs/semantic/predict");
+        let dir = std::path::PathBuf::from(find_next_run_dir("runs/semantic", "predict"));
         if let Err(e) = fs::create_dir_all(&dir) {
             error!("Failed to create save directory '{}': {e}", dir.display());
             process::exit(1);
@@ -356,10 +357,16 @@ pub fn run_prediction(args: &PredictArgs) {
                         if let Some(ref cdir) = results_dir
                             && let Some(ref sm) = result.semantic_mask
                         {
-                            let stem = std::path::Path::new(image_path).file_stem().map_or_else(
-                                || format!("frame_{}", meta.frame_idx),
-                                |s| s.to_string_lossy().into_owned(),
-                            );
+                            // For video/webcam sources every frame shares the same path stem,
+                            // so append the frame index to avoid overwriting earlier frames.
+                            let base_stem = std::path::Path::new(image_path)
+                                .file_stem()
+                                .map_or_else(|| "frame".to_owned(), |s| s.to_string_lossy().into_owned());
+                            let stem = if meta.total_frames == Some(1) {
+                                base_stem
+                            } else {
+                                format!("{base_stem}_{:06}", meta.frame_idx)
+                            };
                             let out_path = cdir.join(format!("{stem}.png"));
                             let (h, w) = (sm.data.shape()[0], sm.data.shape()[1]);
                             let max_id = sm.data.iter().copied().max().unwrap_or(0);

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -157,8 +157,14 @@ pub fn run_prediction(args: &PredictArgs) {
         |s| crate::source::Source::from(s.as_str()),
     );
 
+    // Determine whether we need an incremented predict dir. `--save` always needs one;
+    // `--save-json` for semseg also needs one so PNG class maps land in <predictN>/results/
+    let need_predict_dir = save_json && model.task() == crate::task::Task::SemSeg;
     #[cfg(feature = "annotate")]
-    let save_dir = if save {
+    let need_predict_dir = save || need_predict_dir;
+
+    #[cfg(feature = "annotate")]
+    let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
         let parent_dir = match model.task() {
             crate::task::Task::Detect => "runs/detect",
             crate::task::Task::Segment => "runs/segment",
@@ -176,39 +182,31 @@ pub fn run_prediction(args: &PredictArgs) {
     } else {
         None
     };
-
-    // Matches Ultralytics' val.py for semseg: when --save-json is set, write per-image
-    // PNG class maps into `<save_dir>/results/<image_stem>.png`. Requires --save (which
-    // creates save_dir) and task == SemSeg; ignored otherwise.
-    #[cfg(feature = "annotate")]
-    let results_dir: Option<std::path::PathBuf> = if save_json
-        && model.task() == crate::task::Task::SemSeg
-    {
-        let dir = save_dir
-            .as_ref()
-            .map(|d| d.join("results"))
-            .unwrap_or_else(|| std::path::PathBuf::from("runs/semseg/results"));
-        if let Err(e) = fs::create_dir_all(&dir) {
-            error!("Failed to create results directory '{}': {e}", dir.display());
-            process::exit(1);
-        }
-        Some(dir)
-    } else {
-        None
-    };
+    // Without the `annotate` feature, `--save` is rejected below; classmap save still works.
     #[cfg(not(feature = "annotate"))]
-    let results_dir: Option<std::path::PathBuf> = if save_json
-        && model.task() == crate::task::Task::SemSeg
-    {
-        let dir = std::path::PathBuf::from("runs/semseg/results");
+    let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
+        let dir = std::path::PathBuf::from("runs/semseg/predict");
         if let Err(e) = fs::create_dir_all(&dir) {
-            error!("Failed to create results directory '{}': {e}", dir.display());
+            error!("Failed to create save directory '{}': {e}", dir.display());
             process::exit(1);
         }
         Some(dir)
     } else {
         None
     };
+
+    // `<save_dir>/results/<stem>.png` — matches `ops.scale_masks`-driven layout in val.py.
+    let results_dir: Option<std::path::PathBuf> = save_dir.as_ref().and_then(|d| {
+        if !save_json || model.task() != crate::task::Task::SemSeg {
+            return None;
+        }
+        let dir = d.join("results");
+        if let Err(e) = fs::create_dir_all(&dir) {
+            error!("Failed to create results directory '{}': {e}", dir.display());
+            process::exit(1);
+        }
+        Some(dir)
+    });
 
     #[cfg(not(feature = "annotate"))]
     if save {

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -202,7 +202,10 @@ pub fn run_prediction(args: &PredictArgs) {
         }
         let dir = d.join("results");
         if let Err(e) = fs::create_dir_all(&dir) {
-            error!("Failed to create results directory '{}': {e}", dir.display());
+            error!(
+                "Failed to create results directory '{}': {e}",
+                dir.display()
+            );
             process::exit(1);
         }
         Some(dir)
@@ -361,11 +364,13 @@ pub fn run_prediction(args: &PredictArgs) {
                             let (h, w) = (sm.data.shape()[0], sm.data.shape()[1]);
                             let buf: Vec<u8> =
                                 sm.data.iter().map(|v| (*v).min(255) as u8).collect();
-                            if let Some(gray) =
-                                image::GrayImage::from_raw(w as u32, h as u32, buf)
+                            if let Some(gray) = image::GrayImage::from_raw(w as u32, h as u32, buf)
                                 && let Err(e) = gray.save(&out_path)
                             {
-                                error!("Failed to save semantic mask '{}': {e}", out_path.display());
+                                error!(
+                                    "Failed to save semantic mask '{}': {e}",
+                                    out_path.display()
+                                );
                             }
                         }
 

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -359,9 +359,11 @@ pub fn run_prediction(args: &PredictArgs) {
                         {
                             // For video/webcam sources every frame shares the same path stem,
                             // so append the frame index to avoid overwriting earlier frames.
-                            let base_stem = std::path::Path::new(image_path)
-                                .file_stem()
-                                .map_or_else(|| "frame".to_owned(), |s| s.to_string_lossy().into_owned());
+                            let base_stem =
+                                std::path::Path::new(image_path).file_stem().map_or_else(
+                                    || "frame".to_owned(),
+                                    |s| s.to_string_lossy().into_owned(),
+                                );
                             let stem = if meta.total_frames == Some(1) {
                                 base_stem
                             } else {

--- a/src/download.rs
+++ b/src/download.rs
@@ -41,7 +41,14 @@ fn downloadable_models() -> Vec<String> {
 }
 
 fn supported_models_help() -> String {
-    let variants_display = ["detect", "-seg", "-pose", "-obb", "-cls", "-sem (yolo26 only)"];
+    let variants_display = [
+        "detect",
+        "-seg",
+        "-pose",
+        "-obb",
+        "-cls",
+        "-sem (yolo26 only)",
+    ];
     let sizes_display = MODEL_SIZES.join(", ");
     let variants_joined = variants_display.join(", ");
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -18,14 +18,22 @@ const ASSETS_BASE_URL: &str = "https://github.com/ultralytics/assets/releases/do
 const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11"];
 const MODEL_SIZES: &[&str] = &["n", "s", "m", "l", "x"];
 const MODEL_VARIANTS: &[&str] = &["", "-seg", "-pose", "-obb", "-cls"];
+/// Variants only available for the yolo26 family.
+const YOLO26_ONLY_VARIANTS: &[&str] = &["-semseg"];
 
 fn downloadable_models() -> Vec<String> {
     MODEL_FAMILIES
         .iter()
         .flat_map(|family| {
+            let extra: &[&str] = if *family == "yolo26" {
+                YOLO26_ONLY_VARIANTS
+            } else {
+                &[]
+            };
             MODEL_SIZES.iter().flat_map(move |size| {
                 MODEL_VARIANTS
                     .iter()
+                    .chain(extra.iter())
                     .map(move |variant| format!("{family}{size}{variant}.onnx"))
             })
         })
@@ -304,7 +312,7 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 /// Attempt to download a model if it matches a known downloadable model.
 ///
 /// Supports all YOLO26 and YOLO11 ONNX models across sizes (n/s/m/l/x) and
-/// task variants (detect, segment, pose, obb, classify).
+/// task variants (detect, segment, pose, obb, classify, semseg).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// Returns the path to the downloaded model.

--- a/src/download.rs
+++ b/src/download.rs
@@ -19,7 +19,7 @@ const MODEL_FAMILIES: &[&str] = &["yolo26", "yolo11", "yolov8"];
 const MODEL_SIZES: &[&str] = &["n", "s", "m", "l", "x"];
 const MODEL_VARIANTS: &[&str] = &["", "-seg", "-pose", "-obb", "-cls"];
 /// Variants only available for the yolo26 family.
-const YOLO26_ONLY_VARIANTS: &[&str] = &["-semseg"];
+const YOLO26_ONLY_VARIANTS: &[&str] = &["-sem"];
 
 fn downloadable_models() -> Vec<String> {
     MODEL_FAMILIES

--- a/src/download.rs
+++ b/src/download.rs
@@ -67,7 +67,7 @@ const DEFAULT_BUS_IMAGE_URL: &str = "https://ultralytics.com/images/bus.jpg";
 const DEFAULT_ZIDANE_IMAGE_URL: &str = "https://ultralytics.com/images/zidane.jpg";
 const DEFAULT_BOATS_IMAGE_URL: &str = "https://ultralytics.com/images/boats.jpg";
 
-/// Default image URLs for detection, segmentation, pose, classification, and semseg tasks.
+/// Default image URLs for detection, segmentation, pose, classification, and semantic tasks.
 pub const DEFAULT_IMAGES: &[&str] = &[DEFAULT_BUS_IMAGE_URL, DEFAULT_ZIDANE_IMAGE_URL];
 
 /// Default image URL for OBB (Oriented Bounding Box) tasks.

--- a/src/download.rs
+++ b/src/download.rs
@@ -351,7 +351,7 @@ fn normalize_model_path(path: &Path) -> PathBuf {
 /// Attempt to download a model if it matches a known downloadable model.
 ///
 /// Supports all `YOLO26`, `YOLO11`, and `YOLOv8` ONNX models across sizes (n/s/m/l/x) and
-/// task variants (detect, segment, pose, obb, classify, semseg).
+/// task variants (detect, segment, pose, obb, classify, semantic).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// # Errors

--- a/src/download.rs
+++ b/src/download.rs
@@ -41,7 +41,7 @@ fn downloadable_models() -> Vec<String> {
 }
 
 fn supported_models_help() -> String {
-    let variants_display = ["detect", "-seg", "-pose", "-obb", "-cls"];
+    let variants_display = ["detect", "-seg", "-pose", "-obb", "-cls", "-sem (yolo26 only)"];
     let sizes_display = MODEL_SIZES.join(", ");
     let variants_joined = variants_display.join(", ");
 
@@ -60,7 +60,7 @@ const DEFAULT_BUS_IMAGE_URL: &str = "https://ultralytics.com/images/bus.jpg";
 const DEFAULT_ZIDANE_IMAGE_URL: &str = "https://ultralytics.com/images/zidane.jpg";
 const DEFAULT_BOATS_IMAGE_URL: &str = "https://ultralytics.com/images/boats.jpg";
 
-/// Default image URLs for detection, segmentation, pose, and classification tasks.
+/// Default image URLs for detection, segmentation, pose, classification, and semseg tasks.
 pub const DEFAULT_IMAGES: &[&str] = &[DEFAULT_BUS_IMAGE_URL, DEFAULT_ZIDANE_IMAGE_URL];
 
 /// Default image URL for OBB (Oriented Bounding Box) tasks.
@@ -344,7 +344,7 @@ fn normalize_model_path(path: &Path) -> PathBuf {
 /// Attempt to download a model if it matches a known downloadable model.
 ///
 /// Supports all `YOLO26`, `YOLO11`, and `YOLOv8` ONNX models across sizes (n/s/m/l/x) and
-/// task variants (detect, segment, pose, obb, classify).
+/// task variants (detect, segment, pose, obb, classify, semseg).
 /// Every supported file resolves to `{ASSETS_BASE_URL}/{filename}`.
 ///
 /// # Errors

--- a/src/io.rs
+++ b/src/io.rs
@@ -30,6 +30,23 @@ pub fn init_logging() {
     });
 }
 
+/// Return the next available run directory, e.g. `runs/detect/predict`, then `predict2`, `predict3`, ...
+#[must_use]
+pub fn find_next_run_dir(base: &str, prefix: &str) -> String {
+    let base_path = Path::new(base);
+    let first = base_path.join(prefix);
+    if !first.exists() {
+        return first.to_string_lossy().into_owned();
+    }
+    for i in 2.. {
+        let numbered = base_path.join(format!("{prefix}{i}"));
+        if !numbered.exists() {
+            return numbered.to_string_lossy().into_owned();
+        }
+    }
+    first.to_string_lossy().into_owned()
+}
+
 /// A wrapper around `video-rs` encoder to simplify video saving.
 #[cfg(feature = "video")]
 pub struct VideoWriter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //! }
 //!
 //! // Semantic segmentation model (YOLO26 only) - returns a per-pixel class map
-//! let mut model = YOLOModel::load("yolo26n-semseg.onnx")?;
+//! let mut model = YOLOModel::load("yolo26n-sem.onnx")?;
 //! let results = model.predict("image.jpg")?;
 //! if let Some(ref sem) = results[0].semantic_mask {
 //!     println!("Semantic mask shape: {:?}", sem.data.shape());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! | `--half` | | Use FP16 half-precision inference | `false` |
 //! | `--save` | | Save annotated results to runs/\<task\>/predict | `true` |
 //! | `--save-frames` | | Save individual frames for video input | `false` |
-//! | `--save-json` | | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation | `false` |
+//! | `--save-json` | | Save semantic segmentation class-map PNGs for external evaluation | `false` |
 //! | `--show` | | Display results in a window | `false` |
 //! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //! # Run with defaults (auto-downloads model and sample images)
 //! ultralytics-inference predict
 //!
-//! # Select task — auto-downloads the matching nano model
+//! # Select task: auto-downloads the matching nano model
 //! ultralytics-inference predict --task segment
 //! ultralytics-inference predict --task pose
 //! ultralytics-inference predict --task obb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 //! yolo export model=yolo26n-obb.pt format=onnx
 //!
 //! # Semantic Segmentation (YOLO26 only)
-//! yolo export model=yolo26n-semseg.pt format=onnx
+//! yolo export model=yolo26n-sem.pt format=onnx
 //! ```
 //!
 //! The task is auto-detected from ONNX metadata:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@
 //! | `--half` | | Use FP16 half-precision inference | `false` |
 //! | `--save` | | Save annotated results to runs/\<task\>/predict | `true` |
 //! | `--save-frames` | | Save individual frames for video input | `false` |
+//! | `--save-json` | | Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation | `false` |
 //! | `--show` | | Display results in a window | `false` |
 //! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! - **High Performance** - Pure Rust with zero-cost abstractions and SIMD-optimized preprocessing
 //! - **ONNX Runtime** - Leverages ONNX Runtime for cross-platform hardware acceleration
 //! - **Supported YOLO Versions** - `YOLO26`, `YOLO11`, and `YOLOv8` (including YOLO26 end-to-end NMS-free exports)
-//! - **All Tasks** - Detection, segmentation, pose estimation, classification, and OBB
+//! - **All Tasks** - Detection, segmentation, pose estimation, classification, OBB, and semantic segmentation (YOLO26 only)
 //! - **Ultralytics API** - Results API matches the Python package for easy migration
 //! - **Multiple Backends** - CPU, CUDA, `TensorRT`, `CoreML`, `OpenVINO`, and more
 //! - **Multiple Sources** - Images, directories, glob patterns, video, webcam, streams
@@ -117,7 +117,7 @@
 //! | Option | Short | Description | Default |
 //! |--------|-------|-------------|---------|
 //! | `--model` | `-m` | Path to ONNX model file; auto-downloaded if a known YOLO26/YOLO11/YOLOv8 name | `yolo26n.onnx` |
-//! | `--task` | | Task type (`detect`, `segment`, `pose`, `obb`, `classify`); selects nano model when `--model` is omitted | `detect` |
+//! | `--task` | | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semseg`\*); selects nano model when `--model` is omitted | `detect` |
 //! | `--source` | `-s` | Input source (image, directory, glob, video, webcam index, or URL) | Task-dependent sample assets |
 //! | `--conf` | | Confidence threshold | `0.25` |
 //! | `--iou` | | `IoU` threshold for NMS | `0.7` |
@@ -132,6 +132,8 @@
 //! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |
 //! | `--classes` | | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"` | all classes |
+//!
+//! \* `semseg` (semantic segmentation) is YOLO26-only.
 //!
 //! ## Task-Specific Examples
 //!
@@ -152,6 +154,9 @@
 //!
 //! # Oriented Bounding Boxes
 //! yolo export model=yolo26n-obb.pt format=onnx
+//!
+//! # Semantic Segmentation (YOLO26 only)
+//! yolo export model=yolo26n-semseg.pt format=onnx
 //! ```
 //!
 //! The task is auto-detected from ONNX metadata:
@@ -179,6 +184,13 @@
 //! let results = model.predict("image.jpg")?;
 //! if let Some(ref probs) = results[0].probs {
 //!     println!("Top-1: class {} ({:.1}%)", probs.top1(), probs.top1conf() * 100.0);
+//! }
+//!
+//! // Semantic segmentation model (YOLO26 only) - returns a per-pixel class map
+//! let mut model = YOLOModel::load("yolo26n-semseg.onnx")?;
+//! let results = model.predict("image.jpg")?;
+//! if let Some(ref sem) = results[0].semantic_mask {
+//!     println!("Semantic mask shape: {:?}", sem.data.shape());
 //! }
 //! # Ok(())
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ pub use device::Device;
 pub use error::{InferenceError, Result};
 pub use inference::InferenceConfig;
 pub use model::YOLOModel;
-pub use results::{Boxes, Keypoints, Masks, Obb, Probs, Results, Speed};
+pub use results::{Boxes, Keypoints, Masks, Obb, Probs, Results, SemanticMask, Speed};
 pub use source::{Source, SourceIterator, SourceMeta};
 pub use task::Task;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 //! | Option | Short | Description | Default |
 //! |--------|-------|-------------|---------|
 //! | `--model` | `-m` | Path to ONNX model file; auto-downloaded if a known YOLO26/YOLO11/YOLOv8 name | `yolo26n.onnx` |
-//! | `--task` | | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semseg`\*); selects nano model when `--model` is omitted | `detect` |
+//! | `--task` | | Task type (`detect`, `segment`, `pose`, `obb`, `classify`, `semantic`\*); selects nano model when `--model` is omitted | `detect` |
 //! | `--source` | `-s` | Input source (image, directory, glob, video, webcam index, or URL) | Task-dependent sample assets |
 //! | `--conf` | | Confidence threshold | `0.25` |
 //! | `--iou` | | `IoU` threshold for NMS | `0.7` |
@@ -128,13 +128,13 @@
 //! | `--half` | | Use FP16 half-precision inference | `false` |
 //! | `--save` | | Save annotated results to runs/\<task\>/predict | `true` |
 //! | `--save-frames` | | Save individual frames for video input | `false` |
-//! | `--save-json` | | Save results to COCO JSON (detect/segment/pose) or PNG masks (semseg) for external evaluation | `false` |
+//! | `--save-json` | | Save results to COCO JSON (detect/segment/pose) or PNG masks (semantic) for external evaluation | `false` |
 //! | `--show` | | Display results in a window | `false` |
 //! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |
 //! | `--classes` | | Filter by class IDs, e.g. `0` or `"0,1,2"` or `"[0, 1, 2]"` | all classes |
 //!
-//! \* `semseg` (semantic segmentation) is YOLO26-only.
+//! \* `semantic` (semantic segmentation) is YOLO26-only.
 //!
 //! ## Task-Specific Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,10 +247,10 @@
 //! | [`results`] | Output types ([`Results`], [`Boxes`], [`Masks`], etc.) |
 //! | [`inference`] | [`InferenceConfig`] for customizing inference settings |
 //! | [`source`] | Input source handling ([`Source`], [`SourceIterator`]) |
-//! | [`task`] | YOLO task types ([`Task`]: Detect, Segment, Pose, etc.) |
+//! | [`task`] | YOLO task types ([`Task`]: Detect, Segment, Pose, Classify, Obb, Semantic) |
 //! | [`mod@error`] | Error types ([`InferenceError`], [`Result`]) |
 //! | [`preprocessing`] | Image preprocessing utilities |
-//! | [`postprocessing`] | Detection post-processing (NMS, decode) |
+//! | [`postprocessing`] | Post-processing for all tasks (NMS/decode for detection; argmax for semantic segmentation) |
 //! | [`metadata`] | ONNX model metadata parsing |
 //!
 //! ## Feature Flags

--- a/src/model.rs
+++ b/src/model.rs
@@ -471,6 +471,56 @@ impl YOLOModel {
         ep.build()
     }
 
+    /// Concatenate per-image FP32 input tensors along the batch axis.
+    fn concat_f32_batch(
+        preprocessed: &[crate::preprocessing::PreprocessResult],
+    ) -> Result<ndarray::Array4<f32>> {
+        let arrays: Vec<_> = preprocessed.iter().map(|r| r.tensor.view()).collect();
+        let batch = ndarray::concatenate(ndarray::Axis(0), &arrays).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to concatenate FP32 tensors: {e}"))
+        })?;
+        batch.into_dimensionality::<ndarray::Ix4>().map_err(|e| {
+            InferenceError::InferenceError(format!(
+                "Failed to convert concatenated tensor to 4D: {e}"
+            ))
+        })
+    }
+
+    /// Concatenate per-image FP16 input tensors along the batch axis.
+    fn concat_f16_batch(
+        preprocessed: &[crate::preprocessing::PreprocessResult],
+    ) -> Result<ndarray::Array4<f16>> {
+        let arrays: Vec<_> = preprocessed
+            .iter()
+            .map(|r| {
+                r.tensor_f16
+                    .as_ref()
+                    .expect("FP16 tensor should be available")
+                    .view()
+            })
+            .collect();
+        let batch = ndarray::concatenate(ndarray::Axis(0), &arrays).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to concatenate FP16 tensors: {e}"))
+        })?;
+        batch.into_dimensionality::<ndarray::Ix4>().map_err(|e| {
+            InferenceError::InferenceError(format!(
+                "Failed to convert concatenated tensor to 4D: {e}"
+            ))
+        })
+    }
+
+    /// Returns true when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only output is
+    /// a `[B, H, W] uint8` class map. Lets us skip f32 logits extraction + CPU argmax for semseg.
+    fn has_semantic_mask_output(&self) -> bool {
+        let outs = self.session.outputs();
+        outs.len() == 1
+            && matches!(
+                outs[0].dtype(),
+                ValueType::Tensor { ty: ort::value::TensorElementType::Uint8, shape, .. }
+                    if shape.len() == 3
+            )
+    }
+
     /// Maximum allowed image dimension to prevent OOM during warmup.
     const MAX_IMGSZ: usize = 8192;
 
@@ -500,12 +550,33 @@ impl YOLOModel {
             )));
         }
 
-        let warmup_result = if self.fp16_input {
+        let warmup_result: Result<()> = if self.fp16_input {
             let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
-            self.run_inference_f16(&dummy_input)
+            Self::run_inference_f16_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &dummy_input,
+                |_outputs, _ms| Ok(()),
+            )
+        } else if self.has_semantic_mask_output() {
+            let dummy_input = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
+            Self::run_inference_u8_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &dummy_input,
+                |_outputs, _ms| Ok(()),
+            )
         } else {
             let dummy_input = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
-            self.run_inference(&dummy_input)
+            Self::run_inference_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &dummy_input,
+                |_outputs, _ms| Ok(()),
+            )
         };
 
         if let Err(e) = warmup_result {
@@ -752,121 +823,186 @@ impl YOLOModel {
         let preprocess_time =
             start_preprocess.elapsed().as_secs_f64() * 1000.0 / images.len() as f64;
 
-        // Stack tensors
-        let start_inference = Instant::now();
-        let outputs = if self.fp16_input {
-            let mut arrays = Vec::with_capacity(images.len());
-            for res in &preprocessed_results {
-                arrays.push(
-                    res.tensor_f16
-                        .as_ref()
-                        .expect("FP16 tensor should be available")
-                        .view(),
-                );
-            }
-
-            // Concatenate along batch dimension (axis 0)
-            let batch_tensor = ndarray::concatenate(ndarray::Axis(0), &arrays).map_err(|e| {
-                InferenceError::InferenceError(format!("Failed to concatenate FP16 tensors: {e}"))
-            })?;
-            // ndarray concatenate returns ArrayxD, we need Array4
-            let batch_tensor = batch_tensor
-                .into_dimensionality::<ndarray::Ix4>()
-                .map_err(|e| {
-                    InferenceError::InferenceError(format!(
-                        "Failed to convert concatenated tensor to 4D: {e}"
-                    ))
-                })?;
-
-            self.run_inference_f16(&batch_tensor)?
-        } else {
-            let mut arrays = Vec::with_capacity(images.len());
-            for res in &preprocessed_results {
-                arrays.push(res.tensor.view());
-            }
-            let batch_tensor = ndarray::concatenate(ndarray::Axis(0), &arrays).map_err(|e| {
-                InferenceError::InferenceError(format!("Failed to concatenate FP32 tensors: {e}"))
-            })?;
-            let batch_tensor = batch_tensor
-                .into_dimensionality::<ndarray::Ix4>()
-                .map_err(|e| {
-                    InferenceError::InferenceError(format!(
-                        "Failed to convert concatenated tensor to 4D: {e}"
-                    ))
-                })?;
-
-            self.run_inference(&batch_tensor)?
-        };
+        // Postprocess driver: runs INSIDE the inference closure so we can read the
+        // ORT output buffers without copying. Returns the final batch_results.
+        let n_images = images.len();
         #[allow(clippy::cast_precision_loss)]
-        let inference_time = start_inference.elapsed().as_secs_f64() * 1000.0 / images.len() as f64;
+        let n_images_f = n_images as f64;
+        let task = self.metadata.task;
+        let names = &self.metadata.names;
+        let cfg = &self.config;
+        let end2end = self.metadata.end2end;
+        let kpt_shape = self.metadata.kpt_shape;
 
-        // Process each image's output
-        let mut image_arrays = Vec::with_capacity(images.len());
+        // Compute orig_img arrays now (cheap; no copy of pixels yet other than what image_to_array does).
+        let mut image_arrays = Vec::with_capacity(n_images);
         for image in images {
             image_arrays.push(image_to_array(image));
         }
+        // Move preprocessed_results into an Option so the closure can consume it.
+        let preprocessed_results_opt = std::cell::RefCell::new(Some(preprocessed_results));
+        let image_arrays_opt = std::cell::RefCell::new(Some(image_arrays));
+        let paths_ref = paths;
 
-        // Post-process
-        let start_postprocess = Instant::now();
+        let postprocess_cb = |outputs: &[(&[f32], Vec<usize>)],
+                              inference_ms_total: f64|
+         -> Result<Vec<Vec<Results>>> {
+            let inference_time = inference_ms_total / n_images_f;
+            let start_postprocess = Instant::now();
+            let preprocessed_results = preprocessed_results_opt
+                .borrow_mut()
+                .take()
+                .expect("preprocessed_results");
+            let image_arrays = image_arrays_opt.borrow_mut().take().expect("image_arrays");
 
-        let mut batch_results = Vec::with_capacity(images.len());
+            let mut batch_results: Vec<Vec<Results>> = Vec::with_capacity(n_images);
+            for (i, (orig_img, preprocess_res)) in image_arrays
+                .into_iter()
+                .zip(preprocessed_results)
+                .enumerate()
+            {
+                let path = paths_ref.get(i).cloned().unwrap_or_default();
+                let speed = Speed::new(preprocess_time, inference_time, 0.0);
 
-        // Process each image's output
-        for (i, (orig_img, preprocess_res)) in image_arrays
-            .into_iter()
-            .zip(preprocessed_results)
-            .enumerate()
-        {
-            let path = paths.get(i).cloned().unwrap_or_default();
-            let speed = Speed::new(preprocess_time, inference_time, 0.0);
+                let mut img_outputs = Vec::new();
+                for (data, shape) in outputs {
+                    let batch_size = shape[0];
+                    let actual_batch_size = if batch_size > 0 { batch_size } else { 1 };
+                    let total_elements = data.len();
+                    let elements_per_img = total_elements / actual_batch_size;
+                    let start = i * elements_per_img;
+                    let end = start + elements_per_img;
+                    let img_data = &data[start..end];
+                    let mut img_shape = shape.clone();
+                    img_shape[0] = 1;
+                    img_outputs.push((img_data, img_shape));
+                }
 
-            // Construct outputs for this single image
-            let mut img_outputs = Vec::new();
-            for (data, shape) in &outputs {
-                let batch_size = shape[0];
-                let actual_batch_size = if batch_size > 0 { batch_size } else { 1 };
-                let total_elements = data.len();
-                let elements_per_img = total_elements / actual_batch_size;
-                let start = i * elements_per_img;
-                let end = start + elements_per_img;
-                let img_data = &data[start..end];
-                let mut img_shape = shape.clone();
-                img_shape[0] = 1;
-                img_outputs.push((img_data, img_shape));
+                let tensor_shape = preprocess_res.tensor.shape();
+                let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
+
+                let result = postprocess(
+                    img_outputs,
+                    task,
+                    &preprocess_res,
+                    cfg,
+                    names,
+                    orig_img,
+                    path,
+                    speed,
+                    inference_shape,
+                    end2end,
+                    kpt_shape,
+                );
+
+                batch_results.push(vec![result]);
             }
 
-            let tensor_shape = preprocess_res.tensor.shape();
-            let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
-
-            let result = postprocess(
-                img_outputs,
-                self.metadata.task,
-                &preprocess_res,
-                &self.config,
-                &self.metadata.names,
-                orig_img,
-                path,
-                speed,
-                inference_shape,
-                self.metadata.end2end,
-                self.metadata.kpt_shape,
-            );
-
-            batch_results.push(vec![result]);
-        }
-
-        #[allow(clippy::cast_precision_loss)]
-        let postprocess_time =
-            start_postprocess.elapsed().as_secs_f64() * 1000.0 / images.len() as f64;
-
-        // Update postprocess time for all results
-        for img_results in &mut batch_results {
-            for res in img_results {
-                res.speed.postprocess = Some(postprocess_time);
+            #[allow(clippy::cast_precision_loss)]
+            let postprocess_time =
+                start_postprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
+            for img_results in &mut batch_results {
+                for res in img_results {
+                    res.speed.postprocess = Some(postprocess_time);
+                }
             }
+            Ok(batch_results)
+        };
+
+        if !self.fp16_input && self.has_semantic_mask_output() {
+            // Fast path: ONNX outputs a uint8 class map already (ArgMax baked in on GPU).
+            // Skip the f32 logit extraction + CPU argmax entirely; do a memcpy.
+            let batch_tensor = {
+                let pre_borrow = preprocessed_results_opt.borrow();
+                Self::concat_f32_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
+            };
+
+            let task = self.metadata.task;
+            let names = &self.metadata.names;
+            let preprocessed_results = preprocessed_results_opt.borrow_mut().take().unwrap();
+            let image_arrays = image_arrays_opt.borrow_mut().take().unwrap();
+            let mut batch_results: Vec<Vec<Results>> = Vec::with_capacity(n_images);
+
+            Self::run_inference_u8_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &batch_tensor,
+                |outputs, inference_ms_total| {
+                    debug_assert_eq!(task, crate::task::Task::SemSeg);
+                    let inference_time = inference_ms_total / n_images_f;
+                    let start_postprocess = std::time::Instant::now();
+
+                    for (i, (orig_img, preprocess_res)) in image_arrays
+                        .into_iter()
+                        .zip(preprocessed_results)
+                        .enumerate()
+                    {
+                        let path_i = paths_ref.get(i).cloned().unwrap_or_default();
+                        let speed = Speed::new(preprocess_time, inference_time, 0.0);
+
+                        // Build the per-image slice from the batch output.
+                        let (data, shape) = &outputs[0];
+                        let actual_batch = if shape[0] > 0 { shape[0] } else { 1 };
+                        let elems_per_img = data.len() / actual_batch;
+                        let img_slice = &data[i * elems_per_img..(i + 1) * elems_per_img];
+                        // 3-D shape per image: drop the batch dim.
+                        let img_shape: Vec<usize> = shape[1..].to_vec();
+
+                        let tensor_shape = preprocess_res.tensor.shape();
+                        let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
+
+                        let result = crate::postprocessing::postprocess_semantic_mask(
+                            img_slice,
+                            &img_shape,
+                            names,
+                            orig_img,
+                            path_i,
+                            speed,
+                            inference_shape,
+                        );
+                        batch_results.push(vec![result]);
+                    }
+
+                    #[allow(clippy::cast_precision_loss)]
+                    let postprocess_time =
+                        start_postprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
+                    for v in &mut batch_results {
+                        for r in v {
+                            r.speed.postprocess = Some(postprocess_time);
+                        }
+                    }
+                    Ok(())
+                },
+            )?;
+            return Ok(batch_results);
         }
 
-        Ok(batch_results)
+        if self.fp16_input {
+            let batch_tensor = {
+                let pre_borrow = preprocessed_results_opt.borrow();
+                Self::concat_f16_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
+            };
+            Self::run_inference_f16_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &batch_tensor,
+                postprocess_cb,
+            )
+        } else {
+            let batch_tensor = {
+                let pre_borrow = preprocessed_results_opt.borrow();
+                Self::concat_f32_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
+            };
+            Self::run_inference_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &batch_tensor,
+                postprocess_cb,
+            )
+        }
     }
 
     /// Run inference on a raw array.
@@ -958,100 +1094,165 @@ impl YOLOModel {
         Ok(results_vec)
     }
 
-    /// Run the ONNX model inference with FP32 input.
-    fn run_inference(
-        &mut self,
+    /// Run ONNX inference with FP32 input, calling `cb` with zero-copy output views.
+    ///
+    /// `cb` receives `&[(&[f32], shape)]` borrowing directly into ORT-owned device-to-host
+    /// buffers (no extra Vec allocation), plus the measured `session.run()` time in ms.
+    /// This avoids a ~40 ms memcpy for large semseg outputs.
+    ///
+    /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
+    fn run_inference_with<R>(
+        session: &mut Session,
+        input_name: &str,
+        output_names: &[String],
         input: &ndarray::Array4<f32>,
-    ) -> Result<Vec<(Vec<f32>, Vec<usize>)>> {
-        // Ensure input is contiguous in memory (CowArray)
+        cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-
-        // Create input tensor reference from ndarray view
         let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
             InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
         })?;
+        let inputs = ort::inputs![input_name => input_tensor];
 
-        // Run session - inputs! macro returns a Vec, not a Result
-        let inputs = ort::inputs![&self.input_name => input_tensor];
-
-        let outputs = self
-            .session
+        let t_run = std::time::Instant::now();
+        let outputs = session
             .run(inputs)
             .map_err(|e| InferenceError::InferenceError(format!("Inference failed: {e}")))?;
+        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
 
-        let mut results = Vec::new();
+        // Build zero-copy views (or owned buffers for f16 outputs that must be converted)
+        Self::extract_and_invoke(&outputs, output_names, inference_ms, cb)
+    }
 
-        for output_name in &self.output_names {
+    /// Build zero-copy slice views over ORT output tensors and call `cb`.
+    fn extract_and_invoke<R>(
+        outputs: &ort::session::SessionOutputs<'_>,
+        output_names: &[String],
+        inference_ms: f64,
+        cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
+        let mut owned_bufs: Vec<Vec<f32>> = Vec::new();
+        let mut shapes: Vec<Vec<usize>> = Vec::with_capacity(output_names.len());
+        let mut sources: Vec<(Option<usize>, *const f32, usize)> =
+            Vec::with_capacity(output_names.len());
+        for output_name in output_names {
             let output = outputs.get(output_name.as_str()).ok_or_else(|| {
                 InferenceError::InferenceError(format!("Output '{output_name}' not found"))
             })?;
-
-            // Get output as f32 tensor - use try_extract_tensor which returns (shape, data)
-            let (shape, data) = output.try_extract_tensor::<f32>().map_err(|e| {
-                InferenceError::InferenceError(format!("Failed to extract output: {e}"))
-            })?;
-
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-            let data_vec: Vec<f32> = data.to_vec();
-            results.push((data_vec, shape_vec));
+            if let Ok((shape, data)) = output.try_extract_tensor::<f32>() {
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+                sources.push((None, data.as_ptr(), data.len()));
+                shapes.push(shape_vec);
+            } else {
+                let (shape, data) = output.try_extract_tensor::<f16>().map_err(|e| {
+                    InferenceError::InferenceError(format!("Failed to extract output: {e}"))
+                })?;
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+                let converted: Vec<f32> = data.iter().map(|v| v.to_f32()).collect();
+                let len = converted.len();
+                let idx = owned_bufs.len();
+                owned_bufs.push(converted);
+                sources.push((Some(idx), std::ptr::null(), len));
+                shapes.push(shape_vec);
+            }
         }
+        let views: Vec<(&[f32], Vec<usize>)> = sources
+            .iter()
+            .zip(shapes.iter())
+            .map(|((owned_idx, ptr, len), shape)| {
+                let slice: &[f32] = owned_idx.map_or_else(
+                    // SAFETY: ORT-owned buffer in `outputs` lives until caller returns.
+                    || unsafe { std::slice::from_raw_parts(*ptr, *len) },
+                    |i| owned_bufs[i].as_slice(),
+                );
+                (slice, shape.clone())
+            })
+            .collect();
 
-        Ok(results)
+        cb(&views, inference_ms)
     }
 
-    /// Run the ONNX model inference with FP16 input.
-    fn run_inference_f16(
-        &mut self,
-        input: &ndarray::Array4<f16>,
-    ) -> Result<Vec<(Vec<f32>, Vec<usize>)>> {
-        // Ensure input is contiguous in memory (CowArray)
+    /// Run ONNX inference with FP32 input where outputs are `uint8` tensors
+    /// (e.g. a semseg model that has ArgMax+Cast(uint8) baked in). Zero-copy.
+    fn run_inference_u8_with<R>(
+        session: &mut Session,
+        input_name: &str,
+        output_names: &[String],
+        input: &ndarray::Array4<f32>,
+        cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+        })?;
+        let inputs = ort::inputs![input_name => input_tensor];
 
-        // Create input tensor reference from ndarray view
+        let t_run = std::time::Instant::now();
+        let outputs = session
+            .run(inputs)
+            .map_err(|e| InferenceError::InferenceError(format!("Inference failed: {e}")))?;
+        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
+
+        Self::extract_and_invoke_u8(&outputs, output_names, inference_ms, cb)
+    }
+
+    /// Build zero-copy `&[u8]` slice views over ORT output tensors and call `cb`.
+    fn extract_and_invoke_u8<R>(
+        outputs: &ort::session::SessionOutputs<'_>,
+        output_names: &[String],
+        inference_ms: f64,
+        cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
+        let mut shapes: Vec<Vec<usize>> = Vec::with_capacity(output_names.len());
+        let mut sources: Vec<(*const u8, usize)> = Vec::with_capacity(output_names.len());
+        for output_name in output_names {
+            let output = outputs.get(output_name.as_str()).ok_or_else(|| {
+                InferenceError::InferenceError(format!("Output '{output_name}' not found"))
+            })?;
+            let (shape, data) = output.try_extract_tensor::<u8>().map_err(|e| {
+                InferenceError::InferenceError(format!("Failed to extract uint8 output: {e}"))
+            })?;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+            sources.push((data.as_ptr(), data.len()));
+            shapes.push(shape_vec);
+        }
+        let views: Vec<(&[u8], Vec<usize>)> = sources
+            .iter()
+            .zip(shapes.iter())
+            .map(|((ptr, len), shape)| {
+                // SAFETY: ORT-owned buffer in `outputs` lives until caller returns.
+                let slice: &[u8] = unsafe { std::slice::from_raw_parts(*ptr, *len) };
+                (slice, shape.clone())
+            })
+            .collect();
+
+        cb(&views, inference_ms)
+    }
+
+    /// Run ONNX inference with FP16 input, zero-copy callback (FP16 outputs are converted).
+    fn run_inference_f16_with<R>(
+        session: &mut Session,
+        input_name: &str,
+        output_names: &[String],
+        input: &ndarray::Array4<f16>,
+        cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
+        let input_contiguous = input.as_standard_layout();
         let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
             InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
         })?;
+        let inputs = ort::inputs![input_name => input_tensor];
 
-        // Run session
-        let inputs = ort::inputs![&self.input_name => input_tensor];
-
-        let outputs = self
-            .session
+        let t_run = std::time::Instant::now();
+        let outputs = session
             .run(inputs)
             .map_err(|e| InferenceError::InferenceError(format!("FP16 inference failed: {e}")))?;
+        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
 
-        let mut results = Vec::new();
-
-        for output_name in &self.output_names {
-            let output = outputs.get(output_name.as_str()).ok_or_else(|| {
-                InferenceError::InferenceError(format!("Output '{output_name}' not found"))
-            })?;
-
-            // Try to extract as f32 first (model may have FP32 output even with FP16 input)
-            // If that fails, extract as f16 and convert
-            let (shape_vec, data_vec) = if let Ok((shape, data)) =
-                output.try_extract_tensor::<f32>()
-            {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-                let data_vec: Vec<f32> = data.to_vec();
-                (shape_vec, data_vec)
-            } else {
-                // Extract as f16 and convert to f32 for postprocessing
-                let (shape, data) = output.try_extract_tensor::<f16>().map_err(|e| {
-                    InferenceError::InferenceError(format!("Failed to extract FP16 output: {e}"))
-                })?;
-
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-                let data_vec: Vec<f32> = data.iter().map(|v| v.to_f32()).collect();
-                (shape_vec, data_vec)
-            };
-            results.push((data_vec, shape_vec));
-        }
-
-        Ok(results)
+        Self::extract_and_invoke(&outputs, output_names, inference_ms, cb)
     }
 
     /// Get the model's task type as detected from ONNX metadata.

--- a/src/model.rs
+++ b/src/model.rs
@@ -563,7 +563,16 @@ impl YOLOModel {
             )));
         }
 
-        let warmup_result: Result<()> = if self.fp16_input {
+        let warmup_result: Result<()> = if self.fp16_input && self.has_semantic_mask_output() {
+            let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
+            Self::run_inference_f16_u8_with(
+                &mut self.session,
+                &self.input_name,
+                &self.output_names,
+                &dummy_input,
+                |_outputs, _ms| Ok(()),
+            )
+        } else if self.fp16_input {
             let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
             Self::run_inference_f16_with(
                 &mut self.session,
@@ -915,9 +924,73 @@ impl YOLOModel {
             Ok(batch_results)
         };
 
-        if !self.fp16_input && self.has_semantic_mask_output() {
-            // Fast path: ONNX outputs a uint8 class map already (ArgMax baked in on GPU).
-            // Skip the f32 logit extraction + CPU argmax entirely; do a memcpy.
+        if self.has_semantic_mask_output() {
+            // Fast path: the exported ONNX graph already contains ArgMax+Cast(uint8) nodes,
+            // so ONNX Runtime returns a uint8 class map directly (no f32 logits, no CPU argmax).
+            // Works for both FP32 and FP16 model inputs.
+            if self.fp16_input {
+                let batch_tensor = {
+                    let pre_borrow = preprocessed_results_opt.borrow();
+                    Self::concat_f16_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
+                };
+                let task = self.metadata.task;
+                let names = &self.metadata.names;
+                let preprocessed_results = preprocessed_results_opt.borrow_mut().take().unwrap();
+                let image_arrays = image_arrays_opt.borrow_mut().take().unwrap();
+                let mut batch_results: Vec<Vec<Results>> = Vec::with_capacity(n_images);
+
+                Self::run_inference_f16_u8_with(
+                    &mut self.session,
+                    &self.input_name,
+                    &self.output_names,
+                    &batch_tensor,
+                    |outputs, inference_ms_total| {
+                        debug_assert_eq!(task, crate::task::Task::Semantic);
+                        let inference_time = inference_ms_total / n_images_f;
+                        let start_postprocess = std::time::Instant::now();
+
+                        for (i, (orig_img, preprocess_res)) in image_arrays
+                            .into_iter()
+                            .zip(preprocessed_results)
+                            .enumerate()
+                        {
+                            let path_i = paths_ref.get(i).cloned().unwrap_or_default();
+                            let speed = Speed::new(preprocess_time, inference_time, 0.0);
+
+                            let (data, shape) = &outputs[0];
+                            let actual_batch = if shape[0] > 0 { shape[0] } else { 1 };
+                            let elems_per_img = data.len() / actual_batch;
+                            let img_slice = &data[i * elems_per_img..(i + 1) * elems_per_img];
+                            let img_shape: &[usize] = &shape[1..];
+
+                            let tensor_shape = preprocess_res.tensor.shape();
+                            let inference_shape =
+                                (tensor_shape[2] as u32, tensor_shape[3] as u32);
+
+                            let result = crate::postprocessing::postprocess_semantic_mask(
+                                img_slice,
+                                img_shape,
+                                Arc::clone(names),
+                                orig_img,
+                                path_i,
+                                speed,
+                                inference_shape,
+                            );
+                            batch_results.push(vec![result]);
+                        }
+
+                        Self::apply_postprocess_time(
+                            &mut batch_results,
+                            start_postprocess,
+                            n_images_f,
+                        );
+                        Ok(())
+                    },
+                )?;
+                return Ok(batch_results);
+            }
+
+            // Same fast path for FP32 input models.
             let batch_tensor = {
                 let pre_borrow = preprocessed_results_opt.borrow();
                 Self::concat_f32_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
@@ -1219,6 +1292,32 @@ impl YOLOModel {
             .collect::<Result<_>>()?;
 
         cb(&views, inference_ms)
+    }
+
+    /// Run ONNX inference with FP16 input where outputs are `uint8` tensors
+    /// (e.g. a semantic segmentation model with FP16 input that has ArgMax+Cast(uint8) baked in).
+    fn run_inference_f16_u8_with<R>(
+        session: &mut Session,
+        input_name: &str,
+        output_names: &[String],
+        input: &ndarray::Array4<f16>,
+        cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
+    ) -> Result<R> {
+        let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
+            InferenceError::InferenceError(format!(
+                "Failed to create FP16 input tensor for u8 output: {e}"
+            ))
+        })?;
+        let inputs = ort::inputs![input_name => input_tensor];
+
+        let t_run = std::time::Instant::now();
+        let outputs = session.run(inputs).map_err(|e| {
+            InferenceError::InferenceError(format!("FP16->u8 inference failed: {e}"))
+        })?;
+        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
+
+        Self::extract_and_invoke_u8(&outputs, output_names, inference_ms, cb)
     }
 
     /// Run ONNX inference with FP16 input, zero-copy callback (FP16 outputs are converted).

--- a/src/model.rs
+++ b/src/model.rs
@@ -473,11 +473,7 @@ impl YOLOModel {
 
     /// Distribute the elapsed wall time since `start` evenly across every result in the
     /// batch and stamp it onto `res.speed.postprocess`. Shared by both postprocess closures.
-    fn apply_postprocess_time(
-        batch: &mut [Vec<Results>],
-        start: Instant,
-        n_images_f: f64,
-    ) {
+    fn apply_postprocess_time(batch: &mut [Vec<Results>], start: Instant, n_images_f: f64) {
         #[allow(clippy::cast_precision_loss)]
         let ms = start.elapsed().as_secs_f64() * 1000.0 / n_images_f;
         for img_results in batch {

--- a/src/model.rs
+++ b/src/model.rs
@@ -964,8 +964,7 @@ impl YOLOModel {
                             let img_shape: &[usize] = &shape[1..];
 
                             let tensor_shape = preprocess_res.tensor.shape();
-                            let inference_shape =
-                                (tensor_shape[2] as u32, tensor_shape[3] as u32);
+                            let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
 
                             let result = crate::postprocessing::postprocess_semantic_mask(
                                 img_slice,

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,7 +24,7 @@ use crate::inference::InferenceConfig;
 use crate::metadata::ModelMetadata;
 use crate::postprocessing::postprocess;
 use crate::preprocessing::{
-    calculate_rect_size, image_to_array, preprocess_image_center_crop, preprocess_image_semantic,
+    calculate_rect_size, image_to_array, preprocess_image_center_crop,
     preprocess_image_with_precision,
 };
 use crate::results::{Results, Speed};
@@ -823,14 +823,6 @@ impl YOLOModel {
 
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)
-            } else if self.metadata.task == Task::Semantic {
-                preprocess_image_semantic(
-                    image,
-                    target_size,
-                    self.metadata.stride,
-                    self.fp16_input,
-                    self.is_dynamic,
-                )
             } else {
                 preprocess_image_with_precision(
                     image,

--- a/src/model.rs
+++ b/src/model.rs
@@ -436,13 +436,15 @@ impl YOLOModel {
 
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
-        use ort::ep::coreml::ModelFormat;
+        use ort::ep::coreml::{ModelFormat, SpecializationStrategy};
 
-        // NeuralNetwork avoids the ORT CoreML EP input-rename bug that MLProgram triggers:
-        // MLProgram inserts a FP32→FP16 cast and renames "images" → "graph_input_cast_0",
-        // causing ORT's feed to fail at runtime.
+        // MLProgram with static input shapes and FastPrediction avoids the ORT CoreML EP
+        // input-rename bug: the rename ("images" -> "graph_input_cast_0") only occurs when
+        // CoreML inserts a dynamic FP32->FP16 cast, which static-shape specialization skips.
         let mut ep = ort::execution_providers::CoreMLExecutionProvider::default()
-            .with_model_format(ModelFormat::NeuralNetwork);
+            .with_model_format(ModelFormat::MLProgram)
+            .with_specialization_strategy(SpecializationStrategy::FastPrediction)
+            .with_static_input_shapes(true);
 
         if let Some(cache_base) = dirs::cache_dir() {
             let canonical = model_path
@@ -461,7 +463,7 @@ impl YOLOModel {
             let cache_dir = cache_base
                 .join("ultralytics-inference")
                 .join("coreml")
-                .join(format!("{stem}_{hash:016x}_neuralnet"));
+                .join(format!("{stem}_{hash:016x}_mlprogram"));
             if std::fs::create_dir_all(&cache_dir).is_ok() {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -471,6 +471,22 @@ impl YOLOModel {
         ep.build()
     }
 
+    /// Distribute the elapsed wall time since `start` evenly across every result in the
+    /// batch and stamp it onto `res.speed.postprocess`. Shared by both postprocess closures.
+    fn apply_postprocess_time(
+        batch: &mut [Vec<Results>],
+        start: Instant,
+        n_images_f: f64,
+    ) {
+        #[allow(clippy::cast_precision_loss)]
+        let ms = start.elapsed().as_secs_f64() * 1000.0 / n_images_f;
+        for img_results in batch {
+            for res in img_results {
+                res.speed.postprocess = Some(ms);
+            }
+        }
+    }
+
     /// Concatenate per-image FP32 input tensors along the batch axis.
     fn concat_f32_batch(
         preprocessed: &[crate::preprocessing::PreprocessResult],
@@ -898,14 +914,7 @@ impl YOLOModel {
                 batch_results.push(vec![result]);
             }
 
-            #[allow(clippy::cast_precision_loss)]
-            let postprocess_time =
-                start_postprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
-            for img_results in &mut batch_results {
-                for res in img_results {
-                    res.speed.postprocess = Some(postprocess_time);
-                }
-            }
+            Self::apply_postprocess_time(&mut batch_results, start_postprocess, n_images_f);
             Ok(batch_results)
         };
 
@@ -946,15 +955,15 @@ impl YOLOModel {
                         let actual_batch = if shape[0] > 0 { shape[0] } else { 1 };
                         let elems_per_img = data.len() / actual_batch;
                         let img_slice = &data[i * elems_per_img..(i + 1) * elems_per_img];
-                        // 3-D shape per image: drop the batch dim.
-                        let img_shape: Vec<usize> = shape[1..].to_vec();
+                        // Per-image shape view (drops the batch dim). Zero-copy slice.
+                        let img_shape: &[usize] = &shape[1..];
 
                         let tensor_shape = preprocess_res.tensor.shape();
                         let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
 
                         let result = crate::postprocessing::postprocess_semantic_mask(
                             img_slice,
-                            &img_shape,
+                            img_shape,
                             names,
                             orig_img,
                             path_i,
@@ -964,14 +973,7 @@ impl YOLOModel {
                         batch_results.push(vec![result]);
                     }
 
-                    #[allow(clippy::cast_precision_loss)]
-                    let postprocess_time =
-                        start_postprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
-                    for v in &mut batch_results {
-                        for r in v {
-                            r.speed.postprocess = Some(postprocess_time);
-                        }
-                    }
+                    Self::apply_postprocess_time(&mut batch_results, start_postprocess, n_images_f);
                     Ok(())
                 },
             )?;
@@ -1131,43 +1133,41 @@ impl YOLOModel {
         inference_ms: f64,
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let mut owned_bufs: Vec<Vec<f32>> = Vec::new();
-        let mut shapes: Vec<Vec<usize>> = Vec::with_capacity(output_names.len());
-        let mut sources: Vec<(Option<usize>, *const f32, usize)> =
-            Vec::with_capacity(output_names.len());
+        // Holds each output as either a zero-copy borrow into the ORT buffer or, for f16
+        // outputs needing dtype conversion, an owned Vec<f32>. Vec reallocation moves the
+        // enum value but not the heap allocation behind `Vec<f32>`, so `.as_slice()` taken
+        // in the second pass is stable.
+        enum OutBuf<'a> {
+            Borrow(&'a [f32]),
+            Owned(Vec<f32>),
+        }
+        let mut bufs: Vec<(OutBuf<'_>, Vec<usize>)> = Vec::with_capacity(output_names.len());
         for output_name in output_names {
             let output = outputs.get(output_name.as_str()).ok_or_else(|| {
                 InferenceError::InferenceError(format!("Output '{output_name}' not found"))
             })?;
-            if let Ok((shape, data)) = output.try_extract_tensor::<f32>() {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let (buf, shape) = if let Ok((shape, data)) = output.try_extract_tensor::<f32>() {
                 let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-                sources.push((None, data.as_ptr(), data.len()));
-                shapes.push(shape_vec);
+                (OutBuf::Borrow(data), shape_vec)
             } else {
                 let (shape, data) = output.try_extract_tensor::<f16>().map_err(|e| {
                     InferenceError::InferenceError(format!("Failed to extract output: {e}"))
                 })?;
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                 let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
                 let converted: Vec<f32> = data.iter().map(|v| v.to_f32()).collect();
-                let len = converted.len();
-                let idx = owned_bufs.len();
-                owned_bufs.push(converted);
-                sources.push((Some(idx), std::ptr::null(), len));
-                shapes.push(shape_vec);
-            }
+                (OutBuf::Owned(converted), shape_vec)
+            };
+            bufs.push((buf, shape));
         }
-        let views: Vec<(&[f32], Vec<usize>)> = sources
+        let views: Vec<(&[f32], Vec<usize>)> = bufs
             .iter()
-            .zip(shapes.iter())
-            .map(|((owned_idx, ptr, len), shape)| {
-                let slice: &[f32] = owned_idx.map_or_else(
-                    // SAFETY: ORT-owned buffer in `outputs` lives until caller returns.
-                    || unsafe { std::slice::from_raw_parts(*ptr, *len) },
-                    |i| owned_bufs[i].as_slice(),
-                );
-                (slice, shape.clone())
+            .map(|(b, s)| {
+                let slice: &[f32] = match b {
+                    OutBuf::Borrow(d) => d,
+                    OutBuf::Owned(v) => v.as_slice(),
+                };
+                (slice, s.clone())
             })
             .collect();
 
@@ -1205,29 +1205,21 @@ impl YOLOModel {
         inference_ms: f64,
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let mut shapes: Vec<Vec<usize>> = Vec::with_capacity(output_names.len());
-        let mut sources: Vec<(*const u8, usize)> = Vec::with_capacity(output_names.len());
-        for output_name in output_names {
-            let output = outputs.get(output_name.as_str()).ok_or_else(|| {
-                InferenceError::InferenceError(format!("Output '{output_name}' not found"))
-            })?;
-            let (shape, data) = output.try_extract_tensor::<u8>().map_err(|e| {
-                InferenceError::InferenceError(format!("Failed to extract uint8 output: {e}"))
-            })?;
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-            sources.push((data.as_ptr(), data.len()));
-            shapes.push(shape_vec);
-        }
-        let views: Vec<(&[u8], Vec<usize>)> = sources
+        // All outputs are direct borrows from ORT — no fallback path, no unsafe needed.
+        let views: Vec<(&[u8], Vec<usize>)> = output_names
             .iter()
-            .zip(shapes.iter())
-            .map(|((ptr, len), shape)| {
-                // SAFETY: ORT-owned buffer in `outputs` lives until caller returns.
-                let slice: &[u8] = unsafe { std::slice::from_raw_parts(*ptr, *len) };
-                (slice, shape.clone())
+            .map(|name| {
+                let output = outputs.get(name.as_str()).ok_or_else(|| {
+                    InferenceError::InferenceError(format!("Output '{name}' not found"))
+                })?;
+                let (shape, data) = output.try_extract_tensor::<u8>().map_err(|e| {
+                    InferenceError::InferenceError(format!("Failed to extract uint8 output: {e}"))
+                })?;
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let shape_vec: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+                Ok((data, shape_vec))
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
         cb(&views, inference_ms)
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,7 +24,7 @@ use crate::inference::InferenceConfig;
 use crate::metadata::ModelMetadata;
 use crate::postprocessing::postprocess;
 use crate::preprocessing::{
-    calculate_rect_size, image_to_array, preprocess_image_center_crop, preprocess_image_semseg,
+    calculate_rect_size, image_to_array, preprocess_image_center_crop, preprocess_image_semantic,
     preprocess_image_with_precision,
 };
 use crate::results::{Results, Speed};
@@ -523,7 +523,7 @@ impl YOLOModel {
     }
 
     /// Returns true when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only output is
-    /// a `[B, H, W] uint8` class map. Lets us skip f32 logits extraction + CPU argmax for semseg.
+    /// a `[B, H, W] uint8` class map. Lets us skip f32 logits extraction + CPU argmax for semantic segmentation.
     fn has_semantic_mask_output(&self) -> bool {
         let outs = self.session.outputs();
         outs.len() == 1
@@ -815,7 +815,7 @@ impl YOLOModel {
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)
             } else if self.metadata.task == Task::Semantic {
-                preprocess_image_semseg(
+                preprocess_image_semantic(
                     image,
                     target_size,
                     self.metadata.stride,
@@ -1097,7 +1097,7 @@ impl YOLOModel {
     ///
     /// `cb` receives `&[(&[f32], shape)]` borrowing directly into ORT-owned device-to-host
     /// buffers (no extra Vec allocation), plus the measured `session.run()` time in ms.
-    /// This avoids a ~40 ms memcpy for large semseg outputs.
+    /// This avoids a ~40 ms memcpy for large semantic segmentation outputs.
     ///
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
     fn run_inference_with<R>(
@@ -1172,7 +1172,7 @@ impl YOLOModel {
     }
 
     /// Run ONNX inference with FP32 input where outputs are `uint8` tensors
-    /// (e.g. a semseg model that has ArgMax+Cast(uint8) baked in). Zero-copy.
+    /// (e.g. a semantic segmentation model that has ArgMax+Cast(uint8) baked in). Zero-copy.
     fn run_inference_u8_with<R>(
         session: &mut Session,
         input_name: &str,

--- a/src/model.rs
+++ b/src/model.rs
@@ -23,8 +23,8 @@ use crate::inference::InferenceConfig;
 use crate::metadata::ModelMetadata;
 use crate::postprocessing::postprocess;
 use crate::preprocessing::{
-    calculate_rect_size, image_to_array, preprocess_image_center_crop,
-    preprocess_image_semseg, preprocess_image_with_precision,
+    calculate_rect_size, image_to_array, preprocess_image_center_crop, preprocess_image_semseg,
+    preprocess_image_with_precision,
 };
 use crate::results::{Results, Speed};
 use crate::task::Task;

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,7 +24,7 @@ use crate::metadata::ModelMetadata;
 use crate::postprocessing::postprocess;
 use crate::preprocessing::{
     calculate_rect_size, image_to_array, preprocess_image_center_crop,
-    preprocess_image_with_precision,
+    preprocess_image_semseg, preprocess_image_with_precision,
 };
 use crate::results::{Results, Speed};
 use crate::task::Task;
@@ -154,9 +154,13 @@ impl YOLOModel {
                     provider_name = "CUDAExecutionProvider";
                 }
                 #[cfg(feature = "coreml")]
-                crate::Device::CoreMl | crate::Device::Mps => {
-                    // Map both CoreML and MPS to CoreMLExecutionProvider
+                crate::Device::CoreMl => {
                     eps.push(Self::build_coreml_ep(path));
+                    provider_name = "CoreMLExecutionProvider";
+                }
+                #[cfg(feature = "coreml")]
+                crate::Device::Mps => {
+                    eps.push(Self::build_coreml_gpu_ep(path));
                     provider_name = "CoreMLExecutionProvider";
                 }
                 #[cfg(feature = "tensorrt")]
@@ -415,7 +419,29 @@ impl YOLOModel {
 
     #[cfg(feature = "coreml")]
     fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
-        let mut ep = ort::execution_providers::CoreMLExecutionProvider::default();
+        Self::build_coreml_ep_inner(model_path, false)
+    }
+
+    #[cfg(feature = "coreml")]
+    fn build_coreml_gpu_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
+        Self::build_coreml_ep_inner(model_path, true)
+    }
+
+    #[cfg(feature = "coreml")]
+    fn build_coreml_ep_inner(model_path: &Path, gpu: bool) -> ort::execution_providers::ExecutionProviderDispatch {
+        use ort::ep::coreml::{ComputeUnits, ModelFormat, SpecializationStrategy};
+
+        let mut ep = ort::execution_providers::CoreMLExecutionProvider::default()
+            .with_model_format(ModelFormat::MLProgram)
+            .with_specialization_strategy(SpecializationStrategy::FastPrediction)
+            .with_static_input_shapes(true);
+
+        if gpu {
+            ep = ep
+                .with_compute_units(ComputeUnits::CPUAndGPU)
+                .with_low_precision_accumulation_on_gpu(true);
+        }
+
         if let Some(cache_base) = dirs::cache_dir() {
             let canonical = model_path
                 .canonicalize()
@@ -431,10 +457,11 @@ impl YOLOModel {
                 .fold(14_695_981_039_346_656_037u64, |h, &b| {
                     h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
                 });
+            let variant = if gpu { "gpu" } else { "ane" };
             let cache_dir = cache_base
                 .join("ultralytics-inference")
                 .join("coreml")
-                .join(format!("{stem}_{hash:016x}"));
+                .join(format!("{stem}_{hash:016x}_{variant}"));
             if std::fs::create_dir_all(&cache_dir).is_ok() {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }
@@ -694,6 +721,14 @@ impl YOLOModel {
 
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)
+            } else if self.metadata.task == Task::SemSeg {
+                preprocess_image_semseg(
+                    image,
+                    target_size,
+                    self.metadata.stride,
+                    self.fp16_input,
+                    self.is_dynamic,
+                )
             } else {
                 preprocess_image_with_precision(
                     image,

--- a/src/model.rs
+++ b/src/model.rs
@@ -814,7 +814,7 @@ impl YOLOModel {
 
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)
-            } else if self.metadata.task == Task::SemSeg {
+            } else if self.metadata.task == Task::Semantic {
                 preprocess_image_semseg(
                     image,
                     target_size,
@@ -935,7 +935,7 @@ impl YOLOModel {
                 &self.output_names,
                 &batch_tensor,
                 |outputs, inference_ms_total| {
-                    debug_assert_eq!(task, crate::task::Task::SemSeg);
+                    debug_assert_eq!(task, crate::task::Task::Semantic);
                     let inference_time = inference_ms_total / n_images_f;
                     let start_postprocess = std::time::Instant::now();
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1698,6 +1698,33 @@ fn postprocess_obb_end2end(
     results
 }
 
+/// Compute the centered-letterbox crop bounds in model-output (lh, lw) space that
+/// cover the original image (oh, ow).
+///
+/// Returns `(top, left, crop_h, crop_w)` or `None` if the crop is empty (degenerate input).
+#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+fn letterbox_crop_bounds(
+    lh: usize,
+    lw: usize,
+    oh: usize,
+    ow: usize,
+) -> Option<(usize, usize, usize, usize)> {
+    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
+    let pad_h_half = (lh as f32 - (oh as f32 * gain).round()) / 2.0;
+    let pad_w_half = (lw as f32 - (ow as f32 * gain).round()) / 2.0;
+    let top = (pad_h_half - 0.1).round().max(0.0) as usize;
+    let left = (pad_w_half - 0.1).round().max(0.0) as usize;
+    let bottom = lh.saturating_sub((pad_h_half + 0.1).round() as usize);
+    let right = lw.saturating_sub((pad_w_half + 0.1).round() as usize);
+    let crop_h = bottom.saturating_sub(top);
+    let crop_w = right.saturating_sub(left);
+    if crop_h == 0 || crop_w == 0 {
+        None
+    } else {
+        Some((top, left, crop_h, crop_w))
+    }
+}
+
 /// Post-process a semseg ONNX that has ArgMax + Cast(uint8) baked in.
 ///
 /// Output shape is `[1, lh, lw] uint8`. For cityscapes-style inputs where the model's
@@ -1745,18 +1772,9 @@ pub fn postprocess_semantic_mask(
     }
 
     // Slow path: crop centered letterbox padding in semantic-mask space, then NN upsample.
-    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
-    let pad_h_half = (lh as f32 - (oh as f32 * gain).round()) / 2.0;
-    let pad_w_half = (lw as f32 - (ow as f32 * gain).round()) / 2.0;
-    let top = (pad_h_half - 0.1).round().max(0.0) as usize;
-    let left = (pad_w_half - 0.1).round().max(0.0) as usize;
-    let bottom = lh.saturating_sub((pad_h_half + 0.1).round() as usize);
-    let right = lw.saturating_sub((pad_w_half + 0.1).round() as usize);
-    let crop_h = bottom.saturating_sub(top);
-    let crop_w = right.saturating_sub(left);
-    if crop_h == 0 || crop_w == 0 {
+    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
         return results;
-    }
+    };
 
     let scale_y = crop_h as f32 / oh as f32;
     let scale_x = crop_w as f32 / ow as f32;
@@ -1872,29 +1890,10 @@ fn postprocess_semseg(
             }
         });
 
-    // Crop centered letterbox padding using the same rounding rule as `scale_masks`:
-    //   gain = min(lh/oh, lw/ow)
-    //   pad_w, pad_h = lw - round(ow*gain), lh - round(oh*gain)    // total padding
-    //   if center: pad_w /= 2; pad_h /= 2                          // half on each side
-    //   top, left = round(pad_h - 0.1),  round(pad_w - 0.1)
-    //   bottom, right = lh - round(pad_h + 0.1), lw - round(pad_w + 0.1)
-    // Then upsample masks[..., top:bottom, left:right] to (oh, ow).
-    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
-    let pad_h_total = lh as f32 - (oh as f32 * gain).round();
-    let pad_w_total = lw as f32 - (ow as f32 * gain).round();
-    let pad_h_half = pad_h_total / 2.0;
-    let pad_w_half = pad_w_total / 2.0;
-    let top = (pad_h_half - 0.1).round().max(0.0) as usize;
-    let left = (pad_w_half - 0.1).round().max(0.0) as usize;
-    let bottom = lh.saturating_sub((pad_h_half + 0.1).round() as usize);
-    let right = lw.saturating_sub((pad_w_half + 0.1).round() as usize);
-    let crop_h = bottom.saturating_sub(top);
-    let crop_w = right.saturating_sub(left);
-
-    if crop_h == 0 || crop_w == 0 {
+    // Crop centered letterbox padding, then bilinear-upsample crop to (oh, ow).
+    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
         return results;
-    }
-
+    };
     let scale_y = crop_h as f32 / oh as f32;
     let scale_x = crop_w as f32 / ow as f32;
     let lw_minus_1 = lw.saturating_sub(1);

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1731,70 +1731,6 @@ fn letterbox_crop_bounds(
     }
 }
 
-#[derive(Clone, Copy)]
-struct SemanticGeometry {
-    oh: usize,
-    ow: usize,
-    lh: usize,
-    lw: usize,
-}
-
-#[derive(Clone, Copy)]
-struct SemanticCrop {
-    top: usize,
-    left: usize,
-    crop_h: usize,
-    crop_w: usize,
-    scale_y: f32,
-    scale_x: f32,
-}
-
-fn semantic_geometry(
-    shape: &[usize],
-    output_is_empty: bool,
-    orig_img: &Array3<u8>,
-    min_shape_len: usize,
-) -> Option<SemanticGeometry> {
-    if output_is_empty || shape.len() < min_shape_len {
-        return None;
-    }
-    let oh = orig_img.shape()[0];
-    let ow = orig_img.shape()[1];
-    let (lh, lw) = (shape[shape.len() - 2], shape[shape.len() - 1]);
-    if lh == 0 || lw == 0 || oh == 0 || ow == 0 {
-        None
-    } else {
-        Some(SemanticGeometry { oh, ow, lh, lw })
-    }
-}
-
-#[allow(clippy::cast_precision_loss)]
-fn semantic_crop(geo: SemanticGeometry) -> Option<SemanticCrop> {
-    let (top, left, crop_h, crop_w) = letterbox_crop_bounds(geo.lh, geo.lw, geo.oh, geo.ow)?;
-    Some(SemanticCrop {
-        top,
-        left,
-        crop_h,
-        crop_w,
-        scale_y: crop_h as f32 / geo.oh as f32,
-        scale_x: crop_w as f32 / geo.ow as f32,
-    })
-}
-
-fn semantic_results_with_mask(
-    orig_img: Array3<u8>,
-    path: String,
-    names: Arc<HashMap<usize, String>>,
-    speed: Speed,
-    inference_shape: (u32, u32),
-    class_map: Array2<u32>,
-    orig_shape: (u32, u32),
-) -> Results {
-    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
-    results.semantic_mask = Some(SemanticMask::new(class_map, orig_shape));
-    results
-}
-
 /// Post-process a Semantic Segmentation ONNX that has ArgMax + Cast(uint8) baked in.
 ///
 /// Output shape is `[1, lh, lw] uint8`. For cityscapes-style inputs where the model's
@@ -1824,61 +1760,54 @@ pub fn postprocess_semantic_mask(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let Some(geo) = semantic_geometry(shape, output.is_empty(), &orig_img, 2) else {
-        return Results::new(orig_img, path, names, speed, inference_shape);
-    };
-    let orig_shape = (geo.oh as u32, geo.ow as u32);
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
+
+    if shape.len() < 2 || output.is_empty() {
+        return results;
+    }
+    let (lh, lw) = (shape[shape.len() - 2], shape[shape.len() - 1]);
+    if lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+        return results;
+    }
 
     // Model output already at original resolution: just widen u8 -> u32.
-    if geo.lh == geo.oh && geo.lw == geo.ow {
-        let mut buf = vec![0u32; geo.oh * geo.ow];
+    if lh == oh && lw == ow {
+        let mut buf = vec![0u32; oh * ow];
         for (dst, &src) in buf.iter_mut().zip(output.iter()) {
             *dst = u32::from(src);
         }
-        let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
-        return semantic_results_with_mask(
-            orig_img,
-            path,
-            names,
-            speed,
-            inference_shape,
-            class_map,
-            orig_shape,
-        );
+        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
+        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+        return results;
     }
 
     // Slow path: crop centered letterbox padding in semantic-mask space, then NN upsample.
-    let Some(crop) = semantic_crop(geo) else {
-        return Results::new(orig_img, path, names, speed, inference_shape);
+    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
+        return results;
     };
 
-    let crop_h_minus_1 = crop.crop_h.saturating_sub(1);
-    let crop_w_minus_1 = crop.crop_w.saturating_sub(1);
-    let x_lut: Vec<usize> = (0..geo.ow)
-        .map(|dx| ((dx as f32 + 0.5) * crop.scale_x) as usize)
-        .map(|sx| sx.min(crop_w_minus_1) + crop.left)
+    let scale_y = crop_h as f32 / oh as f32;
+    let scale_x = crop_w as f32 / ow as f32;
+    let crop_h_minus_1 = crop_h.saturating_sub(1);
+    let crop_w_minus_1 = crop_w.saturating_sub(1);
+    let x_lut: Vec<usize> = (0..ow)
+        .map(|dx| ((dx as f32 + 0.5) * scale_x) as usize)
+        .map(|sx| sx.min(crop_w_minus_1) + left)
         .collect();
 
-    let mut buf = vec![0u32; geo.oh * geo.ow];
-    buf.par_chunks_mut(geo.ow)
-        .enumerate()
-        .for_each(|(dy, row)| {
-            let sy = (((dy as f32 + 0.5) * crop.scale_y) as usize).min(crop_h_minus_1) + crop.top;
-            let src_row_base = sy * geo.lw;
-            for (dx, cell) in row.iter_mut().enumerate() {
-                *cell = u32::from(output[src_row_base + x_lut[dx]]);
-            }
-        });
-    let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
-    semantic_results_with_mask(
-        orig_img,
-        path,
-        names,
-        speed,
-        inference_shape,
-        class_map,
-        orig_shape,
-    )
+    let mut buf = vec![0u32; oh * ow];
+    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+        let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
+        let src_row_base = sy * lw;
+        for (dx, cell) in row.iter_mut().enumerate() {
+            *cell = u32::from(output[src_row_base + x_lut[dx]]);
+        }
+    });
+    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
+    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+    results
 }
 
 /// Post-process semantic segmentation model output.
@@ -1907,39 +1836,45 @@ fn postprocess_semantic(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let Some(geo) = semantic_geometry(shape, output.is_empty(), &orig_img, 4) else {
-        return Results::new(orig_img, path, names, speed, inference_shape);
-    };
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
+
+    if shape.len() < 4 || output.is_empty() {
+        return results;
+    }
 
     let nc = shape[1];
-    if nc == 0 {
-        return Results::new(orig_img, path, names, speed, inference_shape);
+    let lh = shape[2];
+    let lw = shape[3];
+
+    if nc == 0 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+        return results;
     }
-    let orig_shape = (geo.oh as u32, geo.ow as u32);
 
     // Model output is already at orig_img resolution (no resize, no padding).
     // Avoids the CHW->HWC transpose and bilinear interpolation entirely: just argmax over
     // the class channel for each pixel. Hits when the export bakes a full-res upsample
     // into the ONNX graph and the input was the model's native rect shape.
-    if geo.lh == geo.oh && geo.lw == geo.ow {
-        let plane = geo.lh * geo.lw;
-        let mut buf = vec![0u32; geo.oh * geo.ow];
+    if lh == oh && lw == ow {
+        let plane = lh * lw;
+        let mut buf = vec![0u32; oh * ow];
         // Load one source row per class at a time so each row fits in cache.
         // Scratch buffer shared across all rows a given thread processes; one allocation per thread.
-        buf.par_chunks_mut(geo.ow).enumerate().for_each_with(
-            vec![0.0f32; geo.lw],
+        buf.par_chunks_mut(ow).enumerate().for_each_with(
+            vec![0.0f32; lw],
             |best_vals, (dy, row)| {
                 if nc == 1 {
-                    let src = &output[dy * geo.lw..(dy + 1) * geo.lw];
+                    let src = &output[dy * lw..(dy + 1) * lw];
                     for (cell, &v) in row.iter_mut().zip(src.iter()) {
                         *cell = u32::from(v > 0.0);
                     }
                 } else {
                     // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
-                    let src0 = &output[dy * geo.lw..(dy + 1) * geo.lw];
+                    let src0 = &output[dy * lw..(dy + 1) * lw];
                     best_vals.copy_from_slice(src0);
                     for c in 1..nc {
-                        let src_c = &output[c * plane + dy * geo.lw..c * plane + (dy + 1) * geo.lw];
+                        let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
                         for ((cell, best), &v) in
                             row.iter_mut().zip(best_vals.iter_mut()).zip(src_c.iter())
                         {
@@ -1952,30 +1887,25 @@ fn postprocess_semantic(
                 }
             },
         );
-        let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
-        return semantic_results_with_mask(
-            orig_img,
-            path,
-            names,
-            speed,
-            inference_shape,
-            class_map,
-            orig_shape,
-        );
+        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
+        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+        return results;
     }
 
     // Crop centered letterbox padding, then bilinear-upsample crop to (oh, ow).
-    let plane = geo.lh * geo.lw;
-    let Some(crop) = semantic_crop(geo) else {
-        return Results::new(orig_img, path, names, speed, inference_shape);
+    let plane = lh * lw;
+    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
+        return results;
     };
-    let lw_minus_1 = geo.lw.saturating_sub(1);
-    let lh_minus_1 = geo.lh.saturating_sub(1);
+    let scale_y = crop_h as f32 / oh as f32;
+    let scale_x = crop_w as f32 / ow as f32;
+    let lw_minus_1 = lw.saturating_sub(1);
+    let lh_minus_1 = lh.saturating_sub(1);
 
     // Precompute source-x neighbors + weights once per output column.
-    let x_lut: Vec<(usize, usize, f32, f32)> = (0..geo.ow)
+    let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
         .map(|dx| {
-            let sx = (dx as f32 + 0.5).mul_add(crop.scale_x, -0.5).max(0.0) + crop.left as f32;
+            let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0) + left as f32;
             let x0 = (sx.floor() as usize).min(lw_minus_1);
             let x1 = (x0 + 1).min(lw_minus_1);
             let fx = sx - x0 as f32;
@@ -1985,28 +1915,40 @@ fn postprocess_semantic(
 
     // Bilinear upsample and argmax directly on CHW data, skipping the transpose.
     // Reads are strided (one plane apart per class) but avoids transposing 39M floats.
-    let mut buf = vec![0u32; geo.oh * geo.ow];
-    buf.par_chunks_mut(geo.ow)
-        .enumerate()
-        .for_each(|(dy, row)| {
-            let sy = (dy as f32 + 0.5).mul_add(crop.scale_y, -0.5).max(0.0) + crop.top as f32;
-            let y0 = (sy.floor() as usize).min(lh_minus_1);
-            let y1 = (y0 + 1).min(lh_minus_1);
-            let fy = sy - y0 as f32;
-            let fyi = 1.0 - fy;
+    let mut buf = vec![0u32; oh * ow];
+    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+        let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
+        let y0 = (sy.floor() as usize).min(lh_minus_1);
+        let y1 = (y0 + 1).min(lh_minus_1);
+        let fy = sy - y0 as f32;
+        let fyi = 1.0 - fy;
 
-            let row0_base = y0 * geo.lw;
-            let row1_base = y1 * geo.lw;
+        let row0_base = y0 * lw;
+        let row1_base = y1 * lw;
 
-            for (dx, cell) in row.iter_mut().enumerate() {
-                let (x0, x1, fxi, fx) = x_lut[dx];
-                let w00 = fyi * fxi;
-                let w10 = fy * fxi;
-                let w01 = fyi * fx;
-                let w11 = fy * fx;
+        for (dx, cell) in row.iter_mut().enumerate() {
+            let (x0, x1, fxi, fx) = x_lut[dx];
+            let w00 = fyi * fxi;
+            let w10 = fy * fxi;
+            let w01 = fyi * fx;
+            let w11 = fy * fx;
 
-                *cell = if nc == 1 {
-                    let base = 0;
+            *cell = if nc == 1 {
+                let base = 0;
+                let v = output[base + row1_base + x1].mul_add(
+                    w11,
+                    output[base + row0_base + x1].mul_add(
+                        w01,
+                        output[base + row1_base + x0]
+                            .mul_add(w10, output[base + row0_base + x0] * w00),
+                    ),
+                );
+                u32::from(v > 0.0)
+            } else {
+                let mut best_cls = 0u32;
+                let mut best_val = f32::NEG_INFINITY;
+                for c in 0..nc {
+                    let base = c * plane;
                     let v = output[base + row1_base + x1].mul_add(
                         w11,
                         output[base + row0_base + x1].mul_add(
@@ -2015,39 +1957,18 @@ fn postprocess_semantic(
                                 .mul_add(w10, output[base + row0_base + x0] * w00),
                         ),
                     );
-                    u32::from(v > 0.0)
-                } else {
-                    let mut best_cls = 0u32;
-                    let mut best_val = f32::NEG_INFINITY;
-                    for c in 0..nc {
-                        let base = c * plane;
-                        let v = output[base + row1_base + x1].mul_add(
-                            w11,
-                            output[base + row0_base + x1].mul_add(
-                                w01,
-                                output[base + row1_base + x0]
-                                    .mul_add(w10, output[base + row0_base + x0] * w00),
-                            ),
-                        );
-                        if v > best_val {
-                            best_val = v;
-                            best_cls = c as u32;
-                        }
+                    if v > best_val {
+                        best_val = v;
+                        best_cls = c as u32;
                     }
-                    best_cls
-                };
-            }
-        });
-    let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
-    semantic_results_with_mask(
-        orig_img,
-        path,
-        names,
-        speed,
-        inference_shape,
-        class_map,
-        orig_shape,
-    )
+                }
+                best_cls
+            };
+        }
+    });
+    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
+    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+    results
 }
 
 #[cfg(test)]

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1823,7 +1823,7 @@ pub fn postprocess_semantic_mask(
 /// The model outputs raw logits of shape `[1, nc, lh, lw]` at the P3 scale
 /// (stride 8). Pipeline:
 /// 1. Transpose CHW to HWC once (small: lh*lw*nc f32s) so per-pixel argmax is contiguous.
-/// 2. Bilinear-interpolate each output pixel's 4 source neighbours, fused with argmax
+/// 2. Bilinear-interpolate each output pixel's 4 source neighbors, fused with argmax
 ///    over `nc` classes, producing the final class map in one pass.
 ///
 /// Memory traffic per output pixel drops from 4*nc strided reads to 4*nc contiguous
@@ -1916,7 +1916,7 @@ fn postprocess_semantic(
     let lw_minus_1 = lw.saturating_sub(1);
     let lh_minus_1 = lh.saturating_sub(1);
 
-    // Precompute source-x neighbours + weights once per output column (with left offset).
+    // Precompute source-x neighbors + weights once per output column (with left offset).
     let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
         .map(|dx| {
             let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0) + left as f32;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -22,7 +22,9 @@ use wide::{CmpGt, f32x8};
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
 use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Axis, Zip, s};
-use rayon::prelude::{IndexedParallelIterator, ParallelIterator, IntoParallelIterator, ParallelSliceMut};
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSliceMut,
+};
 
 use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1731,6 +1731,70 @@ fn letterbox_crop_bounds(
     }
 }
 
+#[derive(Clone, Copy)]
+struct SemanticGeometry {
+    oh: usize,
+    ow: usize,
+    lh: usize,
+    lw: usize,
+}
+
+#[derive(Clone, Copy)]
+struct SemanticCrop {
+    top: usize,
+    left: usize,
+    crop_h: usize,
+    crop_w: usize,
+    scale_y: f32,
+    scale_x: f32,
+}
+
+fn semantic_geometry(
+    shape: &[usize],
+    output_is_empty: bool,
+    orig_img: &Array3<u8>,
+    min_shape_len: usize,
+) -> Option<SemanticGeometry> {
+    if output_is_empty || shape.len() < min_shape_len {
+        return None;
+    }
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+    let (lh, lw) = (shape[shape.len() - 2], shape[shape.len() - 1]);
+    if lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+        None
+    } else {
+        Some(SemanticGeometry { oh, ow, lh, lw })
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn semantic_crop(geo: SemanticGeometry) -> Option<SemanticCrop> {
+    let (top, left, crop_h, crop_w) = letterbox_crop_bounds(geo.lh, geo.lw, geo.oh, geo.ow)?;
+    Some(SemanticCrop {
+        top,
+        left,
+        crop_h,
+        crop_w,
+        scale_y: crop_h as f32 / geo.oh as f32,
+        scale_x: crop_w as f32 / geo.ow as f32,
+    })
+}
+
+fn semantic_results_with_mask(
+    orig_img: Array3<u8>,
+    path: String,
+    names: Arc<HashMap<usize, String>>,
+    speed: Speed,
+    inference_shape: (u32, u32),
+    class_map: Array2<u32>,
+    orig_shape: (u32, u32),
+) -> Results {
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
+    results.semantic_mask = Some(SemanticMask::new(class_map, orig_shape));
+    results
+}
+
 /// Post-process a Semantic Segmentation ONNX that has ArgMax + Cast(uint8) baked in.
 ///
 /// Output shape is `[1, lh, lw] uint8`. For cityscapes-style inputs where the model's
@@ -1760,54 +1824,61 @@ pub fn postprocess_semantic_mask(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let oh = orig_img.shape()[0];
-    let ow = orig_img.shape()[1];
-    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
-
-    if shape.len() < 2 || output.is_empty() {
-        return results;
-    }
-    let (lh, lw) = (shape[shape.len() - 2], shape[shape.len() - 1]);
-    if lh == 0 || lw == 0 || oh == 0 || ow == 0 {
-        return results;
-    }
+    let Some(geo) = semantic_geometry(shape, output.is_empty(), &orig_img, 2) else {
+        return Results::new(orig_img, path, names, speed, inference_shape);
+    };
+    let orig_shape = (geo.oh as u32, geo.ow as u32);
 
     // Model output already at original resolution: just widen u8 -> u32.
-    if lh == oh && lw == ow {
-        let mut buf = vec![0u32; oh * ow];
+    if geo.lh == geo.oh && geo.lw == geo.ow {
+        let mut buf = vec![0u32; geo.oh * geo.ow];
         for (dst, &src) in buf.iter_mut().zip(output.iter()) {
             *dst = u32::from(src);
         }
-        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
-        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
-        return results;
+        let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
+        return semantic_results_with_mask(
+            orig_img,
+            path,
+            names,
+            speed,
+            inference_shape,
+            class_map,
+            orig_shape,
+        );
     }
 
     // Slow path: crop centered letterbox padding in semantic-mask space, then NN upsample.
-    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
-        return results;
+    let Some(crop) = semantic_crop(geo) else {
+        return Results::new(orig_img, path, names, speed, inference_shape);
     };
 
-    let scale_y = crop_h as f32 / oh as f32;
-    let scale_x = crop_w as f32 / ow as f32;
-    let crop_h_minus_1 = crop_h.saturating_sub(1);
-    let crop_w_minus_1 = crop_w.saturating_sub(1);
-    let x_lut: Vec<usize> = (0..ow)
-        .map(|dx| ((dx as f32 + 0.5) * scale_x) as usize)
-        .map(|sx| sx.min(crop_w_minus_1) + left)
+    let crop_h_minus_1 = crop.crop_h.saturating_sub(1);
+    let crop_w_minus_1 = crop.crop_w.saturating_sub(1);
+    let x_lut: Vec<usize> = (0..geo.ow)
+        .map(|dx| ((dx as f32 + 0.5) * crop.scale_x) as usize)
+        .map(|sx| sx.min(crop_w_minus_1) + crop.left)
         .collect();
 
-    let mut buf = vec![0u32; oh * ow];
-    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
-        let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
-        let src_row_base = sy * lw;
-        for (dx, cell) in row.iter_mut().enumerate() {
-            *cell = u32::from(output[src_row_base + x_lut[dx]]);
-        }
-    });
-    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
-    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
-    results
+    let mut buf = vec![0u32; geo.oh * geo.ow];
+    buf.par_chunks_mut(geo.ow)
+        .enumerate()
+        .for_each(|(dy, row)| {
+            let sy = (((dy as f32 + 0.5) * crop.scale_y) as usize).min(crop_h_minus_1) + crop.top;
+            let src_row_base = sy * geo.lw;
+            for (dx, cell) in row.iter_mut().enumerate() {
+                *cell = u32::from(output[src_row_base + x_lut[dx]]);
+            }
+        });
+    let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
+    semantic_results_with_mask(
+        orig_img,
+        path,
+        names,
+        speed,
+        inference_shape,
+        class_map,
+        orig_shape,
+    )
 }
 
 /// Post-process semantic segmentation model output.
@@ -1836,45 +1907,39 @@ fn postprocess_semantic(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let oh = orig_img.shape()[0];
-    let ow = orig_img.shape()[1];
-    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
-
-    if shape.len() < 4 || output.is_empty() {
-        return results;
-    }
+    let Some(geo) = semantic_geometry(shape, output.is_empty(), &orig_img, 4) else {
+        return Results::new(orig_img, path, names, speed, inference_shape);
+    };
 
     let nc = shape[1];
-    let lh = shape[2];
-    let lw = shape[3];
-
-    if nc == 0 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
-        return results;
+    if nc == 0 {
+        return Results::new(orig_img, path, names, speed, inference_shape);
     }
+    let orig_shape = (geo.oh as u32, geo.ow as u32);
 
     // Model output is already at orig_img resolution (no resize, no padding).
     // Avoids the CHW->HWC transpose and bilinear interpolation entirely: just argmax over
     // the class channel for each pixel. Hits when the export bakes a full-res upsample
     // into the ONNX graph and the input was the model's native rect shape.
-    if lh == oh && lw == ow {
-        let plane = lh * lw;
-        let mut buf = vec![0u32; oh * ow];
+    if geo.lh == geo.oh && geo.lw == geo.ow {
+        let plane = geo.lh * geo.lw;
+        let mut buf = vec![0u32; geo.oh * geo.ow];
         // Load one source row per class at a time so each row fits in cache.
         // Scratch buffer shared across all rows a given thread processes; one allocation per thread.
-        buf.par_chunks_mut(ow).enumerate().for_each_with(
-            vec![0.0f32; lw],
+        buf.par_chunks_mut(geo.ow).enumerate().for_each_with(
+            vec![0.0f32; geo.lw],
             |best_vals, (dy, row)| {
                 if nc == 1 {
-                    let src = &output[dy * lw..(dy + 1) * lw];
+                    let src = &output[dy * geo.lw..(dy + 1) * geo.lw];
                     for (cell, &v) in row.iter_mut().zip(src.iter()) {
                         *cell = u32::from(v > 0.0);
                     }
                 } else {
                     // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
-                    let src0 = &output[dy * lw..(dy + 1) * lw];
+                    let src0 = &output[dy * geo.lw..(dy + 1) * geo.lw];
                     best_vals.copy_from_slice(src0);
                     for c in 1..nc {
-                        let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
+                        let src_c = &output[c * plane + dy * geo.lw..c * plane + (dy + 1) * geo.lw];
                         for ((cell, best), &v) in
                             row.iter_mut().zip(best_vals.iter_mut()).zip(src_c.iter())
                         {
@@ -1887,25 +1952,30 @@ fn postprocess_semantic(
                 }
             },
         );
-        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
-        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
-        return results;
+        let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
+        return semantic_results_with_mask(
+            orig_img,
+            path,
+            names,
+            speed,
+            inference_shape,
+            class_map,
+            orig_shape,
+        );
     }
 
     // Crop centered letterbox padding, then bilinear-upsample crop to (oh, ow).
-    let plane = lh * lw;
-    let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
-        return results;
+    let plane = geo.lh * geo.lw;
+    let Some(crop) = semantic_crop(geo) else {
+        return Results::new(orig_img, path, names, speed, inference_shape);
     };
-    let scale_y = crop_h as f32 / oh as f32;
-    let scale_x = crop_w as f32 / ow as f32;
-    let lw_minus_1 = lw.saturating_sub(1);
-    let lh_minus_1 = lh.saturating_sub(1);
+    let lw_minus_1 = geo.lw.saturating_sub(1);
+    let lh_minus_1 = geo.lh.saturating_sub(1);
 
     // Precompute source-x neighbors + weights once per output column.
-    let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
+    let x_lut: Vec<(usize, usize, f32, f32)> = (0..geo.ow)
         .map(|dx| {
-            let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0) + left as f32;
+            let sx = (dx as f32 + 0.5).mul_add(crop.scale_x, -0.5).max(0.0) + crop.left as f32;
             let x0 = (sx.floor() as usize).min(lw_minus_1);
             let x1 = (x0 + 1).min(lw_minus_1);
             let fx = sx - x0 as f32;
@@ -1915,40 +1985,28 @@ fn postprocess_semantic(
 
     // Bilinear upsample and argmax directly on CHW data, skipping the transpose.
     // Reads are strided (one plane apart per class) but avoids transposing 39M floats.
-    let mut buf = vec![0u32; oh * ow];
-    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
-        let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
-        let y0 = (sy.floor() as usize).min(lh_minus_1);
-        let y1 = (y0 + 1).min(lh_minus_1);
-        let fy = sy - y0 as f32;
-        let fyi = 1.0 - fy;
+    let mut buf = vec![0u32; geo.oh * geo.ow];
+    buf.par_chunks_mut(geo.ow)
+        .enumerate()
+        .for_each(|(dy, row)| {
+            let sy = (dy as f32 + 0.5).mul_add(crop.scale_y, -0.5).max(0.0) + crop.top as f32;
+            let y0 = (sy.floor() as usize).min(lh_minus_1);
+            let y1 = (y0 + 1).min(lh_minus_1);
+            let fy = sy - y0 as f32;
+            let fyi = 1.0 - fy;
 
-        let row0_base = y0 * lw;
-        let row1_base = y1 * lw;
+            let row0_base = y0 * geo.lw;
+            let row1_base = y1 * geo.lw;
 
-        for (dx, cell) in row.iter_mut().enumerate() {
-            let (x0, x1, fxi, fx) = x_lut[dx];
-            let w00 = fyi * fxi;
-            let w10 = fy * fxi;
-            let w01 = fyi * fx;
-            let w11 = fy * fx;
+            for (dx, cell) in row.iter_mut().enumerate() {
+                let (x0, x1, fxi, fx) = x_lut[dx];
+                let w00 = fyi * fxi;
+                let w10 = fy * fxi;
+                let w01 = fyi * fx;
+                let w11 = fy * fx;
 
-            *cell = if nc == 1 {
-                let base = 0;
-                let v = output[base + row1_base + x1].mul_add(
-                    w11,
-                    output[base + row0_base + x1].mul_add(
-                        w01,
-                        output[base + row1_base + x0]
-                            .mul_add(w10, output[base + row0_base + x0] * w00),
-                    ),
-                );
-                u32::from(v > 0.0)
-            } else {
-                let mut best_cls = 0u32;
-                let mut best_val = f32::NEG_INFINITY;
-                for c in 0..nc {
-                    let base = c * plane;
+                *cell = if nc == 1 {
+                    let base = 0;
                     let v = output[base + row1_base + x1].mul_add(
                         w11,
                         output[base + row0_base + x1].mul_add(
@@ -1957,18 +2015,39 @@ fn postprocess_semantic(
                                 .mul_add(w10, output[base + row0_base + x0] * w00),
                         ),
                     );
-                    if v > best_val {
-                        best_val = v;
-                        best_cls = c as u32;
+                    u32::from(v > 0.0)
+                } else {
+                    let mut best_cls = 0u32;
+                    let mut best_val = f32::NEG_INFINITY;
+                    for c in 0..nc {
+                        let base = c * plane;
+                        let v = output[base + row1_base + x1].mul_add(
+                            w11,
+                            output[base + row0_base + x1].mul_add(
+                                w01,
+                                output[base + row1_base + x0]
+                                    .mul_add(w10, output[base + row0_base + x0] * w00),
+                            ),
+                        );
+                        if v > best_val {
+                            best_val = v;
+                            best_cls = c as u32;
+                        }
                     }
-                }
-                best_cls
-            };
-        }
-    });
-    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
-    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
-    results
+                    best_cls
+                };
+            }
+        });
+    let class_map = Array2::from_shape_vec((geo.oh, geo.ow), buf).expect("shape matches");
+    semantic_results_with_mask(
+        orig_img,
+        path,
+        names,
+        speed,
+        inference_shape,
+        class_map,
+        orig_shape,
+    )
 }
 
 #[cfg(test)]

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -2293,4 +2293,267 @@ mod tests {
             assert_eq!(data[5], 0.95); // conf
         }
     }
+
+    // --- semantic helpers ---
+
+    fn make_names(nc: usize) -> Arc<HashMap<usize, String>> {
+        Arc::new((0..nc).map(|i| (i, format!("class{i}"))).collect())
+    }
+
+    #[test]
+    fn test_postprocess_semantic_fast_path_argmax() {
+        // 2x2 image, 3 classes, no letterbox (lh==oh, lw==ow).
+        // Verify per-pixel argmax picks the right winning class.
+        let (oh, ow, nc) = (2, 2, 3);
+        let plane = oh * ow;
+        let mut output = vec![0.0f32; nc * plane];
+        // pixel (0,0): class 2 wins
+        output[0 * plane] = 0.1;
+        output[1 * plane] = 0.2;
+        output[2 * plane] = 0.9;
+        // pixel (0,1): class 0 wins
+        output[0 * plane + 1] = 0.8;
+        output[1 * plane + 1] = 0.1;
+        output[2 * plane + 1] = 0.1;
+        // pixel (1,0): class 1 wins
+        output[0 * plane + 2] = 0.3;
+        output[1 * plane + 2] = 0.7;
+        output[2 * plane + 2] = 0.2;
+        // pixel (1,1): class 0 wins
+        output[0 * plane + 3] = 0.5;
+        output[1 * plane + 3] = 0.3;
+        output[2 * plane + 3] = 0.3;
+
+        let result = postprocess_semantic(
+            &output,
+            &[1, nc, oh, ow],
+            make_names(nc),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            "test.jpg".to_string(),
+            Speed::default(),
+            (oh as u32, ow as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), &[oh, ow]);
+        assert_eq!(sm.data[[0, 0]], 2);
+        assert_eq!(sm.data[[0, 1]], 0);
+        assert_eq!(sm.data[[1, 0]], 1);
+        assert_eq!(sm.data[[1, 1]], 0);
+        assert_eq!(sm.orig_shape(), (oh as u32, ow as u32));
+    }
+
+    #[test]
+    fn test_postprocess_semantic_binary_fast_path() {
+        // nc=1 (binary segmentation): positive logit → foreground (1), non-positive → background (0).
+        let (oh, ow, nc) = (1, 4, 1);
+        let output = vec![1.0f32, -1.0, 0.001, -0.001];
+        let result = postprocess_semantic(
+            &output,
+            &[1, nc, oh, ow],
+            make_names(2),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (oh as u32, ow as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data[[0, 0]], 1);
+        assert_eq!(sm.data[[0, 1]], 0);
+        assert_eq!(sm.data[[0, 2]], 1);
+        assert_eq!(sm.data[[0, 3]], 0);
+    }
+
+    #[test]
+    fn test_postprocess_semantic_binary_zero_logit() {
+        // Exactly 0.0 is not > 0, so it must be treated as background (class 0).
+        let (oh, ow, nc) = (1, 1, 1);
+        let result = postprocess_semantic(
+            &[0.0f32],
+            &[1, nc, oh, ow],
+            make_names(2),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (oh as u32, ow as u32),
+        );
+        assert_eq!(result.semantic_mask.unwrap().data[[0, 0]], 0);
+    }
+
+    #[test]
+    fn test_postprocess_semantic_large_nc_fast_path() {
+        // nc=33 exceeds the old 32-element stack buffer; verify no panic and correct argmax.
+        let (oh, ow, nc) = (2, 2, 33);
+        let plane = oh * ow;
+        let mut output = vec![0.0f32; nc * plane];
+        for px in 0..plane {
+            output[32 * plane + px] = 1.0; // class 32 wins everywhere
+        }
+        let result = postprocess_semantic(
+            &output,
+            &[1, nc, oh, ow],
+            make_names(nc),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (oh as u32, ow as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        for &val in sm.data.iter() {
+            assert_eq!(val, 32);
+        }
+    }
+
+    #[test]
+    fn test_postprocess_semantic_malformed_shape_no_panic() {
+        let names = make_names(3);
+        let orig_img = ndarray::Array3::zeros((4, 4, 3));
+
+        // Shape too short (needs at least 4 dims)
+        let r = postprocess_semantic(
+            &[0.0f32; 10],
+            &[1, 3],
+            Arc::clone(&names),
+            orig_img.clone(),
+            String::new(),
+            Speed::default(),
+            (4, 4),
+        );
+        assert!(r.semantic_mask.is_none());
+
+        // Empty output slice
+        let r = postprocess_semantic(
+            &[],
+            &[1, 3, 4, 4],
+            Arc::clone(&names),
+            orig_img,
+            String::new(),
+            Speed::default(),
+            (4, 4),
+        );
+        assert!(r.semantic_mask.is_none());
+    }
+
+    #[test]
+    fn test_postprocess_semantic_large_nc_slow_path() {
+        // nc=33 through the letterbox bilinear path (lh!=oh triggers it).
+        // oh=2, ow=4 wide image letterboxed into 8x8:
+        //   gain=2.0, pad rows=2 top+bottom, crop rows 2..6, crop_w=8 (no x padding).
+        let (oh, ow, lh, lw, nc) = (2, 4, 8, 8, 33);
+        let plane = lh * lw;
+        let mut output = vec![0.0f32; nc * plane];
+        for px in 0..plane {
+            output[32 * plane + px] = 1.0; // class 32 wins everywhere in model space
+        }
+        let result = postprocess_semantic(
+            &output,
+            &[1, nc, lh, lw],
+            make_names(nc),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (lh as u32, lw as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), &[oh, ow]);
+        for &val in sm.data.iter() {
+            assert_eq!(val, 32);
+        }
+    }
+
+    #[test]
+    fn test_postprocess_semantic_binary_slow_path() {
+        // nc=1 binary through the letterbox bilinear path.
+        // oh=2, ow=4 letterboxed into 8x8 (same geometry as above).
+        let (oh, ow, lh, lw, nc) = (2, 4, 8, 8, 1);
+        let mut output = vec![1.0f32; lh * lw]; // all positive → class 1
+        // Flip 4 pixels in the content region (rows 2..6, col 0) to negative
+        for row in 2..6 {
+            output[row * lw] = -1.0;
+        }
+        let result = postprocess_semantic(
+            &output,
+            &[1, nc, lh, lw],
+            make_names(2),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (lh as u32, lw as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), &[oh, ow]);
+        // Col 0 pixels bilinearly interpolate negative logits → class 0
+        assert_eq!(sm.data[[0, 0]], 0);
+        assert_eq!(sm.data[[1, 0]], 0);
+        // Col 1+ pixels have positive logits → class 1
+        assert_eq!(sm.data[[0, 1]], 1);
+        assert_eq!(sm.data[[1, 1]], 1);
+    }
+
+    #[test]
+    fn test_postprocess_semantic_mask_passthrough() {
+        // Pre-argmaxed u8 output at native resolution: values map 1:1 to u32 class map.
+        let (oh, ow) = (2, 3);
+        let output: Vec<u8> = vec![0, 5, 3, 7, 2, 19];
+        let result = postprocess_semantic_mask(
+            &output,
+            &[oh, ow],
+            make_names(20),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (oh as u32, ow as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), &[oh, ow]);
+        assert_eq!(sm.data[[0, 0]], 0);
+        assert_eq!(sm.data[[0, 1]], 5);
+        assert_eq!(sm.data[[0, 2]], 3);
+        assert_eq!(sm.data[[1, 0]], 7);
+        assert_eq!(sm.data[[1, 1]], 2);
+        assert_eq!(sm.data[[1, 2]], 19);
+        assert_eq!(sm.orig_shape(), (oh as u32, ow as u32));
+    }
+
+    #[test]
+    fn test_postprocess_semantic_mask_empty_no_panic() {
+        let r = postprocess_semantic_mask(
+            &[],
+            &[4, 4],
+            make_names(10),
+            ndarray::Array3::zeros((4, 4, 3)),
+            String::new(),
+            Speed::default(),
+            (4, 4),
+        );
+        assert!(r.semantic_mask.is_none());
+    }
+
+    #[test]
+    fn test_postprocess_semantic_mask_letterbox_nn_upsample() {
+        // oh=2, ow=4 wide image letterboxed into 8x8.
+        // letterbox_crop_bounds gives top=2, left=0, crop_h=4, crop_w=8.
+        // Content rows 2..6 set to class 7; padding rows 0..2 and 6..8 set to 99.
+        // After NN upsample all orig pixels should map into content → class 7.
+        let (oh, ow, lh, lw) = (2, 4, 8, 8);
+        let mut output = vec![99u8; lh * lw];
+        for row in 2..6 {
+            for col in 0..lw {
+                output[row * lw + col] = 7;
+            }
+        }
+        let result = postprocess_semantic_mask(
+            &output,
+            &[lh, lw],
+            make_names(100),
+            ndarray::Array3::zeros((oh, ow, 3)),
+            String::new(),
+            Speed::default(),
+            (lh as u32, lw as u32),
+        );
+        let sm = result.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), &[oh, ow]);
+        for &val in sm.data.iter() {
+            assert_eq!(val, 7, "expected class 7 but got {val}");
+        }
+    }
 }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1861,31 +1861,32 @@ fn postprocess_semantic(
         let mut buf = vec![0u32; oh * ow];
         // Load one source row per class at a time so each row fits in cache.
         // Scratch buffer shared across all rows a given thread processes; one allocation per thread.
-    buf.par_chunks_mut(ow)
-        .enumerate()
-        .for_each_with(vec![0.0f32; lw], |best_vals, (dy, row)| {
-            if nc == 1 {
-                let src = &output[dy * lw..(dy + 1) * lw];
-                for (cell, &v) in row.iter_mut().zip(src.iter()) {
-                    *cell = u32::from(v > 0.0);
-                }
-            } else {
-                // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
-                let src0 = &output[dy * lw..(dy + 1) * lw];
-                best_vals.copy_from_slice(src0);
-                for c in 1..nc {
-                    let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
-                    for ((cell, best), &v) in
-                        row.iter_mut().zip(best_vals.iter_mut()).zip(src_c.iter())
-                    {
-                        if v > *best {
-                            *best = v;
-                            *cell = c as u32;
+        buf.par_chunks_mut(ow).enumerate().for_each_with(
+            vec![0.0f32; lw],
+            |best_vals, (dy, row)| {
+                if nc == 1 {
+                    let src = &output[dy * lw..(dy + 1) * lw];
+                    for (cell, &v) in row.iter_mut().zip(src.iter()) {
+                        *cell = u32::from(v > 0.0);
+                    }
+                } else {
+                    // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
+                    let src0 = &output[dy * lw..(dy + 1) * lw];
+                    best_vals.copy_from_slice(src0);
+                    for c in 1..nc {
+                        let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
+                        for ((cell, best), &v) in
+                            row.iter_mut().zip(best_vals.iter_mut()).zip(src_c.iter())
+                        {
+                            if v > *best {
+                                *best = v;
+                                *cell = c as u32;
+                            }
                         }
                     }
                 }
-            }
-        });
+            },
+        );
         let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
         results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
         return results;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -21,11 +21,12 @@ use wide::{CmpGt, f32x8};
 
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
-use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Zip, s};
+use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Axis, Zip, s};
+use rayon::prelude::*;
 
 use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
-use crate::results::{Boxes, Keypoints, Masks, Obb, Probs, Results, Speed};
+use crate::results::{Boxes, Keypoints, Masks, Obb, Probs, Results, SemanticMask, Speed};
 use crate::task::Task;
 use crate::utils::{nms_per_class, nms_rotated_per_class};
 
@@ -163,6 +164,10 @@ pub fn postprocess(
         Task::Classify => {
             let (output, _) = &outputs[0];
             postprocess_classify(output, names, orig_img, path, speed, inference_shape)
+        }
+        Task::SemSeg => {
+            let (output, shape) = &outputs[0];
+            postprocess_semseg(output, shape, names, orig_img, path, speed, inference_shape)
         }
         Task::Obb => {
             let (output, shape) = &outputs[0];
@@ -1753,6 +1758,104 @@ fn postprocess_obb_end2end(
     let n = flat.len() / 7;
     let obb_data = Array2::from_shape_vec((n, 7), flat).expect("flat length matches (n, 7)");
     results.obb = Some(Obb::new(obb_data, preprocess.orig_shape));
+    results
+}
+
+/// Post-process semantic segmentation model output.
+///
+/// The model outputs raw logits of shape `[1, nc, lh, lw]` at the P3 scale
+/// (stride 8).  Postprocessing:
+/// 1. Crops bottom/right padding from logit space (non-centered letterbox).
+/// 2. Bilinear-upsamples each channel from the cropped logit size to the
+///    original image dimensions.
+/// 3. Takes argmax over the class channel to produce a `[H, W]` label map.
+#[allow(clippy::too_many_arguments, clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+fn postprocess_semseg(
+    output: &[f32],
+    shape: &[usize],
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+) -> Results {
+    let mut results = Results::new(orig_img.clone(), path, names.clone(), speed, inference_shape);
+
+    if shape.len() < 4 || output.is_empty() {
+        return results;
+    }
+
+    let nc = shape[1];
+    let lh = shape[2];
+    let lw = shape[3];
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+
+    if nc == 0 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+        return results;
+    }
+
+    // Compute how much of the logit space covers the original image.
+    // Non-centered (top-left) letterbox: content starts at (0, 0).
+    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
+    let crop_h = (oh as f32 * gain).round() as usize;
+    let crop_w = (ow as f32 * gain).round() as usize;
+    let crop_h = crop_h.min(lh);
+    let crop_w = crop_w.min(lw);
+
+    // Bilinear upsample logits from (crop_h, crop_w) to (oh, ow), then argmax.
+    // Each output row is independent, so we parallelise over rows with rayon.
+    let scale_y = crop_h as f32 / oh as f32;
+    let scale_x = crop_w as f32 / ow as f32;
+
+    let mut class_map = Array2::<u32>::zeros((oh, ow));
+
+    class_map
+        .axis_iter_mut(Axis(0))
+        .into_par_iter()
+        .enumerate()
+        .for_each(|(dy, mut row)| {
+            let sy = ((dy as f32 + 0.5) * scale_y - 0.5).max(0.0);
+            let y0 = sy.floor() as usize;
+            let y1 = (y0 + 1).min(lh - 1);
+            let fy = sy - y0 as f32;
+            let fyi = 1.0 - fy;
+
+            for (dx, cell) in row.iter_mut().enumerate() {
+                let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
+                let x0 = sx.floor() as usize;
+                let x1 = (x0 + 1).min(lw - 1);
+                let fx = sx - x0 as f32;
+                let fxi = 1.0 - fx;
+
+                let w00 = fyi * fxi;
+                let w10 = fy * fxi;
+                let w01 = fyi * fx;
+                let w11 = fy * fx;
+
+                let mut best_cls = 0u32;
+                let mut best_val = f32::NEG_INFINITY;
+
+                for c in 0..nc {
+                    let base = c * lh * lw;
+                    let v = output[base + y0 * lw + x0] * w00
+                        + output[base + y1 * lw + x0] * w10
+                        + output[base + y0 * lw + x1] * w01
+                        + output[base + y1 * lw + x1] * w11;
+                    if v > best_val {
+                        best_val = v;
+                        best_cls = c as u32;
+                    }
+                }
+
+                *cell = best_cls;
+            }
+        });
+
+    results.semantic_mask = Some(SemanticMask::new(
+        class_map,
+        (oh as u32, ow as u32),
+    ));
     results
 }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1756,7 +1756,7 @@ fn letterbox_crop_bounds(
 pub fn postprocess_semantic_mask(
     output: &[u8],
     shape: &[usize],
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
@@ -1764,7 +1764,7 @@ pub fn postprocess_semantic_mask(
 ) -> Results {
     let oh = orig_img.shape()[0];
     let ow = orig_img.shape()[1];
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     if shape.len() < 2 || output.is_empty() {
         return results;
@@ -1838,7 +1838,7 @@ pub fn postprocess_semantic_mask(
 fn postprocess_semseg(
     output: &[f32],
     shape: &[usize],
-    names: &HashMap<usize, String>,
+    names: Arc<HashMap<usize, String>>,
     orig_img: Array3<u8>,
     path: String,
     speed: Speed,
@@ -1846,7 +1846,7 @@ fn postprocess_semseg(
 ) -> Results {
     let oh = orig_img.shape()[0];
     let ow = orig_img.shape()[1];
-    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(orig_img, path, names, speed, inference_shape);
 
     if shape.len() < 4 || output.is_empty() {
         return results;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1874,16 +1874,21 @@ fn postprocess_semantic(
             .for_each(|(dy, mut row)| {
                 for (dx, cell) in row.iter_mut().enumerate() {
                     let pix_off = dy * lw + dx;
-                    let mut best_cls = 0u32;
-                    let mut best_val = f32::NEG_INFINITY;
-                    for c in 0..nc {
-                        let v = output[c * plane + pix_off];
-                        if v > best_val {
-                            best_val = v;
-                            best_cls = c as u32;
+                    *cell = if nc == 1 {
+                        // Binary segmentation: single logit channel, class 1 if logit > 0.
+                        u32::from(output[pix_off] > 0.0)
+                    } else {
+                        let mut best_cls = 0u32;
+                        let mut best_val = f32::NEG_INFINITY;
+                        for c in 0..nc {
+                            let v = output[c * plane + pix_off];
+                            if v > best_val {
+                                best_val = v;
+                                best_cls = c as u32;
+                            }
                         }
-                    }
-                    *cell = best_cls;
+                        best_cls
+                    };
                 }
             });
         results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
@@ -1943,8 +1948,8 @@ fn postprocess_semantic(
             let row0_base = y0 * lw;
             let row1_base = y1 * lw;
 
-            // Stack-allocated buffer for nc_padded f32 results per pixel.
-            let mut vals = [0.0f32; 32]; // nc_padded ≤ 32 for typical semantic segmentation models
+            // Per-row buffer; reused across pixels to avoid per-pixel heap allocation.
+            let mut vals = vec![0.0f32; nc_padded];
 
             for (dx, cell) in row.iter_mut().enumerate() {
                 let (x0, x1, fxi, fx) = x_lut[dx];
@@ -1970,15 +1975,20 @@ fn postprocess_semantic(
                     vals[lane..lane + 8].copy_from_slice(&arr);
                 }
 
-                let mut best_cls = 0u32;
-                let mut best_val = f32::NEG_INFINITY;
-                for (c, &v) in vals.iter().take(nc).enumerate() {
-                    if v > best_val {
-                        best_val = v;
-                        best_cls = c as u32;
+                *cell = if nc == 1 {
+                    // Binary segmentation: single logit channel, class 1 if logit > 0.
+                    u32::from(vals[0] > 0.0)
+                } else {
+                    let mut best_cls = 0u32;
+                    let mut best_val = f32::NEG_INFINITY;
+                    for (c, &v) in vals.iter().take(nc).enumerate() {
+                        if v > best_val {
+                            best_val = v;
+                            best_cls = c as u32;
+                        }
                     }
-                }
-                *cell = best_cls;
+                    best_cls
+                };
             }
         });
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1944,7 +1944,7 @@ fn postprocess_semantic(
             let row1_base = y1 * lw;
 
             // Stack-allocated buffer for nc_padded f32 results per pixel.
-            let mut vals = [0.0f32; 32]; // nc_padded ≤ 32 for typical semseg models
+            let mut vals = [0.0f32; 32]; // nc_padded ≤ 32 for typical semantic segmentation models
 
             for (dx, cell) in row.iter_mut().enumerate() {
                 let (x0, x1, fxi, fx) = x_lut[dx];

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -2308,20 +2308,20 @@ mod tests {
         let plane = oh * ow;
         let mut output = vec![0.0f32; nc * plane];
         // pixel (0,0): class 2 wins
-        output[0 * plane] = 0.1;
-        output[1 * plane] = 0.2;
+        output[0] = 0.1;
+        output[plane] = 0.2;
         output[2 * plane] = 0.9;
         // pixel (0,1): class 0 wins
-        output[0 * plane + 1] = 0.8;
-        output[1 * plane + 1] = 0.1;
+        output[1] = 0.8;
+        output[plane + 1] = 0.1;
         output[2 * plane + 1] = 0.1;
         // pixel (1,0): class 1 wins
-        output[0 * plane + 2] = 0.3;
-        output[1 * plane + 2] = 0.7;
+        output[2] = 0.3;
+        output[plane + 2] = 0.7;
         output[2 * plane + 2] = 0.2;
         // pixel (1,1): class 0 wins
-        output[0 * plane + 3] = 0.5;
-        output[1 * plane + 3] = 0.3;
+        output[3] = 0.5;
+        output[plane + 3] = 0.3;
         output[2 * plane + 3] = 0.3;
 
         let result = postprocess_semantic(
@@ -2398,7 +2398,7 @@ mod tests {
             (oh as u32, ow as u32),
         );
         let sm = result.semantic_mask.unwrap();
-        for &val in sm.data.iter() {
+        for &val in &sm.data {
             assert_eq!(val, 32);
         }
     }
@@ -2455,7 +2455,7 @@ mod tests {
         );
         let sm = result.semantic_mask.unwrap();
         assert_eq!(sm.data.shape(), &[oh, ow]);
-        for &val in sm.data.iter() {
+        for &val in &sm.data {
             assert_eq!(val, 32);
         }
     }
@@ -2552,7 +2552,7 @@ mod tests {
         );
         let sm = result.semantic_mask.unwrap();
         assert_eq!(sm.data.shape(), &[oh, ow]);
-        for &val in sm.data.iter() {
+        for &val in &sm.data {
             assert_eq!(val, 7, "expected class 7 but got {val}");
         }
     }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -22,7 +22,7 @@ use wide::{CmpGt, f32x8};
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
 use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Axis, Zip, s};
-use rayon::prelude::*;
+use rayon::prelude::{IndexedParallelIterator, ParallelIterator, IntoParallelIterator, ParallelSliceMut};
 
 use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
@@ -1741,6 +1741,7 @@ fn letterbox_crop_bounds(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation
 )]
+#[must_use] 
 pub fn postprocess_semantic_mask(
     output: &[u8],
     shape: &[usize],
@@ -1906,7 +1907,7 @@ fn postprocess_semseg(
     // Precompute source-x neighbours + weights once per output column (with left offset).
     let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
         .map(|dx| {
-            let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0) + left as f32;
+            let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0) + left as f32;
             let x0 = (sx.floor() as usize).min(lw_minus_1);
             let x1 = (x0 + 1).min(lw_minus_1);
             let fx = sx - x0 as f32;
@@ -1921,7 +1922,7 @@ fn postprocess_semseg(
         .into_par_iter()
         .enumerate()
         .for_each(|(dy, mut row)| {
-            let sy = ((dy as f32 + 0.5) * scale_y - 0.5).max(0.0) + top as f32;
+            let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
             let y0 = (sy.floor() as usize).min(lh_minus_1);
             let y1 = (y0 + 1).min(lh_minus_1);
             let fy = sy - y0 as f32;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1860,22 +1860,19 @@ fn postprocess_semantic(
         let plane = lh * lw;
         let mut buf = vec![0u32; oh * ow];
         // Load one source row per class at a time so each row fits in cache.
-        buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+        // Scratch buffer shared across all rows a given thread processes; one allocation per thread.
+    buf.par_chunks_mut(ow)
+        .enumerate()
+        .for_each_with(vec![0.0f32; lw], |best_vals, (dy, row)| {
             if nc == 1 {
                 let src = &output[dy * lw..(dy + 1) * lw];
                 for (cell, &v) in row.iter_mut().zip(src.iter()) {
                     *cell = u32::from(v > 0.0);
                 }
             } else {
-                // Initialize with class 0 values.
+                // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
                 let src0 = &output[dy * lw..(dy + 1) * lw];
-                let mut best_vals: Vec<f32> = src0.to_vec();
-                // best_cls starts at 0 (implicit in the u32 buf zeros)
-                for (cell, &v) in row.iter_mut().zip(src0.iter()) {
-                    *cell = 0;
-                    let _ = v; // best_vals already has class 0
-                }
-                // Each subsequent class: read its row contiguously, update argmax.
+                best_vals.copy_from_slice(src0);
                 for c in 1..nc {
                     let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
                     for ((cell, best), &v) in
@@ -2531,6 +2528,47 @@ mod tests {
         assert_eq!(sm.data.shape(), &[oh, ow]);
         for &val in &sm.data {
             assert_eq!(val, 7, "expected class 7 but got {val}");
+        }
+    }
+
+    #[test]
+    fn test_postprocess_semantic_batch_slice_per_image() {
+        // Simulate the batch-loop slicing in model.rs for a 2-image batch.
+        // Image 0: class 1 wins everywhere. Image 1: class 2 wins everywhere.
+        // Each image is 2×2 with nc=3 logits; batch output is nc*oh*ow per image.
+        let (oh, ow, nc) = (2, 2, 3);
+        let plane = oh * ow;
+        let elems_per_img = nc * plane;
+
+        let mut batch = vec![0.0f32; 2 * elems_per_img];
+        // Image 0 at offset 0: class 1 wins (logit 0.9 at channel 1).
+        for px in 0..plane {
+            batch[plane + px] = 0.9;
+        }
+        // Image 1 at offset elems_per_img: class 2 wins (logit 0.9 at channel 2).
+        for px in 0..plane {
+            batch[elems_per_img + 2 * plane + px] = 0.9;
+        }
+
+        for (i, expected_cls) in [(0usize, 1u32), (1, 2)] {
+            let start = i * elems_per_img;
+            let slice = &batch[start..start + elems_per_img];
+            let result = postprocess_semantic(
+                slice,
+                &[1, nc, oh, ow],
+                make_names(nc),
+                ndarray::Array3::zeros((oh, ow, 3)),
+                String::new(),
+                Speed::default(),
+                (oh as u32, ow as u32),
+            );
+            let sm = result.semantic_mask.unwrap();
+            for &val in &sm.data {
+                assert_eq!(
+                    val, expected_cls,
+                    "image {i}: expected class {expected_cls} but got {val}"
+                );
+            }
         }
     }
 }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1705,7 +1705,8 @@ fn postprocess_obb_end2end(
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::similar_names
 )]
 fn letterbox_crop_bounds(
     lh: usize,
@@ -1735,13 +1736,20 @@ fn letterbox_crop_bounds(
 /// native rect shape matches the source image (lh==oh && lw==ow), this is a single memcpy
 /// into the class map. For other aspect ratios we crop the centered letterbox padding
 /// and nearest-neighbour upsample to original image shape.
+///
+/// # Panics
+///
+/// Panics if the freshly-allocated `Array2<u32>` class map is not contiguous (cannot occur
+/// for `Array2::zeros` on standard layout).
 #[allow(
     clippy::too_many_arguments,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::similar_names,
+    clippy::implicit_hasher
 )]
-#[must_use] 
+#[must_use]
 pub fn postprocess_semantic_mask(
     output: &[u8],
     shape: &[usize],
@@ -1821,7 +1829,8 @@ pub fn postprocess_semantic_mask(
     clippy::too_many_arguments,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::similar_names
 )]
 fn postprocess_semseg(
     output: &[f32],
@@ -1960,8 +1969,7 @@ fn postprocess_semseg(
 
                 let mut best_cls = 0u32;
                 let mut best_val = f32::NEG_INFINITY;
-                for c in 0..nc {
-                    let v = vals[c];
+                for (c, &v) in vals.iter().take(nc).enumerate() {
                     if v > best_val {
                         best_val = v;
                         best_cls = c as u32;

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1740,7 +1740,7 @@ fn letterbox_crop_bounds(
 ///
 /// # Panics
 ///
-/// Panics if the freshly-allocated `Array2<u32>` class map is not contiguous (cannot occur
+/// Panics if the freshly-allocated `Array2<u16>` class map is not contiguous (cannot occur
 /// for `Array2::zeros` on standard layout).
 #[allow(
     clippy::too_many_arguments,
@@ -1772,11 +1772,11 @@ pub fn postprocess_semantic_mask(
         return results;
     }
 
-    // Model output already at original resolution: just widen u8 -> u32.
+    // Model output already at original resolution: just widen u8 -> u16.
     if lh == oh && lw == ow {
-        let mut buf = vec![0u32; oh * ow];
+        let mut buf = vec![0u16; oh * ow];
         for (dst, &src) in buf.iter_mut().zip(output.iter()) {
-            *dst = u32::from(src);
+            *dst = u16::from(src);
         }
         let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
         results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
@@ -1797,12 +1797,12 @@ pub fn postprocess_semantic_mask(
         .map(|sx| sx.min(crop_w_minus_1) + left)
         .collect();
 
-    let mut buf = vec![0u32; oh * ow];
+    let mut buf = vec![0u16; oh * ow];
     buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
         let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
         let src_row_base = sy * lw;
         for (dx, cell) in row.iter_mut().enumerate() {
-            *cell = u32::from(output[src_row_base + x_lut[dx]]);
+            *cell = u16::from(output[src_row_base + x_lut[dx]]);
         }
     });
     let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
@@ -1848,7 +1848,7 @@ fn postprocess_semantic(
     let lh = shape[2];
     let lw = shape[3];
 
-    if nc == 0 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+    if nc == 0 || nc > usize::from(u16::MAX) + 1 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
         return results;
     }
 
@@ -1858,7 +1858,7 @@ fn postprocess_semantic(
     // into the ONNX graph and the input was the model's native rect shape.
     if lh == oh && lw == ow {
         let plane = lh * lw;
-        let mut buf = vec![0u32; oh * ow];
+        let mut buf = vec![0u16; oh * ow];
         // Load one source row per class at a time so each row fits in cache.
         // Scratch buffer shared across all rows a given thread processes; one allocation per thread.
         buf.par_chunks_mut(ow).enumerate().for_each_with(
@@ -1867,7 +1867,7 @@ fn postprocess_semantic(
                 if nc == 1 {
                     let src = &output[dy * lw..(dy + 1) * lw];
                     for (cell, &v) in row.iter_mut().zip(src.iter()) {
-                        *cell = u32::from(v > 0.0);
+                        *cell = u16::from(v > 0.0);
                     }
                 } else {
                     // Seed best_vals with class 0; row is already zeroed (best_cls = 0).
@@ -1880,7 +1880,7 @@ fn postprocess_semantic(
                         {
                             if v > *best {
                                 *best = v;
-                                *cell = c as u32;
+                                *cell = c as u16;
                             }
                         }
                     }
@@ -1915,7 +1915,7 @@ fn postprocess_semantic(
 
     // Bilinear upsample and argmax directly on CHW data, skipping the transpose.
     // Reads are strided (one plane apart per class) but avoids transposing 39M floats.
-    let mut buf = vec![0u32; oh * ow];
+    let mut buf = vec![0u16; oh * ow];
     buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
         let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
         let y0 = (sy.floor() as usize).min(lh_minus_1);
@@ -1943,9 +1943,9 @@ fn postprocess_semantic(
                             .mul_add(w10, output[base + row0_base + x0] * w00),
                     ),
                 );
-                u32::from(v > 0.0)
+                u16::from(v > 0.0)
             } else {
-                let mut best_cls = 0u32;
+                let mut best_cls = 0u16;
                 let mut best_val = f32::NEG_INFINITY;
                 for c in 0..nc {
                     let base = c * plane;
@@ -1959,7 +1959,7 @@ fn postprocess_semantic(
                     );
                     if v > best_val {
                         best_val = v;
-                        best_cls = c as u32;
+                        best_cls = c as u16;
                     }
                 }
                 best_cls
@@ -2466,7 +2466,7 @@ mod tests {
 
     #[test]
     fn test_postprocess_semantic_mask_passthrough() {
-        // Pre-argmaxed u8 output at native resolution: values map 1:1 to u32 class map.
+        // Pre-argmaxed u8 output at native resolution: values map 1:1 to u16 class map.
         let (oh, ow) = (2, 3);
         let output: Vec<u8> = vec![0, 5, 3, 7, 2, 19];
         let result = postprocess_semantic_mask(
@@ -2551,7 +2551,7 @@ mod tests {
             batch[elems_per_img + 2 * plane + px] = 0.9;
         }
 
-        for (i, expected_cls) in [(0usize, 1u32), (1, 2)] {
+        for (i, expected_cls) in [(0usize, 1u16), (1, 2)] {
             let start = i * elems_per_img;
             let slice = &batch[start..start + elems_per_img];
             let result = postprocess_semantic(

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1733,7 +1733,7 @@ fn letterbox_crop_bounds(
     }
 }
 
-/// Post-process a semseg ONNX that has ArgMax + Cast(uint8) baked in.
+/// Post-process a Semantic Segmentation ONNX that has ArgMax + Cast(uint8) baked in.
 ///
 /// Output shape is `[1, lh, lw] uint8`. For cityscapes-style inputs where the model's
 /// native rect shape matches the source image (lh==oh && lw==ow), this is a single memcpy

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1706,7 +1706,12 @@ fn postprocess_obb_end2end(
 /// 2. Bilinear-upsamples each channel from the cropped logit size to the
 ///    original image dimensions.
 /// 3. Takes argmax over the class channel to produce a `[H, W]` label map.
-#[allow(clippy::too_many_arguments, clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
 fn postprocess_semseg(
     output: &[f32],
     shape: &[usize],
@@ -1716,7 +1721,13 @@ fn postprocess_semseg(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(orig_img.clone(), path, names.clone(), speed, inference_shape);
+    let mut results = Results::new(
+        orig_img.clone(),
+        path,
+        names.clone(),
+        speed,
+        inference_shape,
+    );
 
     if shape.len() < 4 || output.is_empty() {
         return results;
@@ -1789,10 +1800,7 @@ fn postprocess_semseg(
             }
         });
 
-    results.semantic_mask = Some(SemanticMask::new(
-        class_map,
-        (oh as u32, ow as u32),
-    ));
+    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
     results
 }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -22,10 +22,8 @@ use wide::{CmpGt, f32x8};
 
 use fast_image_resize::images::Image;
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
-use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Axis, Zip, s};
-use rayon::prelude::{
-    IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSliceMut,
-};
+use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Zip, s};
+use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSliceMut};
 
 use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
@@ -1776,13 +1774,11 @@ pub fn postprocess_semantic_mask(
 
     // Model output already at original resolution: just widen u8 -> u32.
     if lh == oh && lw == ow {
-        let mut class_map = Array2::<u32>::zeros((oh, ow));
-        class_map
-            .as_slice_mut()
-            .expect("contiguous")
-            .iter_mut()
-            .zip(output.iter())
-            .for_each(|(dst, &src)| *dst = u32::from(src));
+        let mut buf = vec![0u32; oh * ow];
+        for (dst, &src) in buf.iter_mut().zip(output.iter()) {
+            *dst = u32::from(src);
+        }
+        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
         results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
         return results;
     }
@@ -1801,19 +1797,15 @@ pub fn postprocess_semantic_mask(
         .map(|sx| sx.min(crop_w_minus_1) + left)
         .collect();
 
-    let mut class_map = Array2::<u32>::zeros((oh, ow));
-    class_map
-        .axis_iter_mut(Axis(0))
-        .into_par_iter()
-        .enumerate()
-        .for_each(|(dy, mut row)| {
-            let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
-            let src_row_base = sy * lw;
-            for (dx, cell) in row.iter_mut().enumerate() {
-                *cell = u32::from(output[src_row_base + x_lut[dx]]);
-            }
-        });
-
+    let mut buf = vec![0u32; oh * ow];
+    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+        let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
+        let src_row_base = sy * lw;
+        for (dx, cell) in row.iter_mut().enumerate() {
+            *cell = u32::from(output[src_row_base + x_lut[dx]]);
+        }
+    });
+    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
     results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
     results
 }
@@ -1866,53 +1858,44 @@ fn postprocess_semantic(
     // into the ONNX graph and the input was the model's native rect shape.
     if lh == oh && lw == ow {
         let plane = lh * lw;
-        let mut class_map = Array2::<u32>::zeros((oh, ow));
-        class_map
-            .axis_iter_mut(Axis(0))
-            .into_par_iter()
-            .enumerate()
-            .for_each(|(dy, mut row)| {
-                for (dx, cell) in row.iter_mut().enumerate() {
-                    let pix_off = dy * lw + dx;
-                    *cell = if nc == 1 {
-                        // Binary segmentation: single logit channel, class 1 if logit > 0.
-                        u32::from(output[pix_off] > 0.0)
-                    } else {
-                        let mut best_cls = 0u32;
-                        let mut best_val = f32::NEG_INFINITY;
-                        for c in 0..nc {
-                            let v = output[c * plane + pix_off];
-                            if v > best_val {
-                                best_val = v;
-                                best_cls = c as u32;
-                            }
-                        }
-                        best_cls
-                    };
+        let mut buf = vec![0u32; oh * ow];
+        // Load one source row per class at a time so each row fits in cache.
+        buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+            if nc == 1 {
+                let src = &output[dy * lw..(dy + 1) * lw];
+                for (cell, &v) in row.iter_mut().zip(src.iter()) {
+                    *cell = u32::from(v > 0.0);
                 }
-            });
+            } else {
+                // Initialize with class 0 values.
+                let src0 = &output[dy * lw..(dy + 1) * lw];
+                let mut best_vals: Vec<f32> = src0.to_vec();
+                // best_cls starts at 0 (implicit in the u32 buf zeros)
+                for (cell, &v) in row.iter_mut().zip(src0.iter()) {
+                    *cell = 0;
+                    let _ = v; // best_vals already has class 0
+                }
+                // Each subsequent class: read its row contiguously, update argmax.
+                for c in 1..nc {
+                    let src_c = &output[c * plane + dy * lw..c * plane + (dy + 1) * lw];
+                    for ((cell, best), &v) in
+                        row.iter_mut().zip(best_vals.iter_mut()).zip(src_c.iter())
+                    {
+                        if v > *best {
+                            *best = v;
+                            *cell = c as u32;
+                        }
+                    }
+                }
+            }
+        });
+        let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
         results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
         return results;
     }
 
-    // Transpose CHW to HWC, padding nc up to a multiple of 8 with -INF so the per-pixel
-    // argmax can run as `n_chunks` SIMD f32x8 FMAs with no special-case for the tail.
-    let plane = lh * lw;
-    let nc_padded = nc.div_ceil(8) * 8;
-    let mut hwc = vec![f32::NEG_INFINITY; plane * nc_padded];
-    hwc.par_chunks_mut(lw * nc_padded)
-        .enumerate()
-        .for_each(|(y, row)| {
-            for x in 0..lw {
-                let dst = x * nc_padded;
-                for c in 0..nc {
-                    row[dst + c] = output[c * plane + y * lw + x];
-                }
-                // Lanes nc..nc_padded remain f32::NEG_INFINITY (set at vec init).
-            }
-        });
-
     // Crop centered letterbox padding, then bilinear-upsample crop to (oh, ow).
+    let plane = lh * lw;
     let Some((top, left, crop_h, crop_w)) = letterbox_crop_bounds(lh, lw, oh, ow) else {
         return results;
     };
@@ -1921,7 +1904,7 @@ fn postprocess_semantic(
     let lw_minus_1 = lw.saturating_sub(1);
     let lh_minus_1 = lh.saturating_sub(1);
 
-    // Precompute source-x neighbors + weights once per output column (with left offset).
+    // Precompute source-x neighbors + weights once per output column.
     let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
         .map(|dx| {
             let sx = (dx as f32 + 0.5).mul_add(scale_x, -0.5).max(0.0) + left as f32;
@@ -1932,66 +1915,60 @@ fn postprocess_semantic(
         })
         .collect();
 
-    let n_chunks = nc_padded / 8;
-    let mut class_map = Array2::<u32>::zeros((oh, ow));
-    class_map
-        .axis_iter_mut(Axis(0))
-        .into_par_iter()
-        .enumerate()
-        .for_each(|(dy, mut row)| {
-            let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
-            let y0 = (sy.floor() as usize).min(lh_minus_1);
-            let y1 = (y0 + 1).min(lh_minus_1);
-            let fy = sy - y0 as f32;
-            let fyi = 1.0 - fy;
+    // Bilinear upsample and argmax directly on CHW data, skipping the transpose.
+    // Reads are strided (one plane apart per class) but avoids transposing 39M floats.
+    let mut buf = vec![0u32; oh * ow];
+    buf.par_chunks_mut(ow).enumerate().for_each(|(dy, row)| {
+        let sy = (dy as f32 + 0.5).mul_add(scale_y, -0.5).max(0.0) + top as f32;
+        let y0 = (sy.floor() as usize).min(lh_minus_1);
+        let y1 = (y0 + 1).min(lh_minus_1);
+        let fy = sy - y0 as f32;
+        let fyi = 1.0 - fy;
 
-            let row0_base = y0 * lw;
-            let row1_base = y1 * lw;
+        let row0_base = y0 * lw;
+        let row1_base = y1 * lw;
 
-            // Per-row buffer; reused across pixels to avoid per-pixel heap allocation.
-            let mut vals = vec![0.0f32; nc_padded];
+        for (dx, cell) in row.iter_mut().enumerate() {
+            let (x0, x1, fxi, fx) = x_lut[dx];
+            let w00 = fyi * fxi;
+            let w10 = fy * fxi;
+            let w01 = fyi * fx;
+            let w11 = fy * fx;
 
-            for (dx, cell) in row.iter_mut().enumerate() {
-                let (x0, x1, fxi, fx) = x_lut[dx];
-
-                let w00_v = f32x8::splat(fyi * fxi);
-                let w10_v = f32x8::splat(fy * fxi);
-                let w01_v = f32x8::splat(fyi * fx);
-                let w11_v = f32x8::splat(fy * fx);
-
-                let off00 = (row0_base + x0) * nc_padded;
-                let off10 = (row1_base + x0) * nc_padded;
-                let off01 = (row0_base + x1) * nc_padded;
-                let off11 = (row1_base + x1) * nc_padded;
-
-                for k in 0..n_chunks {
-                    let lane = k * 8;
-                    let p00 = f32x8::from(&hwc[off00 + lane..off00 + lane + 8]);
-                    let p10 = f32x8::from(&hwc[off10 + lane..off10 + lane + 8]);
-                    let p01 = f32x8::from(&hwc[off01 + lane..off01 + lane + 8]);
-                    let p11 = f32x8::from(&hwc[off11 + lane..off11 + lane + 8]);
-                    let v = p00 * w00_v + p10 * w10_v + p01 * w01_v + p11 * w11_v;
-                    let arr = v.to_array();
-                    vals[lane..lane + 8].copy_from_slice(&arr);
-                }
-
-                *cell = if nc == 1 {
-                    // Binary segmentation: single logit channel, class 1 if logit > 0.
-                    u32::from(vals[0] > 0.0)
-                } else {
-                    let mut best_cls = 0u32;
-                    let mut best_val = f32::NEG_INFINITY;
-                    for (c, &v) in vals.iter().take(nc).enumerate() {
-                        if v > best_val {
-                            best_val = v;
-                            best_cls = c as u32;
-                        }
+            *cell = if nc == 1 {
+                let base = 0;
+                let v = output[base + row1_base + x1].mul_add(
+                    w11,
+                    output[base + row0_base + x1].mul_add(
+                        w01,
+                        output[base + row1_base + x0]
+                            .mul_add(w10, output[base + row0_base + x0] * w00),
+                    ),
+                );
+                u32::from(v > 0.0)
+            } else {
+                let mut best_cls = 0u32;
+                let mut best_val = f32::NEG_INFINITY;
+                for c in 0..nc {
+                    let base = c * plane;
+                    let v = output[base + row1_base + x1].mul_add(
+                        w11,
+                        output[base + row0_base + x1].mul_add(
+                            w01,
+                            output[base + row1_base + x0]
+                                .mul_add(w10, output[base + row0_base + x0] * w00),
+                        ),
+                    );
+                    if v > best_val {
+                        best_val = v;
+                        best_cls = c as u32;
                     }
-                    best_cls
-                };
-            }
-        });
-
+                }
+                best_cls
+            };
+        }
+    });
+    let class_map = Array2::from_shape_vec((oh, ow), buf).expect("shape matches");
     results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
     results
 }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1771,7 +1771,7 @@ pub fn postprocess_semantic_mask(
         return results;
     }
 
-    // Fast path: model output already at original resolution: just widen u8 -> u32.
+    // Model output already at original resolution: just widen u8 -> u32.
     if lh == oh && lw == ow {
         let mut class_map = Array2::<u32>::zeros((oh, ow));
         class_map
@@ -1857,7 +1857,7 @@ fn postprocess_semseg(
         return results;
     }
 
-    // Fast path: model output is already at orig_img resolution (no resize, no padding).
+    // Model output is already at orig_img resolution (no resize, no padding).
     // Avoids the CHW->HWC transpose and bilinear interpolation entirely: just argmax over
     // the class channel for each pixel. Hits when the export bakes a full-res upsample
     // into the ONNX graph and the input was the model's native rect shape.

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1698,14 +1698,102 @@ fn postprocess_obb_end2end(
     results
 }
 
+/// Post-process a semseg ONNX that has ArgMax + Cast(uint8) baked in.
+///
+/// Output shape is `[1, lh, lw] uint8`. For cityscapes-style inputs where the model's
+/// native rect shape matches the source image (lh==oh && lw==ow), this is a single memcpy
+/// into the class map. For other aspect ratios we crop the centered letterbox padding
+/// and nearest-neighbour upsample to original image shape.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
+pub fn postprocess_semantic_mask(
+    output: &[u8],
+    shape: &[usize],
+    names: &HashMap<usize, String>,
+    orig_img: Array3<u8>,
+    path: String,
+    speed: Speed,
+    inference_shape: (u32, u32),
+) -> Results {
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
+
+    if shape.len() < 2 || output.is_empty() {
+        return results;
+    }
+    let (lh, lw) = (shape[shape.len() - 2], shape[shape.len() - 1]);
+    if lh == 0 || lw == 0 || oh == 0 || ow == 0 {
+        return results;
+    }
+
+    // Fast path: model output already at original resolution: just widen u8 -> u32.
+    if lh == oh && lw == ow {
+        let mut class_map = Array2::<u32>::zeros((oh, ow));
+        class_map
+            .as_slice_mut()
+            .expect("contiguous")
+            .iter_mut()
+            .zip(output.iter())
+            .for_each(|(dst, &src)| *dst = u32::from(src));
+        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+        return results;
+    }
+
+    // Slow path: crop centered letterbox padding in semantic-mask space, then NN upsample.
+    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
+    let pad_h_half = (lh as f32 - (oh as f32 * gain).round()) / 2.0;
+    let pad_w_half = (lw as f32 - (ow as f32 * gain).round()) / 2.0;
+    let top = (pad_h_half - 0.1).round().max(0.0) as usize;
+    let left = (pad_w_half - 0.1).round().max(0.0) as usize;
+    let bottom = lh.saturating_sub((pad_h_half + 0.1).round() as usize);
+    let right = lw.saturating_sub((pad_w_half + 0.1).round() as usize);
+    let crop_h = bottom.saturating_sub(top);
+    let crop_w = right.saturating_sub(left);
+    if crop_h == 0 || crop_w == 0 {
+        return results;
+    }
+
+    let scale_y = crop_h as f32 / oh as f32;
+    let scale_x = crop_w as f32 / ow as f32;
+    let crop_h_minus_1 = crop_h.saturating_sub(1);
+    let crop_w_minus_1 = crop_w.saturating_sub(1);
+    let x_lut: Vec<usize> = (0..ow)
+        .map(|dx| ((dx as f32 + 0.5) * scale_x) as usize)
+        .map(|sx| sx.min(crop_w_minus_1) + left)
+        .collect();
+
+    let mut class_map = Array2::<u32>::zeros((oh, ow));
+    class_map
+        .axis_iter_mut(Axis(0))
+        .into_par_iter()
+        .enumerate()
+        .for_each(|(dy, mut row)| {
+            let sy = (((dy as f32 + 0.5) * scale_y) as usize).min(crop_h_minus_1) + top;
+            let src_row_base = sy * lw;
+            for (dx, cell) in row.iter_mut().enumerate() {
+                *cell = u32::from(output[src_row_base + x_lut[dx]]);
+            }
+        });
+
+    results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+    results
+}
+
 /// Post-process semantic segmentation model output.
 ///
 /// The model outputs raw logits of shape `[1, nc, lh, lw]` at the P3 scale
-/// (stride 8).  Postprocessing:
-/// 1. Crops bottom/right padding from logit space (non-centered letterbox).
-/// 2. Bilinear-upsamples each channel from the cropped logit size to the
-///    original image dimensions.
-/// 3. Takes argmax over the class channel to produce a `[H, W]` label map.
+/// (stride 8). Pipeline:
+/// 1. Transpose CHW to HWC once (small: lh*lw*nc f32s) so per-pixel argmax is contiguous.
+/// 2. Bilinear-interpolate each output pixel's 4 source neighbours, fused with argmax
+///    over `nc` classes, producing the final class map in one pass.
+///
+/// Memory traffic per output pixel drops from 4*nc strided reads to 4*nc contiguous
+/// reads; the source channels for one source pixel fit in ~80 bytes (1-2 cache lines).
 #[allow(
     clippy::too_many_arguments,
     clippy::cast_precision_loss,
@@ -1721,13 +1809,9 @@ fn postprocess_semseg(
     speed: Speed,
     inference_shape: (u32, u32),
 ) -> Results {
-    let mut results = Results::new(
-        orig_img.clone(),
-        path,
-        names.clone(),
-        speed,
-        inference_shape,
-    );
+    let oh = orig_img.shape()[0];
+    let ow = orig_img.shape()[1];
+    let mut results = Results::new(orig_img, path, names.clone(), speed, inference_shape);
 
     if shape.len() < 4 || output.is_empty() {
         return results;
@@ -1736,66 +1820,149 @@ fn postprocess_semseg(
     let nc = shape[1];
     let lh = shape[2];
     let lw = shape[3];
-    let oh = orig_img.shape()[0];
-    let ow = orig_img.shape()[1];
 
     if nc == 0 || lh == 0 || lw == 0 || oh == 0 || ow == 0 {
         return results;
     }
 
-    // Compute how much of the logit space covers the original image.
-    // Non-centered (top-left) letterbox: content starts at (0, 0).
-    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
-    let crop_h = (oh as f32 * gain).round() as usize;
-    let crop_w = (ow as f32 * gain).round() as usize;
-    let crop_h = crop_h.min(lh);
-    let crop_w = crop_w.min(lw);
+    // Fast path: model output is already at orig_img resolution (no resize, no padding).
+    // Avoids the CHW->HWC transpose and bilinear interpolation entirely: just argmax over
+    // the class channel for each pixel. Hits when the export bakes a full-res upsample
+    // into the ONNX graph and the input was the model's native rect shape.
+    if lh == oh && lw == ow {
+        let plane = lh * lw;
+        let mut class_map = Array2::<u32>::zeros((oh, ow));
+        class_map
+            .axis_iter_mut(Axis(0))
+            .into_par_iter()
+            .enumerate()
+            .for_each(|(dy, mut row)| {
+                for (dx, cell) in row.iter_mut().enumerate() {
+                    let pix_off = dy * lw + dx;
+                    let mut best_cls = 0u32;
+                    let mut best_val = f32::NEG_INFINITY;
+                    for c in 0..nc {
+                        let v = output[c * plane + pix_off];
+                        if v > best_val {
+                            best_val = v;
+                            best_cls = c as u32;
+                        }
+                    }
+                    *cell = best_cls;
+                }
+            });
+        results.semantic_mask = Some(SemanticMask::new(class_map, (oh as u32, ow as u32)));
+        return results;
+    }
 
-    // Bilinear upsample logits from (crop_h, crop_w) to (oh, ow), then argmax.
-    // Each output row is independent, so we parallelise over rows with rayon.
+    // Transpose CHW to HWC, padding nc up to a multiple of 8 with -INF so the per-pixel
+    // argmax can run as `n_chunks` SIMD f32x8 FMAs with no special-case for the tail.
+    let plane = lh * lw;
+    let nc_padded = nc.div_ceil(8) * 8;
+    let mut hwc = vec![f32::NEG_INFINITY; plane * nc_padded];
+    hwc.par_chunks_mut(lw * nc_padded)
+        .enumerate()
+        .for_each(|(y, row)| {
+            for x in 0..lw {
+                let dst = x * nc_padded;
+                for c in 0..nc {
+                    row[dst + c] = output[c * plane + y * lw + x];
+                }
+                // Lanes nc..nc_padded remain f32::NEG_INFINITY (set at vec init).
+            }
+        });
+
+    // Crop centered letterbox padding using the same rounding rule as `scale_masks`:
+    //   gain = min(lh/oh, lw/ow)
+    //   pad_w, pad_h = lw - round(ow*gain), lh - round(oh*gain)    // total padding
+    //   if center: pad_w /= 2; pad_h /= 2                          // half on each side
+    //   top, left = round(pad_h - 0.1),  round(pad_w - 0.1)
+    //   bottom, right = lh - round(pad_h + 0.1), lw - round(pad_w + 0.1)
+    // Then upsample masks[..., top:bottom, left:right] to (oh, ow).
+    let gain = (lh as f32 / oh as f32).min(lw as f32 / ow as f32);
+    let pad_h_total = lh as f32 - (oh as f32 * gain).round();
+    let pad_w_total = lw as f32 - (ow as f32 * gain).round();
+    let pad_h_half = pad_h_total / 2.0;
+    let pad_w_half = pad_w_total / 2.0;
+    let top = (pad_h_half - 0.1).round().max(0.0) as usize;
+    let left = (pad_w_half - 0.1).round().max(0.0) as usize;
+    let bottom = lh.saturating_sub((pad_h_half + 0.1).round() as usize);
+    let right = lw.saturating_sub((pad_w_half + 0.1).round() as usize);
+    let crop_h = bottom.saturating_sub(top);
+    let crop_w = right.saturating_sub(left);
+
+    if crop_h == 0 || crop_w == 0 {
+        return results;
+    }
+
     let scale_y = crop_h as f32 / oh as f32;
     let scale_x = crop_w as f32 / ow as f32;
+    let lw_minus_1 = lw.saturating_sub(1);
+    let lh_minus_1 = lh.saturating_sub(1);
 
+    // Precompute source-x neighbours + weights once per output column (with left offset).
+    let x_lut: Vec<(usize, usize, f32, f32)> = (0..ow)
+        .map(|dx| {
+            let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0) + left as f32;
+            let x0 = (sx.floor() as usize).min(lw_minus_1);
+            let x1 = (x0 + 1).min(lw_minus_1);
+            let fx = sx - x0 as f32;
+            (x0, x1, 1.0 - fx, fx)
+        })
+        .collect();
+
+    let n_chunks = nc_padded / 8;
     let mut class_map = Array2::<u32>::zeros((oh, ow));
-
     class_map
         .axis_iter_mut(Axis(0))
         .into_par_iter()
         .enumerate()
         .for_each(|(dy, mut row)| {
-            let sy = ((dy as f32 + 0.5) * scale_y - 0.5).max(0.0);
-            let y0 = sy.floor() as usize;
-            let y1 = (y0 + 1).min(lh - 1);
+            let sy = ((dy as f32 + 0.5) * scale_y - 0.5).max(0.0) + top as f32;
+            let y0 = (sy.floor() as usize).min(lh_minus_1);
+            let y1 = (y0 + 1).min(lh_minus_1);
             let fy = sy - y0 as f32;
             let fyi = 1.0 - fy;
 
-            for (dx, cell) in row.iter_mut().enumerate() {
-                let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
-                let x0 = sx.floor() as usize;
-                let x1 = (x0 + 1).min(lw - 1);
-                let fx = sx - x0 as f32;
-                let fxi = 1.0 - fx;
+            let row0_base = y0 * lw;
+            let row1_base = y1 * lw;
 
-                let w00 = fyi * fxi;
-                let w10 = fy * fxi;
-                let w01 = fyi * fx;
-                let w11 = fy * fx;
+            // Stack-allocated buffer for nc_padded f32 results per pixel.
+            let mut vals = [0.0f32; 32]; // nc_padded ≤ 32 for typical semseg models
+
+            for (dx, cell) in row.iter_mut().enumerate() {
+                let (x0, x1, fxi, fx) = x_lut[dx];
+
+                let w00_v = f32x8::splat(fyi * fxi);
+                let w10_v = f32x8::splat(fy * fxi);
+                let w01_v = f32x8::splat(fyi * fx);
+                let w11_v = f32x8::splat(fy * fx);
+
+                let off00 = (row0_base + x0) * nc_padded;
+                let off10 = (row1_base + x0) * nc_padded;
+                let off01 = (row0_base + x1) * nc_padded;
+                let off11 = (row1_base + x1) * nc_padded;
+
+                for k in 0..n_chunks {
+                    let lane = k * 8;
+                    let p00 = f32x8::from(&hwc[off00 + lane..off00 + lane + 8]);
+                    let p10 = f32x8::from(&hwc[off10 + lane..off10 + lane + 8]);
+                    let p01 = f32x8::from(&hwc[off01 + lane..off01 + lane + 8]);
+                    let p11 = f32x8::from(&hwc[off11 + lane..off11 + lane + 8]);
+                    let v = p00 * w00_v + p10 * w10_v + p01 * w01_v + p11 * w11_v;
+                    let arr = v.to_array();
+                    vals[lane..lane + 8].copy_from_slice(&arr);
+                }
 
                 let mut best_cls = 0u32;
                 let mut best_val = f32::NEG_INFINITY;
-
                 for c in 0..nc {
-                    let base = c * lh * lw;
-                    let v = output[base + y0 * lw + x0] * w00
-                        + output[base + y1 * lw + x0] * w10
-                        + output[base + y0 * lw + x1] * w01
-                        + output[base + y1 * lw + x1] * w11;
+                    let v = vals[c];
                     if v > best_val {
                         best_val = v;
                         best_cls = c as u32;
                     }
                 }
-
                 *cell = best_cls;
             }
         });

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1702,7 +1702,11 @@ fn postprocess_obb_end2end(
 /// cover the original image (oh, ow).
 ///
 /// Returns `(top, left, crop_h, crop_w)` or `None` if the crop is empty (degenerate input).
-#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
 fn letterbox_crop_bounds(
     lh: usize,
     lw: usize,

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -168,9 +168,9 @@ pub fn postprocess(
             let (output, _) = &outputs[0];
             postprocess_classify(output, names, orig_img, path, speed, inference_shape)
         }
-        Task::SemSeg => {
+        Task::Semantic => {
             let (output, shape) = &outputs[0];
-            postprocess_semseg(output, shape, names, orig_img, path, speed, inference_shape)
+            postprocess_semantic(output, shape, names, orig_img, path, speed, inference_shape)
         }
         Task::Obb => {
             let (output, shape) = &outputs[0];
@@ -1835,7 +1835,7 @@ pub fn postprocess_semantic_mask(
     clippy::cast_possible_truncation,
     clippy::similar_names
 )]
-fn postprocess_semseg(
+fn postprocess_semantic(
     output: &[f32],
     shape: &[usize],
     names: Arc<HashMap<usize, String>>,

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -904,4 +904,32 @@ mod tests {
         assert!((clipped[2] - 640.0).abs() < 1e-6);
         assert!((clipped[3] - 480.0).abs() < 1e-6);
     }
+
+    #[test]
+    fn test_preprocess_image_semantic_dynamic_no_padding() {
+        // 480×640 image, target=1024, is_dynamic=true.
+        // Short-side=480 → scale=1024/480; content at (0,0), no centered padding.
+        let img = image::DynamicImage::new_rgb8(640, 480);
+        let res = preprocess_image_semantic(&img, (1024, 1024), 32, false, true);
+        assert_eq!(res.padding, (0.0, 0.0), "dynamic path must have no padding");
+        assert_eq!(res.orig_shape, (480, 640));
+        let (_, _, h, w) = res.tensor.dim();
+        assert_eq!(h % 32, 0, "height must be stride-aligned");
+        assert_eq!(w % 32, 0, "width must be stride-aligned");
+        assert_eq!(h, 1024, "short side should map to target");
+    }
+
+    #[test]
+    fn test_preprocess_image_semantic_static_centered_letterbox() {
+        // 480×640 wide image, target=1024×1024, is_dynamic=false.
+        // Scale = min(1024/480, 1024/640) = 1024/640 = 1.6; nh=768, nw=1024, pad_top≈128.
+        let img = image::DynamicImage::new_rgb8(640, 480);
+        let res = preprocess_image_semantic(&img, (1024, 1024), 32, false, false);
+        let (_, _, h, w) = res.tensor.dim();
+        assert_eq!(h, 1024);
+        assert_eq!(w, 1024);
+        // Wide image: horizontal padding is 0, vertical padding is non-zero.
+        assert_eq!(res.padding.1, 0.0, "wide image: no left padding");
+        assert!(res.padding.0 > 0.0, "wide image: top padding expected");
+    }
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -95,6 +95,110 @@ pub struct PreprocessResult {
     pub padding: (f32, f32),
 }
 
+/// Preprocess an image for semantic segmentation inference.
+///
+/// Dynamic models: short-side scaling so the shorter dimension equals
+/// `target_size.0`, with stride-aligned padding appended at the bottom/right only.
+///
+/// Static models: fit-within-target letterbox to exactly `target_size` with
+/// top-left alignment (padding at the bottom/right only, matching Python's
+/// `center=False` letterbox).
+///
+/// # Arguments
+///
+/// * `image` - Input image.
+/// * `target_size` - `(height, width)` of the model input tensor.
+/// * `stride` - Model stride for padding alignment (typically 32).
+/// * `half` - If true, also generate an FP16 tensor.
+/// * `is_dynamic` - True for dynamic-shape ONNX; false for a fixed-shape export.
+///
+/// # Returns
+///
+/// Preprocessed tensor and transform information for post-processing.
+#[must_use]
+pub fn preprocess_image_semseg(
+    image: &DynamicImage,
+    target_size: (usize, usize),
+    stride: u32,
+    half: bool,
+    is_dynamic: bool,
+) -> PreprocessResult {
+    let (orig_width, orig_height) = image.dimensions();
+    let orig_shape = (orig_height, orig_width);
+    let stride_usize = stride as usize;
+
+    #[allow(clippy::cast_precision_loss)]
+    let orig_h = orig_height as f32;
+    #[allow(clippy::cast_precision_loss)]
+    let orig_w = orig_width as f32;
+    #[allow(clippy::cast_precision_loss)]
+    let (target_h_f, target_w_f) = (target_size.0 as f32, target_size.1 as f32);
+
+    let (target_size, new_h, new_w, scale) = if is_dynamic {
+        // Short-side scaling: scale so the shorter dimension equals target_size.0,
+        // then round the longer side up to the nearest stride multiple.
+        let scale = target_h_f / orig_h.min(orig_w);
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let (nh, nw) = if orig_h <= orig_w {
+            (target_size.0, (orig_w * scale).round() as usize)
+        } else {
+            ((orig_h * scale).round() as usize, target_size.0)
+        };
+        let ph = ((nh + stride_usize - 1) / stride_usize) * stride_usize;
+        let pw = ((nw + stride_usize - 1) / stride_usize) * stride_usize;
+        ((ph, pw), nh, nw, scale)
+    } else {
+        // Fit-within-target letterbox: scale to fit inside target_size,
+        // pad the remainder at the bottom/right only (center=False).
+        let scale = (target_h_f / orig_h).min(target_w_f / orig_w);
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let nh = (orig_h * scale).round() as usize;
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let nw = (orig_w * scale).round() as usize;
+        (target_size, nh, nw, scale)
+    };
+
+    let tensor = match image {
+        DynamicImage::ImageRgb8(rgb) => fused_zerocopy_preprocess(
+            rgb.as_raw(),
+            orig_width,
+            orig_height,
+            target_size,
+            0,
+            0,
+            new_w as u32,
+            new_h as u32,
+        ),
+        _ => {
+            let src_rgb = image.to_rgb8();
+            fused_zerocopy_preprocess(
+                src_rgb.as_raw(),
+                orig_width,
+                orig_height,
+                target_size,
+                0,
+                0,
+                new_w as u32,
+                new_h as u32,
+            )
+        }
+    };
+
+    let tensor_f16 = if half {
+        Some(tensor_f32_to_f16(&tensor))
+    } else {
+        None
+    };
+
+    PreprocessResult {
+        tensor,
+        tensor_f16,
+        orig_shape,
+        scale: (scale, scale),
+        padding: (0.0, 0.0),
+    }
+}
+
 /// Preprocess an image for YOLO inference.
 ///
 /// Performs letterbox resizing, BGR to RGB conversion (if needed),

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -99,7 +99,7 @@ pub struct PreprocessResult {
 ///
 /// Preprocessed tensor and transform information for post-processing.
 #[must_use]
-pub fn preprocess_image_semseg(
+pub fn preprocess_image_semantic(
     image: &DynamicImage,
     target_size: (usize, usize),
     stride: u32,
@@ -173,7 +173,7 @@ pub fn preprocess_image_semseg(
 
 /// Build a `PreprocessResult` from a resolved letterbox geometry.
 ///
-/// Shared tail for `preprocess_image_semseg` and `preprocess_image_with_precision`:
+/// Shared tail for `preprocess_image_semantic` and `preprocess_image_with_precision`:
 /// runs the fused zero-copy resize/pad/normalize, optionally produces an FP16 tensor,
 /// and packages the transform metadata. The caller is responsible for computing
 /// `target_size`, `new_w`/`new_h`, padding, and `scale` for its specific letterbox style.

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -570,12 +570,9 @@ fn calculate_letterbox_params(
     let pad_left = pad_w / 2;
     let pad_top = pad_h / 2;
 
-    // Use a uniform gain for coordinate back-projection.
-    // This matches Ultralytics `scale_boxes()`, which applies a single
-    // `gain = min(target_h / orig_h, target_w / orig_w)` to both axes.
-    // Per-axis gains (`new_w / orig_w`, `new_h / orig_h`) can diverge slightly
-    // after rounding `new_w`/`new_h`, leading to small box shifts and
-    // different NMS results.
+    // Use a single `gain = min(target_h / orig_h, target_w / orig_w)` on both axes for
+    // coordinate back-projection. Per-axis gains computed from rounded `new_w`/`new_h`
+    // can diverge slightly, shifting boxes and changing NMS results.
     (new_w, new_h, pad_left, pad_top, (scale, scale))
 }
 
@@ -822,7 +819,7 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     let resized_rgb = RgbImage::from_raw(safe_new_w, safe_new_h, resized_buffer)
         .expect("Failed to create resized buffer");
 
-    // Calculate crop offsets using Banker's Rounding (to match Python round())
+    // Calculate crop offsets using Banker's Rounding (round half to even).
     #[allow(clippy::cast_precision_loss)]
     let crop_x_float = (new_w.saturating_sub(target_w)) as f32 / 2.0;
     #[allow(clippy::cast_precision_loss)]
@@ -840,7 +837,6 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
 }
 
 /// Round float to nearest integer, rounding half to even (Banker's Rounding).
-/// This matches Python's `round()` behavior.
 fn bankers_round(v: f32) -> f32 {
     let n = v.floor();
     let d = v - n;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -54,7 +54,6 @@ const INV_255: f32 = 1.0 / 255.0;
 /// Maximum LRU cache size for X coordinate LUTs.
 const LUT_CACHE_SIZE: usize = 8;
 
-
 /// X LUT entry: (`x0_byte_offset`, `x1_byte_offset`, 1-fx, fx) using 11-bit fixed-point
 /// weights matching `OpenCV`'s `INTER_LINEAR` coordinate mapping.
 type XLutEntry = (usize, usize, i32, i32);
@@ -144,9 +143,17 @@ pub fn preprocess_image_semseg(
         let pad_w = target_size.1.saturating_sub(nw);
         // Half-padding with biased rounding: `top = round(pad_h / 2 - 0.1)`. The -0.1
         // bias ensures odd total padding lands one extra pixel at the bottom/right.
-        #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation
+        )]
         let pad_top_u = ((pad_h as f32) / 2.0 - 0.1).round().max(0.0) as u32;
-        #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation
+        )]
         let pad_left_u = ((pad_w as f32) / 2.0 - 0.1).round().max(0.0) as u32;
         (target_size, nh, nw, scale, pad_top_u, pad_left_u)
     };

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -30,10 +30,6 @@ use image::{DynamicImage, GenericImageView, RgbImage};
 use lru::LruCache;
 use ndarray::{Array3, Array4};
 
-// ================================================================================================
-// Constants
-// ================================================================================================
-
 /// Default letterbox padding color (gray).
 pub const LETTERBOX_COLOR: [u8; 3] = [114, 114, 114];
 
@@ -58,27 +54,16 @@ const INV_255: f32 = 1.0 / 255.0;
 /// Maximum LRU cache size for X coordinate LUTs.
 const LUT_CACHE_SIZE: usize = 8;
 
-// ================================================================================================
-// Type Aliases
-// ================================================================================================
 
 /// X LUT entry: (`x0_byte_offset`, `x1_byte_offset`, 1-fx, fx) using 11-bit fixed-point
 /// weights matching `OpenCV`'s `INTER_LINEAR` coordinate mapping.
 type XLutEntry = (usize, usize, i32, i32);
 type XLutKey = (u32, u32);
 
-// ================================================================================================
-// Thread-Local State
-// ================================================================================================
-
 thread_local! {
     static X_LUT_CACHE: RefCell<LruCache<XLutKey, Vec<XLutEntry>>> =
         RefCell::new(LruCache::new(NonZeroUsize::new(LUT_CACHE_SIZE).unwrap()));
 }
-
-// ================================================================================================
-// Types
-// ================================================================================================
 
 /// Result of preprocessing an image, containing the tensor and transform info.
 #[derive(Debug, Clone)]
@@ -101,8 +86,8 @@ pub struct PreprocessResult {
 /// `target_size.0`, with stride-aligned padding appended at the bottom/right only.
 ///
 /// Static models: fit-within-target letterbox to exactly `target_size` with
-/// top-left alignment (padding at the bottom/right only, matching Python's
-/// `center=False` letterbox).
+/// centered alignment (padding split between both sides, default for
+/// `LetterBox(center=True)`).
 ///
 /// # Arguments
 ///
@@ -134,9 +119,10 @@ pub fn preprocess_image_semseg(
     #[allow(clippy::cast_precision_loss)]
     let (target_h_f, target_w_f) = (target_size.0 as f32, target_size.1 as f32);
 
-    let (target_size, new_h, new_w, scale) = if is_dynamic {
+    let (target_size, new_h, new_w, scale, pad_top, pad_left) = if is_dynamic {
         // Short-side scaling: scale so the shorter dimension equals target_size.0,
         // then round the longer side up to the nearest stride multiple.
+        // Dynamic mode places content at (0, 0): no padding to split.
         let scale = target_h_f / orig_h.min(orig_w);
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let (nh, nw) = if orig_h <= orig_w {
@@ -144,18 +130,26 @@ pub fn preprocess_image_semseg(
         } else {
             ((orig_h * scale).round() as usize, target_size.0)
         };
-        let ph = ((nh + stride_usize - 1) / stride_usize) * stride_usize;
-        let pw = ((nw + stride_usize - 1) / stride_usize) * stride_usize;
-        ((ph, pw), nh, nw, scale)
+        let ph = nh.div_ceil(stride_usize) * stride_usize;
+        let pw = nw.div_ceil(stride_usize) * stride_usize;
+        ((ph, pw), nh, nw, scale, 0u32, 0u32)
     } else {
-        // Fit-within-target letterbox: scale to fit inside target_size,
-        // pad the remainder at the bottom/right only (center=False).
+        // Centered letterbox: scale to fit, split the remainder evenly between top/bottom
+        // and left/right (this is the predictor's default; matches `LetterBox(center=True)`).
         let scale = (target_h_f / orig_h).min(target_w_f / orig_w);
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let nh = (orig_h * scale).round() as usize;
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let nw = (orig_w * scale).round() as usize;
-        (target_size, nh, nw, scale)
+        let pad_h = target_size.0.saturating_sub(nh);
+        let pad_w = target_size.1.saturating_sub(nw);
+        // Use the same rounding rule as `cv2.copyMakeBorder` in `LetterBox.apply_image`:
+        // `top = round(dh - 0.1)` where dh = pad_h / 2 (float).
+        #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let pad_top_u = ((pad_h as f32) / 2.0 - 0.1).round().max(0.0) as u32;
+        #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let pad_left_u = ((pad_w as f32) / 2.0 - 0.1).round().max(0.0) as u32;
+        (target_size, nh, nw, scale, pad_top_u, pad_left_u)
     };
 
     let tensor = match image {
@@ -164,8 +158,8 @@ pub fn preprocess_image_semseg(
             orig_width,
             orig_height,
             target_size,
-            0,
-            0,
+            pad_top,
+            pad_left,
             new_w as u32,
             new_h as u32,
         ),
@@ -176,8 +170,8 @@ pub fn preprocess_image_semseg(
                 orig_width,
                 orig_height,
                 target_size,
-                0,
-                0,
+                pad_top,
+                pad_left,
                 new_w as u32,
                 new_h as u32,
             )
@@ -195,7 +189,7 @@ pub fn preprocess_image_semseg(
         tensor_f16,
         orig_shape,
         scale: (scale, scale),
-        padding: (0.0, 0.0),
+        padding: (pad_top as f32, pad_left as f32),
     }
 }
 

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -824,4 +824,17 @@ mod tests {
         assert!(res.padding.1.abs() < 1e-6, "wide image: no left padding");
         assert!(res.padding.0 > 0.0, "wide image: top padding expected");
     }
+
+    #[test]
+    fn test_preprocess_image_rect_uses_centered_letterbox() {
+        // Mirrors Ultralytics LetterBox((1024, 1024), auto=True, stride=32) for a 333×640 image:
+        // resized content is 533×1024 and centered in a 544×1024 rect with 5/6 vertical padding.
+        let img = image::DynamicImage::new_rgb8(640, 333);
+        let rect_size = calculate_rect_size(640, 333, (1024, 1024), 32);
+        assert_eq!(rect_size, (544, 1024));
+        let res = preprocess_image_with_precision(&img, rect_size, 32, false);
+        let (_, _, h, w) = res.tensor.dim();
+        assert_eq!((h, w), rect_size);
+        assert_eq!(res.padding, (5.0, 0.0));
+    }
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -158,6 +158,39 @@ pub fn preprocess_image_semseg(
         (target_size, nh, nw, scale, pad_top_u, pad_left_u)
     };
 
+    build_preprocess_result(
+        image,
+        target_size,
+        new_w as u32,
+        new_h as u32,
+        pad_left,
+        pad_top,
+        (scale, scale),
+        orig_shape,
+        half,
+    )
+}
+
+/// Build a `PreprocessResult` from a resolved letterbox geometry.
+///
+/// Shared tail for `preprocess_image_semseg` and `preprocess_image_with_precision`:
+/// runs the fused zero-copy resize/pad/normalize, optionally produces an FP16 tensor,
+/// and packages the transform metadata. The caller is responsible for computing
+/// `target_size`, `new_w`/`new_h`, padding, and `scale` for its specific letterbox style.
+#[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+fn build_preprocess_result(
+    image: &DynamicImage,
+    target_size: (usize, usize),
+    new_w: u32,
+    new_h: u32,
+    pad_left: u32,
+    pad_top: u32,
+    scale: (f32, f32),
+    orig_shape: (u32, u32),
+    half: bool,
+) -> PreprocessResult {
+    let (orig_width, orig_height) = image.dimensions();
+
     let tensor = match image {
         DynamicImage::ImageRgb8(rgb) => fused_zerocopy_preprocess(
             rgb.as_raw(),
@@ -166,8 +199,8 @@ pub fn preprocess_image_semseg(
             target_size,
             pad_top,
             pad_left,
-            new_w as u32,
-            new_h as u32,
+            new_w,
+            new_h,
         ),
         _ => {
             let src_rgb = image.to_rgb8();
@@ -178,8 +211,8 @@ pub fn preprocess_image_semseg(
                 target_size,
                 pad_top,
                 pad_left,
-                new_w as u32,
-                new_h as u32,
+                new_w,
+                new_h,
             )
         }
     };
@@ -194,7 +227,7 @@ pub fn preprocess_image_semseg(
         tensor,
         tensor_f16,
         orig_shape,
-        scale: (scale, scale),
+        scale,
         padding: (pad_top as f32, pad_left as f32),
     }
 }
@@ -248,49 +281,17 @@ pub fn preprocess_image_with_precision(
     let (new_width, new_height, pad_left, pad_top, scale) =
         calculate_letterbox_params(orig_width, orig_height, target_size, stride);
 
-    // Zero-copy path: avoid to_rgb8() allocation when possible
-    let tensor = match image {
-        // Fast path: already RGB8, use bytes directly without copy
-        DynamicImage::ImageRgb8(rgb) => fused_zerocopy_preprocess(
-            rgb.as_raw(),
-            orig_width,
-            orig_height,
-            target_size,
-            pad_top,
-            pad_left,
-            new_width,
-            new_height,
-        ),
-        // Fallback: convert to RGB8 (allocates)
-        _ => {
-            let src_rgb = image.to_rgb8();
-            fused_zerocopy_preprocess(
-                src_rgb.as_raw(),
-                orig_width,
-                orig_height,
-                target_size,
-                pad_top,
-                pad_left,
-                new_width,
-                new_height,
-            )
-        }
-    };
-
-    let tensor_f16 = if half {
-        Some(tensor_f32_to_f16(&tensor))
-    } else {
-        None
-    };
-
-    PreprocessResult {
-        tensor,
-        tensor_f16,
-        orig_shape,
+    build_preprocess_result(
+        image,
+        target_size,
+        new_width,
+        new_height,
+        pad_left,
+        pad_top,
         scale,
-        #[allow(clippy::cast_precision_loss)]
-        padding: (pad_top as f32, pad_left as f32),
-    }
+        orig_shape,
+        half,
+    )
 }
 
 // ================================================================================================

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -929,7 +929,7 @@ mod tests {
         assert_eq!(h, 1024);
         assert_eq!(w, 1024);
         // Wide image: horizontal padding is 0, vertical padding is non-zero.
-        assert_eq!(res.padding.1, 0.0, "wide image: no left padding");
+        assert!(res.padding.1.abs() < 1e-6, "wide image: no left padding");
         assert!(res.padding.0 > 0.0, "wide image: top padding expected");
     }
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -79,104 +79,10 @@ pub struct PreprocessResult {
     pub padding: (f32, f32),
 }
 
-/// Preprocess an image for semantic segmentation inference.
-///
-/// Dynamic models: short-side scaling so the shorter dimension equals
-/// `target_size.0`, with stride-aligned padding appended at the bottom/right only.
-///
-/// Static models: fit-within-target letterbox to exactly `target_size` with
-/// centered alignment (padding split evenly between both sides).
-///
-/// # Arguments
-///
-/// * `image` - Input image.
-/// * `target_size` - `(height, width)` of the model input tensor.
-/// * `stride` - Model stride for padding alignment (typically 32).
-/// * `half` - If true, also generate an FP16 tensor.
-/// * `is_dynamic` - True for dynamic-shape ONNX; false for a fixed-shape export.
-///
-/// # Returns
-///
-/// Preprocessed tensor and transform information for post-processing.
-#[must_use]
-pub fn preprocess_image_semantic(
-    image: &DynamicImage,
-    target_size: (usize, usize),
-    stride: u32,
-    half: bool,
-    is_dynamic: bool,
-) -> PreprocessResult {
-    let (orig_width, orig_height) = image.dimensions();
-    let orig_shape = (orig_height, orig_width);
-    let stride_usize = stride as usize;
-
-    #[allow(clippy::cast_precision_loss)]
-    let orig_h = orig_height as f32;
-    #[allow(clippy::cast_precision_loss)]
-    let orig_w = orig_width as f32;
-    #[allow(clippy::cast_precision_loss)]
-    let (target_h_f, target_w_f) = (target_size.0 as f32, target_size.1 as f32);
-
-    let (target_size, new_h, new_w, scale, pad_top, pad_left) = if is_dynamic {
-        // Short-side scaling: scale so the shorter dimension equals target_size.0,
-        // then round the longer side up to the nearest stride multiple.
-        // Dynamic mode places content at (0, 0): no padding to split.
-        let scale = target_h_f / orig_h.min(orig_w);
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        let (nh, nw) = if orig_h <= orig_w {
-            (target_size.0, (orig_w * scale).round() as usize)
-        } else {
-            ((orig_h * scale).round() as usize, target_size.0)
-        };
-        let ph = nh.div_ceil(stride_usize) * stride_usize;
-        let pw = nw.div_ceil(stride_usize) * stride_usize;
-        ((ph, pw), nh, nw, scale, 0u32, 0u32)
-    } else {
-        // Centered letterbox: scale to fit, split the remainder evenly between top/bottom
-        // and left/right.
-        let scale = (target_h_f / orig_h).min(target_w_f / orig_w);
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        let nh = (orig_h * scale).round() as usize;
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        let nw = (orig_w * scale).round() as usize;
-        let pad_h = target_size.0.saturating_sub(nh);
-        let pad_w = target_size.1.saturating_sub(nw);
-        // Half-padding with biased rounding: `top = round(pad_h / 2 - 0.1)`. The -0.1
-        // bias ensures odd total padding lands one extra pixel at the bottom/right.
-        #[allow(
-            clippy::cast_precision_loss,
-            clippy::cast_sign_loss,
-            clippy::cast_possible_truncation
-        )]
-        let pad_top_u = ((pad_h as f32) / 2.0 - 0.1).round().max(0.0) as u32;
-        #[allow(
-            clippy::cast_precision_loss,
-            clippy::cast_sign_loss,
-            clippy::cast_possible_truncation
-        )]
-        let pad_left_u = ((pad_w as f32) / 2.0 - 0.1).round().max(0.0) as u32;
-        (target_size, nh, nw, scale, pad_top_u, pad_left_u)
-    };
-
-    build_preprocess_result(
-        image,
-        target_size,
-        new_w as u32,
-        new_h as u32,
-        pad_left,
-        pad_top,
-        (scale, scale),
-        orig_shape,
-        half,
-    )
-}
-
 /// Build a `PreprocessResult` from a resolved letterbox geometry.
 ///
-/// Shared tail for `preprocess_image_semantic` and `preprocess_image_with_precision`:
-/// runs the fused zero-copy resize/pad/normalize, optionally produces an FP16 tensor,
-/// and packages the transform metadata. The caller is responsible for computing
-/// `target_size`, `new_w`/`new_h`, padding, and `scale` for its specific letterbox style.
+/// Runs the fused zero-copy resize/pad/normalize, optionally produces an FP16 tensor,
+/// and packages the transform metadata.
 #[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
 fn build_preprocess_result(
     image: &DynamicImage,
@@ -906,25 +812,11 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocess_image_semantic_dynamic_no_padding() {
-        // 480×640 image, target=1024, is_dynamic=true.
-        // Short-side=480 → scale=1024/480; content at (0,0), no centered padding.
-        let img = image::DynamicImage::new_rgb8(640, 480);
-        let res = preprocess_image_semantic(&img, (1024, 1024), 32, false, true);
-        assert_eq!(res.padding, (0.0, 0.0), "dynamic path must have no padding");
-        assert_eq!(res.orig_shape, (480, 640));
-        let (_, _, h, w) = res.tensor.dim();
-        assert_eq!(h % 32, 0, "height must be stride-aligned");
-        assert_eq!(w % 32, 0, "width must be stride-aligned");
-        assert_eq!(h, 1024, "short side should map to target");
-    }
-
-    #[test]
-    fn test_preprocess_image_semantic_static_centered_letterbox() {
+    fn test_preprocess_image_static_centered_letterbox() {
         // 480×640 wide image, target=1024×1024, is_dynamic=false.
         // Scale = min(1024/480, 1024/640) = 1024/640 = 1.6; nh=768, nw=1024, pad_top≈128.
         let img = image::DynamicImage::new_rgb8(640, 480);
-        let res = preprocess_image_semantic(&img, (1024, 1024), 32, false, false);
+        let res = preprocess_image_with_precision(&img, (1024, 1024), 32, false);
         let (_, _, h, w) = res.tensor.dim();
         assert_eq!(h, 1024);
         assert_eq!(w, 1024);

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -86,8 +86,7 @@ pub struct PreprocessResult {
 /// `target_size.0`, with stride-aligned padding appended at the bottom/right only.
 ///
 /// Static models: fit-within-target letterbox to exactly `target_size` with
-/// centered alignment (padding split between both sides, default for
-/// `LetterBox(center=True)`).
+/// centered alignment (padding split evenly between both sides).
 ///
 /// # Arguments
 ///
@@ -135,7 +134,7 @@ pub fn preprocess_image_semseg(
         ((ph, pw), nh, nw, scale, 0u32, 0u32)
     } else {
         // Centered letterbox: scale to fit, split the remainder evenly between top/bottom
-        // and left/right (this is the predictor's default; matches `LetterBox(center=True)`).
+        // and left/right.
         let scale = (target_h_f / orig_h).min(target_w_f / orig_w);
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let nh = (orig_h * scale).round() as usize;
@@ -143,8 +142,8 @@ pub fn preprocess_image_semseg(
         let nw = (orig_w * scale).round() as usize;
         let pad_h = target_size.0.saturating_sub(nh);
         let pad_w = target_size.1.saturating_sub(nw);
-        // Use the same rounding rule as `cv2.copyMakeBorder` in `LetterBox.apply_image`:
-        // `top = round(dh - 0.1)` where dh = pad_h / 2 (float).
+        // Half-padding with biased rounding: `top = round(pad_h / 2 - 0.1)`. The -0.1
+        // bias ensures odd total padding lands one extra pixel at the bottom/right.
         #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let pad_top_u = ((pad_h as f32) / 2.0 - 0.1).round().max(0.0) as u32;
         #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss, clippy::cast_possible_truncation)]

--- a/src/results.rs
+++ b/src/results.rs
@@ -54,6 +54,29 @@ impl Speed {
     }
 }
 
+/// Per-pixel class label map for semantic segmentation.
+#[derive(Debug, Clone)]
+pub struct SemanticMask {
+    /// Class index for each pixel, shape [H, W].
+    pub data: Array2<u32>,
+    /// Original image shape (height, width).
+    pub orig_shape: (u32, u32),
+}
+
+impl SemanticMask {
+    /// Create a new `SemanticMask`.
+    #[must_use]
+    pub fn new(data: Array2<u32>, orig_shape: (u32, u32)) -> Self {
+        Self { data, orig_shape }
+    }
+
+    /// Get the original image shape (height, width).
+    #[must_use]
+    pub const fn orig_shape(&self) -> (u32, u32) {
+        self.orig_shape
+    }
+}
+
 /// Main results container for YOLO inference.
 ///
 /// Contains the original image, detection results (boxes, masks, keypoints, etc.), timing information, and metadata.
@@ -75,6 +98,8 @@ pub struct Results {
     pub probs: Option<Probs>,
     /// Oriented bounding boxes (if applicable).
     pub obb: Option<Obb>,
+    /// Semantic segmentation class map (if applicable).
+    pub semantic_mask: Option<SemanticMask>,
     /// Inference timing information.
     pub speed: Speed,
     /// Class ID to name mapping.
@@ -118,6 +143,7 @@ impl Results {
             keypoints: None,
             probs: None,
             obb: None,
+            semantic_mask: None,
             speed,
             names,
             path,
@@ -145,6 +171,9 @@ impl Results {
         }
         if let Some(ref obb) = self.obb {
             return obb.len();
+        }
+        if self.semantic_mask.is_some() {
+            return 1;
         }
         0
     }

--- a/src/results.rs
+++ b/src/results.rs
@@ -66,7 +66,7 @@ pub struct SemanticMask {
 impl SemanticMask {
     /// Create a new `SemanticMask`.
     #[must_use]
-    pub fn new(data: Array2<u32>, orig_shape: (u32, u32)) -> Self {
+    pub const fn new(data: Array2<u32>, orig_shape: (u32, u32)) -> Self {
         Self { data, orig_shape }
     }
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -59,7 +59,7 @@ impl Speed {
 #[derive(Debug, Clone)]
 pub struct SemanticMask {
     /// Class index for each pixel, shape [H, W].
-    pub data: Array2<u32>,
+    pub data: Array2<u16>,
     /// Original image shape (height, width).
     pub orig_shape: (u32, u32),
 }
@@ -67,7 +67,7 @@ pub struct SemanticMask {
 impl SemanticMask {
     /// Create a new `SemanticMask`.
     #[must_use]
-    pub const fn new(data: Array2<u32>, orig_shape: (u32, u32)) -> Self {
+    pub const fn new(data: Array2<u16>, orig_shape: (u32, u32)) -> Self {
         Self { data, orig_shape }
     }
 
@@ -75,6 +75,21 @@ impl SemanticMask {
     #[must_use]
     pub const fn orig_shape(&self) -> (u32, u32) {
         self.orig_shape
+    }
+
+    /// Count unique class IDs present in the mask.
+    #[must_use]
+    pub fn classes_present(&self) -> usize {
+        let mut seen = vec![false; usize::from(u16::MAX) + 1];
+        let mut count = 0;
+        for &v in &self.data {
+            let idx = usize::from(v);
+            if !seen[idx] {
+                seen[idx] = true;
+                count += 1;
+            }
+        }
+        count
     }
 }
 
@@ -155,7 +170,8 @@ impl Results {
     ///
     /// # Returns
     ///
-    /// * The count of detected objects, keyspoints, or masks.
+    /// * The count of detected objects, keypoints, or instance masks.
+    ///   Semantic segmentation masks are per-pixel maps, not detections, so they return 0.
     #[must_use]
     pub fn len(&self) -> usize {
         if let Some(ref boxes) = self.boxes {
@@ -173,9 +189,6 @@ impl Results {
         if let Some(ref obb) = self.obb {
             return obb.len();
         }
-        if self.semantic_mask.is_some() {
-            return 1;
-        }
         0
     }
 
@@ -183,7 +196,7 @@ impl Results {
     ///
     /// # Returns
     ///
-    /// * `true` if no objects were detected.
+    /// * `true` if no object-like results were detected.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -216,6 +229,11 @@ impl Results {
     /// * A string summary of detections (e.g., "2 persons, 1 car, ").
     #[must_use]
     pub fn verbose(&self) -> String {
+        if let Some(ref sm) = self.semantic_mask {
+            let n = sm.classes_present();
+            return format!("{n} {}, ", if n == 1 { "class" } else { "classes" });
+        }
+
         if self.is_empty() {
             if self.probs.is_some() {
                 return String::new();
@@ -1040,5 +1058,19 @@ mod tests {
         let results = Results::new(orig_img, "test.jpg".to_string(), names, speed, (640, 640));
         assert!(results.is_empty());
         assert_eq!(results.verbose(), "(no detections), ");
+    }
+
+    #[test]
+    fn test_semantic_mask_has_no_detection_len() {
+        let names = Arc::new(HashMap::from([(0, "background".to_string())]));
+        let speed = Speed::default();
+        let orig_img = Array3::zeros((2, 2, 3));
+        let mut results = Results::new(orig_img, "test.jpg".to_string(), names, speed, (2, 2));
+        results.semantic_mask = Some(SemanticMask::new(array![[0u16, 1], [1, 2]], (2, 2)));
+
+        assert_eq!(results.len(), 0);
+        assert!(results.is_empty());
+        assert_eq!(results.semantic_mask.as_ref().unwrap().classes_present(), 3);
+        assert_eq!(results.verbose(), "3 classes, ");
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -119,7 +119,7 @@ impl Task {
     /// Returns `true` only for the `SemSeg` task, which outputs a per-pixel class label map.
     #[must_use]
     pub const fn has_semantic_mask(&self) -> bool {
-        matches!(self, Self::SemSeg)
+        matches!(self, Self::Semantic)
     }
 }
 
@@ -139,7 +139,7 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => Ok(Self::SemSeg),
+            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => Ok(Self::Semantic),
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -153,7 +153,7 @@ impl fmt::Display for TaskParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid task '{}', expected one of: detect, segment, pose, classify, obb, semseg",
+            "invalid task '{}', expected one of: detect, segment, pose, classify, obb, semantic",
             self.0
         )
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -86,7 +86,7 @@ impl Task {
         format!("yolo26n{}.onnx", self.model_suffix())
     }
 
-    /// Returns `true` when the task outputs bounding boxes — namely Detect, Segment, Pose, and Obb.
+    /// Returns `true` when the task outputs bounding boxes: Detect, Segment, Pose, and Obb.
     #[must_use]
     pub const fn has_boxes(&self) -> bool {
         matches!(self, Self::Detect | Self::Segment | Self::Pose | Self::Obb)

--- a/src/task.rs
+++ b/src/task.rs
@@ -31,6 +31,9 @@ pub enum Task {
     /// Oriented bounding box detection (OBB).
     /// Predicts rotated bounding boxes for objects, useful for aerial imagery etc.
     Obb,
+    /// Semantic segmentation.
+    /// Assigns a class label to every pixel in the image.
+    SemSeg,
 }
 
 impl Task {
@@ -44,6 +47,7 @@ impl Task {
             Self::Pose => "pose",
             Self::Classify => "classify",
             Self::Obb => "obb",
+            Self::SemSeg => "semseg",
         }
     }
 
@@ -62,6 +66,7 @@ impl Task {
             Self::Pose => "-pose",
             Self::Classify => "-cls",
             Self::Obb => "-obb",
+            Self::SemSeg => "-semseg",
         }
     }
 
@@ -108,6 +113,12 @@ impl Task {
     pub const fn has_obb(&self) -> bool {
         matches!(self, Self::Obb)
     }
+
+    /// Returns `true` only for the SemSeg task, which outputs a per-pixel class label map.
+    #[must_use]
+    pub const fn has_semantic_mask(&self) -> bool {
+        matches!(self, Self::SemSeg)
+    }
 }
 
 impl fmt::Display for Task {
@@ -126,6 +137,9 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
+            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => {
+                Ok(Self::SemSeg)
+            }
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -139,7 +153,7 @@ impl fmt::Display for TaskParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid task '{}', expected one of: detect, segment, pose, classify, obb",
+            "invalid task '{}', expected one of: detect, segment, pose, classify, obb, semseg",
             self.0
         )
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -139,7 +139,7 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semantic" | "semantic_segmentation" | "semseg" => Ok(Self::Semantic),
+            "semantic" | "semantic_segmentation" => Ok(Self::Semantic),
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -184,8 +184,6 @@ mod tests {
             "semantic_segmentation".parse::<Task>().unwrap(),
             Task::Semantic
         );
-        // PT/ONNX files exported before the rename still embed task=semseg
-        assert_eq!("semseg".parse::<Task>().unwrap(), Task::Semantic);
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -139,9 +139,7 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => {
-                Ok(Self::SemSeg)
-            }
+            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => Ok(Self::SemSeg),
             _ => Err(TaskParseError(s.to_string())),
         }
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -139,7 +139,7 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semantic" | "semantic_segmentation" => Ok(Self::Semantic),
+            "semantic" | "semantic_segmentation" | "semseg" => Ok(Self::Semantic),
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -184,6 +184,8 @@ mod tests {
             "semantic_segmentation".parse::<Task>().unwrap(),
             Task::Semantic
         );
+        // PT/ONNX files exported before the rename still embed task=semseg
+        assert_eq!("semseg".parse::<Task>().unwrap(), Task::Semantic);
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -33,7 +33,7 @@ pub enum Task {
     Obb,
     /// Semantic segmentation.
     /// Assigns a class label to every pixel in the image.
-    SemSeg,
+    Semantic,
 }
 
 impl Task {
@@ -47,7 +47,7 @@ impl Task {
             Self::Pose => "pose",
             Self::Classify => "classify",
             Self::Obb => "obb",
-            Self::SemSeg => "semseg",
+            Self::Semantic => "semantic",
         }
     }
 
@@ -67,7 +67,7 @@ impl Task {
             Self::Pose => "-pose",
             Self::Classify => "-cls",
             Self::Obb => "-obb",
-            Self::SemSeg => "-sem",
+            Self::Semantic => "-sem",
         }
     }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -116,7 +116,7 @@ impl Task {
         matches!(self, Self::Obb)
     }
 
-    /// Returns `true` only for the SemSeg task, which outputs a per-pixel class label map.
+    /// Returns `true` only for the `SemSeg` task, which outputs a per-pixel class label map.
     #[must_use]
     pub const fn has_semantic_mask(&self) -> bool {
         matches!(self, Self::SemSeg)

--- a/src/task.rs
+++ b/src/task.rs
@@ -116,7 +116,7 @@ impl Task {
         matches!(self, Self::Obb)
     }
 
-    /// Returns `true` only for the `SemSeg` task, which outputs a per-pixel class label map.
+    /// Returns `true` only for the `Semantic` task, which outputs a per-pixel class label map.
     #[must_use]
     pub const fn has_semantic_mask(&self) -> bool {
         matches!(self, Self::Semantic)
@@ -139,7 +139,9 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => Ok(Self::Semantic),
+            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => {
+                Ok(Self::Semantic)
+            }
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -173,17 +175,25 @@ mod tests {
         assert_eq!("classify".parse::<Task>().unwrap(), Task::Classify);
         assert_eq!("obb".parse::<Task>().unwrap(), Task::Obb);
 
+        assert_eq!("semantic".parse::<Task>().unwrap(), Task::Semantic);
+
         // Alternative names
         assert_eq!("detection".parse::<Task>().unwrap(), Task::Detect);
         assert_eq!("segmentation".parse::<Task>().unwrap(), Task::Segment);
         assert_eq!("keypoints".parse::<Task>().unwrap(), Task::Pose);
         assert_eq!("cls".parse::<Task>().unwrap(), Task::Classify);
+        assert_eq!("semseg".parse::<Task>().unwrap(), Task::Semantic);
+        assert_eq!(
+            "semantic_segmentation".parse::<Task>().unwrap(),
+            Task::Semantic
+        );
     }
 
     #[test]
     fn test_task_display() {
         assert_eq!(Task::Detect.to_string(), "detect");
         assert_eq!(Task::Segment.to_string(), "segment");
+        assert_eq!(Task::Semantic.to_string(), "semantic");
     }
 
     #[test]
@@ -194,5 +204,7 @@ mod tests {
         assert!(Task::Pose.has_keypoints());
         assert!(Task::Classify.has_probs());
         assert!(Task::Obb.has_obb());
+        assert!(Task::Semantic.has_semantic_mask());
+        assert!(!Task::Detect.has_semantic_mask());
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -139,9 +139,7 @@ impl FromStr for Task {
             "pose" | "keypoint" | "keypoints" => Ok(Self::Pose),
             "classify" | "classification" | "cls" => Ok(Self::Classify),
             "obb" | "oriented" => Ok(Self::Obb),
-            "semseg" | "semantic" | "semantic_segmentation" | "semsegmentation" => {
-                Ok(Self::Semantic)
-            }
+            "semantic" | "semantic_segmentation" => Ok(Self::Semantic),
             _ => Err(TaskParseError(s.to_string())),
         }
     }
@@ -182,7 +180,6 @@ mod tests {
         assert_eq!("segmentation".parse::<Task>().unwrap(), Task::Segment);
         assert_eq!("keypoints".parse::<Task>().unwrap(), Task::Pose);
         assert_eq!("cls".parse::<Task>().unwrap(), Task::Classify);
-        assert_eq!("semseg".parse::<Task>().unwrap(), Task::Semantic);
         assert_eq!(
             "semantic_segmentation".parse::<Task>().unwrap(),
             Task::Semantic

--- a/src/task.rs
+++ b/src/task.rs
@@ -67,7 +67,7 @@ impl Task {
             Self::Pose => "-pose",
             Self::Classify => "-cls",
             Self::Obb => "-obb",
-            Self::SemSeg => "-semseg",
+            Self::SemSeg => "-sem",
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -158,7 +158,7 @@ fn test_semantic_save_class_map() {
         .ok()
         .into_iter()
         .flatten()
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .any(|predict_dir| predict_dir.path().join("results").join("bus.png").exists());
     assert!(
         results_png_exists,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,10 +20,9 @@ use ultralytics_inference::{Device, YOLOModel};
 /// 1. **Issue #148 / PR #149**: `GatherElements op: Out of range` during warmup.
 ///    `CoreML`'s DFL head produces out-of-range gather indices on an all-zeros dummy input.
 ///
-/// 2. **`graph_input_cast_0` crash**: `MLProgram` format causes ORT's `CoreML` EP to insert a
-///    cast node, renaming the ONNX input (e.g. `images`) to `graph_input_cast_0`. ORT then
-///    feeds the tensor with the original name, which `CoreML` can't find.
-///    The fix (`NeuralNetwork` format) avoids the rename entirely.
+/// 2. **`graph_input_cast_0` crash**: `CoreML` must not rename the ONNX input
+///    (e.g. `images`) to an internal cast node that ORT cannot feed. The current
+///    `MLProgram` path uses static input shapes and `FastPrediction` to avoid that cast.
 #[cfg(feature = "coreml")]
 #[test]
 #[ignore = "downloads a YOLO model; requires CoreML (macOS only)"]
@@ -35,7 +34,7 @@ fn test_coreml_model_loads_and_warms_up() {
     let mut model = YOLOModel::load_with_config(model_path.to_string_lossy().as_ref(), config)
         .expect("CoreML model should load");
 
-    // warmup() must succeed: graph_input_cast_0 errors are gone (`NeuralNetwork` format fix)
+    // warmup() must succeed: graph_input_cast_0 errors are gone (static-shape MLProgram path)
     // and GatherElements out-of-range is tolerated (issue #148 fix).
     model.warmup().expect("CoreML warmup should not fail");
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,13 +75,20 @@ fn test_auto_download_semantic_model() {
     let temp_dir = tempdir().expect("temp dir should be created");
     let model_path = temp_dir.path().join("yolo26n-sem.onnx");
     let result = ultralytics_inference::download::try_download_model(&model_path);
-    assert!(result.is_ok(), "download should succeed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "download should succeed: {:?}",
+        result.err()
+    );
     assert!(
         model_path.exists(),
         "yolo26n-sem.onnx should be present after auto-download"
     );
     let size = std::fs::metadata(&model_path).unwrap().len();
-    assert!(size > 1_000_000, "downloaded file should be a real model (>1 MB), got {size} bytes");
+    assert!(
+        size > 1_000_000,
+        "downloaded file should be a real model (>1 MB), got {size} bytes"
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tempfile::tempdir;
 use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
+use ultralytics_inference::task::Task;
 use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
 #[cfg(feature = "coreml")]
 use ultralytics_inference::{Device, YOLOModel};
@@ -66,6 +67,96 @@ fn test_run_prediction_e2e() {
     };
 
     run_prediction(&args);
+}
+
+#[test]
+#[ignore = "downloads yolo26n-sem.onnx from GitHub releases; requires network"]
+fn test_auto_download_semantic_model() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let model_path = temp_dir.path().join("yolo26n-sem.onnx");
+    let result = ultralytics_inference::download::try_download_model(&model_path);
+    assert!(result.is_ok(), "download should succeed: {:?}", result.err());
+    assert!(
+        model_path.exists(),
+        "yolo26n-sem.onnx should be present after auto-download"
+    );
+    let size = std::fs::metadata(&model_path).unwrap().len();
+    assert!(size > 1_000_000, "downloaded file should be a real model (>1 MB), got {size} bytes");
+}
+
+#[test]
+#[ignore = "downloads a YOLO semantic model and sample image"]
+fn test_run_prediction_e2e_semantic() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let model_path = temp_dir.path().join("yolo26n-sem.onnx");
+
+    let args = PredictArgs {
+        model: Some(model_path.to_string_lossy().into_owned()),
+        task: Some(Task::Semantic),
+        source: Some("https://ultralytics.com/images/bus.jpg".to_string()),
+        conf: 0.25,
+        iou: 0.45,
+        max_det: 300,
+        imgsz: Some(640),
+        rect: false,
+        batch: 1,
+        half: false,
+        save: false,
+        save_frames: false,
+        save_json: false,
+        show: false,
+        device: None,
+        verbose: false,
+        classes: None,
+    };
+
+    run_prediction(&args);
+}
+
+#[test]
+#[ignore = "downloads a YOLO semantic model and sample image; writes class-map PNG to runs/"]
+fn test_semantic_save_class_map() {
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let model_path = temp_dir.path().join("yolo26n-sem.onnx");
+
+    let args = PredictArgs {
+        model: Some(model_path.to_string_lossy().into_owned()),
+        task: Some(Task::Semantic),
+        source: Some("https://ultralytics.com/images/bus.jpg".to_string()),
+        conf: 0.25,
+        iou: 0.45,
+        max_det: 300,
+        imgsz: Some(640),
+        rect: false,
+        batch: 1,
+        half: false,
+        save: false,
+        save_frames: false,
+        save_json: true,
+        show: false,
+        device: None,
+        verbose: false,
+        classes: None,
+    };
+
+    run_prediction(&args);
+
+    // Verify a results/ dir was created under runs/semantic/predict*/
+    let runs_dir = std::path::Path::new("runs").join("semantic");
+    assert!(
+        runs_dir.exists(),
+        "runs/semantic/ should exist after save_json=true for semantic task"
+    );
+    let results_png_exists = std::fs::read_dir(&runs_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .any(|predict_dir| predict_dir.path().join("results").join("bus.png").exists());
+    assert!(
+        results_png_exists,
+        "class-map PNG should be written to runs/semantic/predict*/results/bus.png"
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,11 +15,10 @@ use ultralytics_inference::{Device, YOLOModel};
 
 /// End-to-end `CoreML` test covering two known regressions:
 ///
-/// 1. **Issue #148 / PR #149** — `GatherElements op: Out of range` during warmup.
+/// 1. **Issue #148 / PR #149**: `GatherElements op: Out of range` during warmup.
 ///    `CoreML`'s DFL head produces out-of-range gather indices on an all-zeros dummy input.
-///    
 ///
-/// 2. **`graph_input_cast_0` crash** — `MLProgram` format causes ORT's `CoreML` EP to insert a
+/// 2. **`graph_input_cast_0` crash**: `MLProgram` format causes ORT's `CoreML` EP to insert a
 ///    cast node, renaming the ONNX input (e.g. `images`) to `graph_input_cast_0`. ORT then
 ///    feeds the tensor with the original name, which `CoreML` can't find.
 ///    The fix (`NeuralNetwork` format) avoids the rename entirely.
@@ -58,6 +57,7 @@ fn test_run_prediction_e2e() {
         half: false,
         save: false,
         save_frames: false,
+        save_json: false,
         show: false,
         device: None,
         verbose: false,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR adds **semantic segmentation support** to `ultralytics/inference`, including new YOLO26 `-sem` model handling, per-pixel result outputs, visualization, and export options, while also improving inference efficiency and CoreML behavior.

### 📊 Key Changes
- 🧠 Added a new **`Semantic` task** across the library and CLI, including support for YOLO26 semantic segmentation models like `yolo26n-sem.onnx`.
- 🎨 Introduced a new **`SemanticMask` result type** to store per-pixel class maps, alongside existing `Boxes`, `Masks`, `Keypoints`, `Probs`, and `Obb`.
- 🖼️ Added **semantic mask visualization**, overlaying class colors on output images.
- 💾 Added CLI support for **saving semantic segmentation outputs** as per-image PNG class maps via `--save-json` for external evaluation workflows.
- 📥 Extended **auto-download support** so YOLO26 semantic models can be fetched automatically.
- ⚡ Optimized semantic inference with a **fast path for models that already output class maps**, avoiding extra CPU work and unnecessary memory copies.
- 🔧 Refactored batching and postprocessing code to better support **all task types**, especially semantic segmentation.
- 🍎 Updated **CoreML execution settings** to use a more robust MLProgram path with static input shapes, helping avoid known input-renaming crashes.
- 🧪 Added extensive **unit and integration tests** for semantic segmentation, preprocessing behavior, output summaries, model download, and saved mask files.
- 📚 Updated documentation, examples, CLI help text, and versioning from **0.0.16 to 0.0.17**.

### 🎯 Purpose & Impact
- ✅ Expands the Rust inference library beyond object detection-style tasks to include **full semantic segmentation**, making it more complete for vision applications.
- 🚗 Helps users working on scenes like **road understanding, urban mapping, and pixel-level labeling** use YOLO26 models directly in Rust.
- ⚡ Improves performance for semantic models by reducing extra processing, which can mean **faster inference and lower memory overhead**.
- 🖥️ Makes results easier to use in downstream pipelines by allowing **direct export of class-map PNGs** for benchmarking or evaluation.
- 🍏 Improves reliability on **CoreML/macOS** setups by addressing a known execution issue.
- 🤝 Keeps the API more consistent with Ultralytics Python behavior, which should make adoption easier for developers moving between ecosystems.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
