### PR TITLE
refactor: 🚀 add draw_label function for improved label placement in image annotations

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -254,7 +254,12 @@ fn draw_filled_circle(img: &mut image::RgbImage, cx: i32, cy: i32, radius: i32, 
     }
 }
 
-#[allow(clippy::cast_sign_loss, clippy::too_many_arguments)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::too_many_arguments
+)]
 fn draw_label(
     img: &mut image::RgbImage,
     font: &FontRef,
@@ -463,7 +468,7 @@ fn draw_detection(img: &mut image::RgbImage, result: &Results, font: Option<&Fon
             let class_name = result.names.get(&class_id).map_or("object", String::as_str);
             let label = format!(" {class_name} {confidence:.2} ");
 
-            if let Some(ref f) = font {
+            if let Some(f) = font {
                 draw_label(
                     img,
                     f,
@@ -653,7 +658,7 @@ fn draw_obb(img: &mut image::RgbImage, result: &Results, font: Option<&FontRef>)
             let class_name = result.names.get(&class_id).map_or("object", String::as_str);
             let label = format!(" {} {:.2} ", class_name, conf[i]);
 
-            if let Some(ref f) = font {
+            if let Some(f) = font {
                 draw_label(
                     img,
                     f,

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -254,6 +254,85 @@ fn draw_filled_circle(img: &mut image::RgbImage, cx: i32, cy: i32, radius: i32, 
     }
 }
 
+#[allow(clippy::cast_sign_loss, clippy::too_many_arguments)]
+fn draw_label(
+    img: &mut image::RgbImage,
+    font: &FontRef,
+    occupied: &mut Vec<Rect>,
+    label: &str,
+    color: Rgb<u8>,
+    font_scale: f32,
+    anchor_x: i32,
+    anchor_y: i32,
+    top_fallback_y: i32,
+) {
+    let (width, height) = img.dimensions();
+    let scale = PxScale::from(font_scale);
+    let scaled_font = font.as_scaled(scale);
+    let text_w = label
+        .chars()
+        .map(|c| scaled_font.h_advance(scaled_font.glyph_id(c)))
+        .sum::<f32>()
+        .ceil() as i32;
+    let text_h = scale.y.ceil() as i32;
+
+    let mut text_x = anchor_x;
+    let mut text_y = anchor_y - text_h;
+
+    if text_y < 0 {
+        text_y = top_fallback_y;
+    }
+    if text_x < 0 {
+        text_x = 0;
+    }
+    if text_x + text_w >= width as i32 {
+        text_x = width as i32 - text_w - 1;
+    }
+    if text_y + text_h >= height as i32 {
+        text_y = height as i32 - text_h - 1;
+    }
+
+    let mut attempts = 0;
+    let max_attempts = 10;
+    let mut current_rect = Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
+
+    while attempts < max_attempts {
+        if !occupied
+            .iter()
+            .any(|existing| rect_intersect(&current_rect, existing))
+        {
+            break;
+        }
+
+        text_y += text_h;
+        if text_y + text_h >= height as i32 {
+            text_y = anchor_y - text_h;
+            if text_y < 0 {
+                text_y = top_fallback_y;
+            }
+            text_x += 10;
+            if text_x + text_w >= width as i32 {
+                break;
+            }
+        }
+
+        current_rect = Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
+        attempts += 1;
+    }
+
+    occupied.push(current_rect);
+
+    if text_x >= 0
+        && text_y >= 0
+        && text_x + text_w < width as i32
+        && text_y + text_h < height as i32
+    {
+        draw_filled_rect_mut(img, current_rect, color);
+        let text_color = get_text_color(color);
+        draw_text_mut(img, text_color, text_x, text_y, scale, font, label);
+    }
+}
+
 /// Draw object detection results (boxes and masks)
 #[allow(
     clippy::cast_possible_truncation,
@@ -385,90 +464,17 @@ fn draw_detection(img: &mut image::RgbImage, result: &Results, font: Option<&Fon
             let label = format!(" {class_name} {confidence:.2} ");
 
             if let Some(ref f) = font {
-                let scale = PxScale::from(font_scale);
-                let scaled_font = f.as_scaled(scale);
-                let mut text_w = 0.0;
-                for c in label.chars() {
-                    text_w += scaled_font.h_advance(scaled_font.glyph_id(c));
-                }
-                let text_w = text_w.ceil() as i32;
-                let text_h = scale.y.ceil() as i32;
-
-                // Smart label placement
-                // Default: above the box
-                let mut text_x = x1;
-                let mut text_y = y1 - text_h;
-
-                // If label is out of image (top), move inside
-                if text_y < 0 {
-                    text_y = y1;
-                }
-
-                // If label is out of image (left), move right
-                if text_x < 0 {
-                    text_x = 0;
-                }
-
-                // If label is out of image (right), move left
-                if text_x + text_w >= width as i32 {
-                    text_x = width as i32 - text_w - 1;
-                }
-
-                // Check bounds one last time (bottom)
-                if text_y + text_h >= height as i32 {
-                    text_y = height as i32 - text_h - 1;
-                }
-
-                // Overlap avoidance
-                // Check against existing labels. If overlap, move down.
-                let mut attempts = 0;
-                let max_attempts = 10;
-                let mut current_rect =
-                    Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
-
-                'placement: while attempts < max_attempts {
-                    if !labels_rects
-                        .iter()
-                        .any(|existing| rect_intersect(&current_rect, existing))
-                    {
-                        break 'placement;
-                    }
-
-                    // Move down
-                    text_y += text_h; // stack below
-
-                    // Check bounds again
-                    if text_y + text_h >= height as i32 {
-                        // Reached bottom, maybe try moving right?
-                        // For now just stop here or loop around?
-                        // Let's try moving x a bit and resetting y
-                        text_y = y1 - text_h;
-                        if text_y < 0 {
-                            text_y = y1;
-                        }
-                        text_x += 10; // Shift right slightly
-                        if text_x + text_w >= width as i32 {
-                            // Screen full, just give up and draw wherever
-                            break 'placement;
-                        }
-                    }
-
-                    current_rect = Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
-                    attempts += 1;
-                }
-
-                // Add to occupied list
-                labels_rects.push(current_rect);
-
-                if text_x >= 0
-                    && text_y >= 0
-                    && text_x + text_w < width as i32
-                    && text_y + text_h < height as i32
-                {
-                    draw_filled_rect_mut(img, current_rect, color);
-                    let text_color = get_text_color(color);
-                    draw_text_mut(img, text_color, text_x, text_y, scale, f, &label);
-                }
+                draw_label(
+                    img,
+                    f,
+                    &mut labels_rects,
+                    &label,
+                    color,
+                    font_scale,
+                    x1,
+                    y1,
+                    y1,
+                );
             }
         }
     }
@@ -648,79 +654,17 @@ fn draw_obb(img: &mut image::RgbImage, result: &Results, font: Option<&FontRef>)
             let label = format!(" {} {:.2} ", class_name, conf[i]);
 
             if let Some(ref f) = font {
-                let scale = PxScale::from(font_scale);
-                let scaled_font = f.as_scaled(scale);
-                let mut text_w = 0.0;
-                for c in label.chars() {
-                    text_w += scaled_font.h_advance(scaled_font.glyph_id(c));
-                }
-                let text_w = text_w.ceil() as i32;
-                let text_h = scale.y.ceil() as i32;
-
-                // Smart label placement
-                // Default: at the first corner (usually top-left-ish)
-                let mut text_x = corners[[i, 0, 0]] as i32;
-                let mut text_y = (corners[[i, 0, 1]] as i32 - text_h).max(0);
-
-                // If label is out of image (left), move right
-                if text_x < 0 {
-                    text_x = 0;
-                }
-
-                // If label is out of image (right), move left
-                if text_x + text_w >= width as i32 {
-                    text_x = width as i32 - text_w - 1;
-                }
-
-                // Check bounds one last time (bottom)
-                if text_y + text_h >= height as i32 {
-                    text_y = height as i32 - text_h - 1;
-                }
-
-                // Overlap avoidance
-                // Check against existing labels. If overlap, move down.
-                let mut attempts = 0;
-                let max_attempts = 10;
-                let mut current_rect =
-                    Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
-
-                'placement: while attempts < max_attempts {
-                    if !labels_rects
-                        .iter()
-                        .any(|existing| rect_intersect(&current_rect, existing))
-                    {
-                        break 'placement;
-                    }
-
-                    // Move down
-                    text_y += text_h; // stack below
-
-                    // Check bounds again
-                    if text_y + text_h >= height as i32 {
-                        // Reached bottom, try resetting y and moving x
-                        text_y = (corners[[i, 0, 1]] as i32 - text_h).max(0);
-                        text_x += 10; // Shift right
-                        if text_x + text_w >= width as i32 {
-                            break 'placement;
-                        }
-                    }
-
-                    current_rect = Rect::at(text_x, text_y).of_size(text_w as u32, text_h as u32);
-                    attempts += 1;
-                }
-
-                // Add to occupied list
-                labels_rects.push(current_rect);
-
-                if text_x >= 0
-                    && text_y >= 0
-                    && text_x + text_w < width as i32
-                    && text_y + text_h < height as i32
-                {
-                    draw_filled_rect_mut(img, current_rect, color);
-                    let text_color = get_text_color(color);
-                    draw_text_mut(img, text_color, text_x, text_y, scale, f, &label);
-                }
+                draw_label(
+                    img,
+                    f,
+                    &mut labels_rects,
+                    &label,
+                    color,
+                    font_scale,
+                    corners[[i, 0, 0]] as i32,
+                    corners[[i, 0, 1]] as i32,
+                    0,
+                );
             }
         }
     }


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactored label drawing in the Rust annotation pipeline to use one shared `draw_label()` helper, improving code reuse and keeping detection labels cleaner and better positioned 🏷️✨

### 📊 Key Changes
- Added a new `draw_label()` function in `src/annotate.rs` to centralize text label rendering logic 🛠️
- Moved repeated label-placement behavior out of both `draw_detection()` and `draw_obb()` into this shared helper
- Preserved and standardized smart label placement features, including:
  - keeping labels inside image bounds 🖼️
  - placing labels above objects when possible
  - falling back to alternate positions when space is limited
  - avoiding overlap with previously drawn labels 📍
- Updated both standard detection annotations and oriented bounding box annotations to call the new helper for label drawing

### 🎯 Purpose & Impact
- Reduces duplicated code, making the annotation system easier to maintain and less error-prone ✅
- Keeps labeling behavior more consistent across different annotation types, especially between regular boxes and oriented boxes 🔄
- Makes future improvements to label placement easier, since changes now only need to be made in one place 🚀
- Improves readability of the codebase for developers without changing the core user-facing annotation behavior in major ways 👨‍💻
- Helps produce cleaner visual outputs in crowded scenes by continuing to manage label collisions and boundary handling more reliably 🎨