### PR TITLE
Bump taiki-e/install-action from v2.79.15 to v2.80.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
+        uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.15 to v2.80.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use a newer version of the `taiki-e/install-action` used for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Updated the pinned commit from an older release to **v2.80.0**
- This action is used during CI to install `cargo-llvm-cov`, a Rust code coverage tool

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping workflow dependencies up to date 🛠️
- May bring small reliability, compatibility, or security improvements from the newer action release
- Has no direct effect on product features or user-facing behavior 👀
- Helps ensure Rust coverage tooling continues to install smoothly in automated tests ✅