### PR TITLE
test: 🧪 add tests for Device enum

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -92,4 +92,24 @@ mod tests {
         assert_eq!(Device::from_str("directml").unwrap(), Device::DirectMl(0));
         assert_eq!(Device::from_str("directml:1").unwrap(), Device::DirectMl(1));
     }
+
+    #[test]
+    fn test_device_display() {
+        assert_eq!(Device::Cpu.to_string(), "cpu");
+        assert_eq!(Device::Cuda(0).to_string(), "cuda:0");
+        assert_eq!(Device::Cuda(1).to_string(), "cuda:1");
+        assert_eq!(Device::CoreMl.to_string(), "coreml");
+        assert_eq!(Device::DirectMl(0).to_string(), "directml:0");
+        assert_eq!(Device::OpenVino.to_string(), "openvino");
+        assert_eq!(Device::Xnnpack.to_string(), "xnnpack");
+        assert_eq!(Device::TensorRt(2).to_string(), "tensorrt:2");
+        assert_eq!(Device::Rocm(3).to_string(), "rocm:3");
+    }
+
+    #[test]
+    fn test_device_display_roundtrip() {
+        for s in ["cpu", "cuda:0", "coreml", "directml:0", "openvino", "xnnpack"] {
+            assert_eq!(Device::from_str(s).unwrap().to_string(), s);
+        }
+    }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -108,7 +108,14 @@ mod tests {
 
     #[test]
     fn test_device_display_roundtrip() {
-        for s in ["cpu", "cuda:0", "coreml", "directml:0", "openvino", "xnnpack"] {
+        for s in [
+            "cpu",
+            "cuda:0",
+            "coreml",
+            "directml:0",
+            "openvino",
+            "xnnpack",
+        ] {
             assert_eq!(Device::from_str(s).unwrap().to_string(), s);
         }
     }


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧪 This PR strengthens device handling tests by verifying that supported inference devices are converted to clean string names correctly and can round-trip between parsing and display formats.

### 📊 Key Changes
- Added a new `test_device_display` test in `src/device.rs` to confirm `Device::to_string()` outputs the expected values for:
  - `cpu`
  - `cuda:0`, `cuda:1`
  - `coreml`
  - `directml:0`
  - `openvino`
  - `xnnpack`
  - `tensorrt:2`
  - `rocm:3`
- Added a `test_device_display_roundtrip` test to verify that several device strings can be:
  - parsed into a `Device`
  - converted back to a string
  - matched exactly to the original input
- Focused entirely on test coverage; no production logic was changed. ✅

### 🎯 Purpose & Impact
- Improves reliability of device string formatting and parsing across supported backends 🔒
- Helps catch regressions early when adding or modifying inference device support 🛠️
- Ensures more consistent behavior for users who configure devices via strings in APIs, CLI tools, or config files 💻
- Low-risk change since it adds validation only, without altering runtime functionality 📉