### PR TITLE
Bump taiki-e/install-action from v2.79.4 to v2.79.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.4 to v2.79.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the `taiki-e/install-action` GitHub Action version used to install `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from commit `e0eafa9...` to `6c1f7cf...`
- This corresponds to a version bump from `v2.79.4` to `v2.79.5`
- The updated action is still used for installing `cargo-llvm-cov` during CI runs

### 🎯 Purpose & Impact
- Keeps CI dependencies up to date 🛠️
- May include upstream fixes, minor improvements, or security updates from the action maintainer
- Helps maintain reliable code coverage tooling in automated workflows ✅
- Low-risk change with little to no expected impact on end users, but beneficial for repository maintenance and CI stability 🚀