### PR TITLE
Bump taiki-e/install-action from v2.80.0 to v2.81.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.80.0 to v2.81.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub CI workflow to use a newer version of the action that installs `cargo-llvm-cov`, improving build tooling reliability.

### 📊 Key Changes
- Updated the GitHub Actions step for installing `cargo-llvm-cov` in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from version `v2.80.0` to `v2.81.1`
- Kept the same tool installation behavior, with only the underlying action version refreshed

### 🎯 Purpose & Impact
- ✅ Helps keep CI dependencies up to date and aligned with the latest fixes or improvements
- 🛠️ Reduces the chance of workflow issues caused by older action versions
- 🚀 Improves maintenance and long-term stability of the repository’s automated testing and coverage pipeline
- 👥 For most users, this has no direct product-facing change, but it supports a healthier and more reliable development process behind the scenes