### PR TITLE
Bump taiki-e/install-action from v2.81.1 to v2.81.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.1 to v2.81.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step used to install `cargo-llvm-cov` in CI, bringing the pinned `taiki-e/install-action` version from `v2.81.1` to `v2.81.3`.

### 📊 Key Changes
- ⬆️ Updated the GitHub Actions dependency `taiki-e/install-action` to a newer pinned commit.
- 🛠️ The change affects the CI workflow step responsible for installing `cargo-llvm-cov`.
- 🔒 Kept the action pinned to a specific commit hash, which helps maintain reproducible and secure CI runs.

### 🎯 Purpose & Impact
- 🚀 Improves CI maintenance by keeping workflow dependencies up to date.
- 🧩 May include upstream fixes or minor improvements in the install action used during coverage-related jobs.
- 🛡️ Preserves build reliability and security by continuing to use an explicitly pinned action version.
- 👥 For most users, there is no direct product-facing change, but developers may benefit from slightly more stable and current CI behavior.