### PR TITLE
Bump taiki-e/install-action from v2.79.5 to v2.79.6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2.79.6
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.5 to v2.79.6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust coverage tool setup current.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Bumped the pinned action commit from `v2.79.5` to `v2.79.6`
- No application code or runtime behavior was changed—this only affects the CI pipeline 🛠️

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping workflow dependencies up to date ✅
- May include upstream fixes or small reliability improvements for installing `cargo-llvm-cov`
- Helps ensure Rust code coverage jobs continue to run smoothly and securely in GitHub Actions 🔒
- Has little to no direct impact on end users, but benefits developers through a more stable development pipeline 👨‍💻👩‍💻