### PR TITLE
refactor: 🧹 dedup box normalization via normalize_box_rows

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -425,6 +425,20 @@ pub struct Boxes {
     is_track: bool,
 }
 
+/// Normalize box rows in-place by image size: columns 0 and 2 are divided by the
+/// width and columns 1 and 3 by the height. Shared by the xyxy and xywh paths,
+/// both of which store x-like values in columns 0/2 and y-like values in 1/3.
+#[allow(clippy::cast_precision_loss)]
+fn normalize_box_rows(boxes: &mut Array2<f32>, orig_shape: (u32, u32)) {
+    let (h, w) = (orig_shape.0 as f32, orig_shape.1 as f32);
+    for mut row in boxes.rows_mut() {
+        row[0] /= w;
+        row[1] /= h;
+        row[2] /= w;
+        row[3] /= h;
+    }
+}
+
 impl Boxes {
     /// Create a new Boxes instance.
     ///
@@ -544,16 +558,7 @@ impl Boxes {
     #[must_use]
     pub fn xyxyn(&self) -> Array2<f32> {
         let mut xyxyn = self.xyxy().to_owned();
-        #[allow(clippy::cast_precision_loss)]
-        let (h, w) = (self.orig_shape.0 as f32, self.orig_shape.1 as f32);
-
-        for mut row in xyxyn.rows_mut() {
-            row[0] /= w;
-            row[1] /= h;
-            row[2] /= w;
-            row[3] /= h;
-        }
-
+        normalize_box_rows(&mut xyxyn, self.orig_shape);
         xyxyn
     }
 
@@ -565,16 +570,7 @@ impl Boxes {
     #[must_use]
     pub fn xywhn(&self) -> Array2<f32> {
         let mut xywhn = self.xywh();
-        #[allow(clippy::cast_precision_loss)]
-        let (h, w) = (self.orig_shape.0 as f32, self.orig_shape.1 as f32);
-
-        for mut row in xywhn.rows_mut() {
-            row[0] /= w;
-            row[1] /= h;
-            row[2] /= w;
-            row[3] /= h;
-        }
-
+        normalize_box_rows(&mut xywhn, self.orig_shape);
         xywhn
     }
 


### PR DESCRIPTION
Extract results::normalize_box_rows, shared by Boxes::xyxyn and Boxes::xywhn, removing the copy-pasted per-row division loop. Keypoints::xyn left untouched pending a separate fix.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR refactors box-coordinate normalization in `src/results.rs` by moving duplicated logic into a shared helper, making the code cleaner and easier to maintain.

### 📊 Key Changes
- Added a new internal helper function, `normalize_box_rows`, to normalize bounding box coordinates in-place by image width and height.
- Replaced duplicated normalization code in both `Boxes::xyxyn()` and `Boxes::xywhn()` with calls to the new shared helper.
- Kept the normalization behavior the same for both box formats:
  - `xyxy`: corner-based boxes
  - `xywh`: center/size-based boxes
- Improved inline documentation to clarify that both formats use x-like values in columns `0/2` and y-like values in columns `1/3`. 📝

### 🎯 Purpose & Impact
- Reduces code duplication, which makes the implementation simpler and less error-prone. ✅
- Makes future updates to normalization logic easier, since changes now only need to be made in one place. 🔧
- Improves readability for contributors working in the `results.rs` box-processing code. 👀
- No expected user-facing behavior changes; this is mainly a maintainability and code quality improvement. 🚀