### PR TITLE
Bump astral-sh/setup-uv from v8.1.0 to v8.2.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.1.0 to v8.2.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub publishing workflow to use a newer version of `setup-uv`, improving CI dependency setup with a small but useful maintenance upgrade.

### 📊 Key Changes
- Updated the `astral-sh/setup-uv` GitHub Action in `.github/workflows/publish.yml`
- Bumped the action from `v8.1.0` to `v8.2.0`
- Kept the rest of the publish workflow unchanged, making this a focused CI maintenance update

### 🎯 Purpose & Impact
- Improves the reliability and freshness of the package publishing pipeline 🚀
- Brings the workflow in line with the latest upstream fixes or improvements from `setup-uv`
- Low risk change since it only updates a pinned CI action version and does not affect application code directly ✅
- Helps maintain a healthier release process for contributors and maintainers by keeping automation dependencies up to date 🔄