### PR TITLE
refactor: ♻️ simplify `warmup()` by extracting `run_warmup` helper

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -563,27 +563,9 @@ impl YOLOModel {
             )));
         }
 
-        let warmup_result: Result<()> = if self.fp16_input && self.has_semantic_mask_output() {
-            let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
-            Self::run_inference_f16_u8_with(
-                &mut self.session,
-                &self.input_name,
-                &self.output_names,
-                &dummy_input,
-                |_outputs, _ms| Ok(()),
-            )
-        } else if self.fp16_input {
+        let warmup_result: Result<()> = if self.fp16_input {
             let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
             Self::run_inference_f16_with(
-                &mut self.session,
-                &self.input_name,
-                &self.output_names,
-                &dummy_input,
-                |_outputs, _ms| Ok(()),
-            )
-        } else if self.has_semantic_mask_output() {
-            let dummy_input = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
-            Self::run_inference_u8_with(
                 &mut self.session,
                 &self.input_name,
                 &self.output_names,

--- a/src/model.rs
+++ b/src/model.rs
@@ -563,45 +563,12 @@ impl YOLOModel {
             )));
         }
 
-        let warmup_result: Result<()> = if self.fp16_input {
-            let dummy = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
-            if self.has_semantic_mask_output() {
-                Self::run_inference_f16_u8_with(
-                    &mut self.session,
-                    &self.input_name,
-                    &self.output_names,
-                    &dummy,
-                    |_outputs, _ms| Ok(()),
-                )
-            } else {
-                Self::run_inference_f16_with(
-                    &mut self.session,
-                    &self.input_name,
-                    &self.output_names,
-                    &dummy,
-                    |_outputs, _ms| Ok(()),
-                )
-            }
-        } else {
-            let dummy = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
-            if self.has_semantic_mask_output() {
-                Self::run_inference_u8_with(
-                    &mut self.session,
-                    &self.input_name,
-                    &self.output_names,
-                    &dummy,
-                    |_outputs, _ms| Ok(()),
-                )
-            } else {
-                Self::run_inference_with(
-                    &mut self.session,
-                    &self.input_name,
-                    &self.output_names,
-                    &dummy,
-                    |_outputs, _ms| Ok(()),
-                )
-            }
-        };
+        let warmup_result = Self::run_warmup(
+            &mut self.session,
+            &self.input_name,
+            self.fp16_input,
+            target_size,
+        );
 
         if let Err(e) = warmup_result {
             let msg = e.to_string();
@@ -1193,6 +1160,33 @@ impl YOLOModel {
 
     /// Run the ORT session, returning outputs and measured inference time in ms.
     ///
+    /// Run a single forward pass for warmup, discarding outputs.
+    ///
+    fn run_warmup(
+        session: &mut Session,
+        input_name: &str,
+        fp16_input: bool,
+        size: (usize, usize),
+    ) -> Result<()> {
+        let (h, w) = size;
+        if fp16_input {
+            let dummy = ndarray::Array4::<f16>::zeros((1, 3, h, w));
+            let cont = dummy.as_standard_layout();
+            let tensor = TensorRef::from_array_view(&cont).map_err(|e| {
+                InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
+            })?;
+            Self::run_timed(session, ort::inputs![input_name => tensor])?;
+        } else {
+            let dummy = ndarray::Array4::<f32>::zeros((1, 3, h, w));
+            let cont = dummy.as_standard_layout();
+            let tensor = TensorRef::from_array_view(cont.view()).map_err(|e| {
+                InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+            })?;
+            Self::run_timed(session, ort::inputs![input_name => tensor])?;
+        }
+        Ok(())
+    }
+
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
     fn run_timed<'s>(
         session: &'s mut Session,

--- a/src/model.rs
+++ b/src/model.rs
@@ -564,23 +564,43 @@ impl YOLOModel {
         }
 
         let warmup_result: Result<()> = if self.fp16_input {
-            let dummy_input = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
-            Self::run_inference_f16_with(
-                &mut self.session,
-                &self.input_name,
-                &self.output_names,
-                &dummy_input,
-                |_outputs, _ms| Ok(()),
-            )
+            let dummy = ndarray::Array4::<f16>::zeros((1, 3, target_size.0, target_size.1));
+            if self.has_semantic_mask_output() {
+                Self::run_inference_f16_u8_with(
+                    &mut self.session,
+                    &self.input_name,
+                    &self.output_names,
+                    &dummy,
+                    |_outputs, _ms| Ok(()),
+                )
+            } else {
+                Self::run_inference_f16_with(
+                    &mut self.session,
+                    &self.input_name,
+                    &self.output_names,
+                    &dummy,
+                    |_outputs, _ms| Ok(()),
+                )
+            }
         } else {
-            let dummy_input = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
-            Self::run_inference_with(
-                &mut self.session,
-                &self.input_name,
-                &self.output_names,
-                &dummy_input,
-                |_outputs, _ms| Ok(()),
-            )
+            let dummy = ndarray::Array4::<f32>::zeros((1, 3, target_size.0, target_size.1));
+            if self.has_semantic_mask_output() {
+                Self::run_inference_u8_with(
+                    &mut self.session,
+                    &self.input_name,
+                    &self.output_names,
+                    &dummy,
+                    |_outputs, _ms| Ok(()),
+                )
+            } else {
+                Self::run_inference_with(
+                    &mut self.session,
+                    &self.input_name,
+                    &self.output_names,
+                    &dummy,
+                    |_outputs, _ms| Ok(()),
+                )
+            }
         };
 
         if let Err(e) = warmup_result {


### PR DESCRIPTION
Extracted a private `run_warmup` associated fn that calls `run_timed` directly and drops outputs. The `warmup()` body now dispatches through a single call instead of 4 near-identical branches.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR simplifies model warmup in `ultralytics/inference` by replacing several specialized warmup inference paths with one shared `run_warmup()` helper.

### 📊 Key Changes
- ♻️ Replaced a long conditional warmup block in `src/model.rs` with a single call to `Self::run_warmup(...)`.
- 🧩 Added a new `run_warmup()` helper that performs one dummy forward pass and discards outputs.
- ⚡ Warmup now only depends on:
  - whether the model input uses `fp16`
  - the target input size
- 🧹 Removed separate warmup handling for semantic mask outputs, reducing duplicated logic.
- 🛠️ The new helper directly creates a dummy tensor, runs the ONNX Runtime session, and reuses `run_timed()` for execution and timing.

### 🎯 Purpose & Impact
- ✅ Makes the code easier to maintain by centralizing warmup behavior in one function.
- 🧠 Reduces complexity, making the warmup process easier for developers to understand and modify.
- 🐛 Lowers the risk of inconsistencies or bugs caused by maintaining multiple nearly identical warmup paths.
- 🚀 Keeps the same practical goal of warming up the model before real inference, which can help avoid first-run latency surprises.
- 📦 For users, this is mainly an internal cleanup, but it should improve reliability and make future inference updates easier to implement.