### PR TITLE
Bump taiki-e/install-action from v2.79.7 to v2.79.8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2.79.7
+        uses: taiki-e/install-action@920ab1831fbf4fb3ef75c8ead83556c918bb7290 # v2.79.8
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.7 to v2.79.8 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, keeping CI tooling current with a small maintenance upgrade.

### 📊 Key Changes
- ⬆️ Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- 🔄 Updated the pinned commit from `v2.79.7` to `v2.79.8`
- 🧪 This affects the CI step responsible for installing `cargo-llvm-cov` for Rust coverage reporting

### 🎯 Purpose & Impact
- 🛠️ Keeps the CI pipeline up to date with the latest patch release of the install action
- 🔒 Maintains pinned-action security and reproducibility by continuing to reference a specific commit
- 📉 Low-risk change with no direct impact on product features or end users
- 🚀 Helps ensure continued reliability of automated testing and coverage workflows for developers