### PR TITLE
fix: 🐞 caching mechanism by capturing FFmpeg version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,16 @@ jobs:
       - name: Install dependencies
         run: brew install ffmpeg
 
+      - name: Capture FFmpeg version for cache key
+        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg | awk '{print $2}')" >> $GITHUB_ENV
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}
 
       - name: Ensure toolchain
         run: rustup show


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves macOS CI reliability ⚙️ by making the Rust dependency cache aware of the installed FFmpeg version.

### 📊 Key Changes
- Added a new CI step to detect and store the installed FFmpeg version during the macOS workflow 🧩
- Updated the Rust cache configuration to include the FFmpeg version in its cache key 🔑
- Left the rest of the build setup unchanged, including FFmpeg installation and Rust toolchain setup 🛠️

### 🎯 Purpose & Impact
- Prevents stale or incompatible Rust build caches from being reused when FFmpeg changes ✅
- Makes CI runs more reliable and easier to debug on macOS 🍎
- Helps avoid unexpected build or linking issues tied to FFmpeg version differences 🎥
- May slightly reduce cache reuse across FFmpeg upgrades, but improves correctness and stability overall 📈