### PR TITLE
Bump taiki-e/install-action from v2.79.13 to v2.79.15 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.13 to v2.79.15 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI to a newer pinned release for improved maintenance and reliability.

### 📊 Key Changes
- Updated the CI workflow in `.github/workflows/ci.yml`.
- Bumped the `taiki-e/install-action` GitHub Action used to install `cargo-llvm-cov`:
  - from `v2.79.13`
  - to `v2.79.15`
- Kept the action pinned to a specific commit, which helps ensure reproducible and secure CI runs 🔒

### 🎯 Purpose & Impact
- Improves CI maintainability by keeping dependencies current 🛠️
- May include upstream fixes or minor improvements in the install action, helping reduce CI issues over time ✅
- Has no direct user-facing product changes; impact is mainly on internal development and test infrastructure 📦
- Preserves build stability and security by continuing to use a commit-pinned GitHub Action 🔐