### PR TITLE
Bump taiki-e/install-action from v2.79.9 to v2.79.11 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@8f531eaecd1898bc3da7d104ad91bee98d1b97bd # v2.79.9
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.9 to v2.79.11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use a newer version of the `taiki-e/install-action` used for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the CI workflow file at `.github/workflows/ci.yml`.
- Bumped `taiki-e/install-action` from commit `8f531e...` to `13608c...`.
- This changes the pinned action version from `v2.79.9` to `v2.79.11`.
- The updated action is still used to install the Rust coverage tool `cargo-llvm-cov` during CI runs.

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest patch-level improvements.
- 🔒 Maintains secure, reproducible builds by continuing to pin the GitHub Action to a specific commit.
- 🛠️ May improve reliability or compatibility of Rust coverage setup in automated tests.
- 👥 Minimal user-facing impact, but helps developers by keeping the CI pipeline current and stable.