### PR TITLE
refactor: ♻️ extract run_timed helper to deduplicate session run logic 

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1157,6 +1157,20 @@ impl YOLOModel {
         Ok(results_vec)
     }
 
+    /// Run the ORT session, returning outputs and measured inference time in ms.
+    ///
+    /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
+    fn run_timed<'s>(
+        session: &'s mut Session,
+        inputs: Vec<(std::borrow::Cow<'_, str>, ort::session::SessionInputValue<'_>)>,
+    ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
+        let t = Instant::now();
+        let outputs = session
+            .run(inputs)
+            .map_err(|e| InferenceError::InferenceError(format!("Inference failed: {e}")))?;
+        Ok((outputs, t.elapsed().as_secs_f64() * 1000.0))
+    }
+
     /// Run ONNX inference with FP32 input, calling `cb` with zero-copy output views.
     ///
     /// `cb` receives `&[(&[f32], shape)]` borrowing directly into ORT-owned device-to-host
@@ -1172,19 +1186,10 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let inputs = ort::inputs![input_name => input_tensor];
-
-        let t_run = std::time::Instant::now();
-        let outputs = session
-            .run(inputs)
-            .map_err(|e| InferenceError::InferenceError(format!("Inference failed: {e}")))?;
-        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
-
-        // Build zero-copy views (or owned buffers for f16 outputs that must be converted)
-        Self::extract_and_invoke(&outputs, output_names, inference_ms, cb)
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view())
+            .map_err(|e| InferenceError::InferenceError(format!("Failed to create input tensor: {e}")))?;
+        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 
     /// Build zero-copy slice views over ORT output tensors and call `cb`.
@@ -1245,18 +1250,10 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let inputs = ort::inputs![input_name => input_tensor];
-
-        let t_run = std::time::Instant::now();
-        let outputs = session
-            .run(inputs)
-            .map_err(|e| InferenceError::InferenceError(format!("Inference failed: {e}")))?;
-        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
-
-        Self::extract_and_invoke_u8(&outputs, output_names, inference_ms, cb)
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view())
+            .map_err(|e| InferenceError::InferenceError(format!("Failed to create input tensor: {e}")))?;
+        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
     /// Build zero-copy `&[u8]` slice views over ORT output tensors and call `cb`.
@@ -1295,20 +1292,10 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!(
-                "Failed to create FP16 input tensor for u8 output: {e}"
-            ))
-        })?;
-        let inputs = ort::inputs![input_name => input_tensor];
-
-        let t_run = std::time::Instant::now();
-        let outputs = session.run(inputs).map_err(|e| {
-            InferenceError::InferenceError(format!("FP16->u8 inference failed: {e}"))
-        })?;
-        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
-
-        Self::extract_and_invoke_u8(&outputs, output_names, inference_ms, cb)
+        let input_tensor = TensorRef::from_array_view(&input_contiguous)
+            .map_err(|e| InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}")))?;
+        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
     /// Run ONNX inference with FP16 input, zero-copy callback (FP16 outputs are converted).
@@ -1320,18 +1307,10 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
-        })?;
-        let inputs = ort::inputs![input_name => input_tensor];
-
-        let t_run = std::time::Instant::now();
-        let outputs = session
-            .run(inputs)
-            .map_err(|e| InferenceError::InferenceError(format!("FP16 inference failed: {e}")))?;
-        let inference_ms = t_run.elapsed().as_secs_f64() * 1000.0;
-
-        Self::extract_and_invoke(&outputs, output_names, inference_ms, cb)
+        let input_tensor = TensorRef::from_array_view(&input_contiguous)
+            .map_err(|e| InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}")))?;
+        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 
     /// Get the model's task type as detected from ONNX metadata.

--- a/src/model.rs
+++ b/src/model.rs
@@ -1194,7 +1194,10 @@ impl YOLOModel {
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
     fn run_timed<'s>(
         session: &'s mut Session,
-        inputs: Vec<(std::borrow::Cow<'_, str>, ort::session::SessionInputValue<'_>)>,
+        inputs: Vec<(
+            std::borrow::Cow<'_, str>,
+            ort::session::SessionInputValue<'_>,
+        )>,
     ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
         let t = Instant::now();
         let outputs = session
@@ -1218,8 +1221,9 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view())
-            .map_err(|e| InferenceError::InferenceError(format!("Failed to create input tensor: {e}")))?;
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+        })?;
         let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
@@ -1282,8 +1286,9 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view())
-            .map_err(|e| InferenceError::InferenceError(format!("Failed to create input tensor: {e}")))?;
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+        })?;
         let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
@@ -1324,8 +1329,9 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous)
-            .map_err(|e| InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}")))?;
+        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
+        })?;
         let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
@@ -1339,8 +1345,9 @@ impl YOLOModel {
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
         let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous)
-            .map_err(|e| InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}")))?;
+        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
+        })?;
         let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR refactors ONNX inference execution in `YOLOModel` by centralizing session runtime measurement into a new shared helper, reducing duplicated code and making inference handling more consistent.

### 📊 Key Changes
- Added a new internal helper function, `run_timed(...)`, in `src/model.rs`.
- Moved repeated ONNX session execution and inference-time measurement logic into this single helper. ⏱️
- Updated multiple inference paths to use the new shared function, including:
  - FP32 input inference
  - FP32 input with `u8` output handling
  - FP16 input with `u8` output handling
  - FP16 input inference
- Simplified several methods by replacing repeated `session.run(...)` + timing blocks with one reusable call. ♻️
- Standardized some error messaging, including simplifying one FP16 tensor creation error string.

### 🎯 Purpose & Impact
- Improves maintainability by removing duplicated inference code, making future changes easier and safer. ✅
- Helps keep inference timing behavior consistent across different input/output data paths. 📏
- Reduces the chance of bugs caused by copy-pasted session execution logic. 🧩
- Makes the code easier for developers to read and extend, especially when adding new inference modes. 🚀
- For end users, this is mainly an internal quality improvement, so behavior should stay the same while the implementation becomes cleaner and more reliable. 🙂