### PR TITLE
Bump taiki-e/install-action from v2.79.11 to v2.79.13 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.11 to v2.79.13 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, bringing the CI workflow to a newer patch version for improved maintenance and reliability.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version used in `.github/workflows/ci.yml`
- Bumped the pinned action commit from `v2.79.11` to `v2.79.13`
- The change affects the CI step responsible for installing `cargo-llvm-cov` for Rust code coverage

### 🎯 Purpose & Impact
- Improves CI maintainability by keeping a dependency up to date 🛠️
- May include upstream fixes or small reliability improvements in the install action ✅
- Keeps the workflow securely pinned to a specific commit while still receiving recent patch-level updates 🔒
- No product or user-facing behavior changes are expected; impact is limited to internal CI infrastructure 📦