### PR TITLE
build(deps): Bump taiki-e/install-action from v2.79.2 to v2.79.3 in /github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub CI workflow to use a newer version of the `taiki-e/install-action` dependency for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the GitHub Actions step in `.github/workflows/ci.yml`
- Bumped `taiki-e/install-action` from commit `213ccc1...` to `65851e1...`
- This changes the pinned action version from `v2.79.2` to `v2.79.3`
- The affected step is the CI setup for installing `cargo-llvm-cov`, a Rust code coverage tool

### 🎯 Purpose & Impact
- 🛡️ Keeps CI dependencies up to date with the latest patch release
- 🔒 Maintains pinned commit usage, which helps preserve workflow security and reproducibility
- ⚙️ May include small fixes or reliability improvements in the action used during CI runs
- 👥 Minimal user-facing impact, but helps keep the project’s automated testing and coverage pipeline healthy and current