### PR TITLE
Bump taiki-e/install-action from v2.79.3 to v2.79.4 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.3 to v2.79.4 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, bumping the pinned `taiki-e/install-action` version from `v2.79.3` to `v2.79.4`.

### 📊 Key Changes
- Updated the CI workflow file at `.github/workflows/ci.yml`.
- Changed the GitHub Action used for installing `cargo-llvm-cov`:
  - from `taiki-e/install-action` `v2.79.3`
  - to `taiki-e/install-action` `v2.79.4`
- Kept the existing CI behavior and tool usage the same, with only the action version refreshed. ♻️

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping dependencies in GitHub Actions up to date. 🛠️
- May bring small fixes, compatibility updates, or security improvements from the newer action release. 🔒
- Low-risk change: it does not alter product features or runtime behavior, only the automation used in testing/coverage workflows. ✅
- Helps keep the repository’s Rust coverage setup more reliable over time. 📈