### PR TITLE
refactor: ♻️ extract shared box-transform helpers

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -29,7 +29,7 @@ use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
 use crate::results::{Boxes, Keypoints, Masks, Obb, Probs, Results, SemanticMask, Speed};
 use crate::task::Task;
-use crate::utils::{nms_per_class, nms_rotated_per_class};
+use crate::utils::{nms_per_class, nms_rotated_per_class, xywh_to_xyxy};
 
 /// Post-process raw model output based on task type.
 ///
@@ -350,6 +350,14 @@ fn parse_detect_shape(shape: &[usize], expected_classes: usize) -> (usize, usize
         }
         _ => (expected_classes.max(1), 0, false),
     }
+}
+
+/// Scale a corner-form box from letterboxed inference space back to the original
+/// image, then clip it to the image bounds.
+#[inline]
+fn scale_and_clip_box(xyxy: &[f32; 4], preprocess: &PreprocessResult) -> [f32; 4] {
+    let scaled = scale_coords(xyxy, preprocess.scale, preprocess.padding);
+    clip_coords(&scaled, preprocess.orig_shape)
 }
 
 #[derive(Clone, Copy)]
@@ -770,13 +778,7 @@ fn postprocess_segment(
         let cy = output_2d[[i, 1]];
         let w = output_2d[[i, 2]];
         let h = output_2d[[i, 3]];
-        let x1 = cx - w / 2.0;
-        let y1 = cy - h / 2.0;
-        let x2 = cx + w / 2.0;
-        let y2 = cy + h / 2.0;
-
-        let scaled = scale_coords(&[x1, y1, x2, y2], preprocess.scale, preprocess.padding);
-        let clipped = clip_coords(&scaled, preprocess.orig_shape);
+        let clipped = scale_and_clip_box(&xywh_to_xyxy(cx, cy, w, h), preprocess);
 
         // Filter by class if specified
         if !config.keep_class(best_class) {
@@ -1007,15 +1009,8 @@ fn postprocess_pose(
         let w = output_2d[[i, 2]];
         let h = output_2d[[i, 3]];
 
-        // Convert to xyxy
-        let x1 = cx - w / 2.0;
-        let y1 = cy - h / 2.0;
-        let x2 = cx + w / 2.0;
-        let y2 = cy + h / 2.0;
-
-        // Scale box to original image space
-        let scaled = scale_coords(&[x1, y1, x2, y2], preprocess.scale, preprocess.padding);
-        let clipped = clip_coords(&scaled, preprocess.orig_shape);
+        // Convert to xyxy, then scale to original image space and clip
+        let clipped = scale_and_clip_box(&xywh_to_xyxy(cx, cy, w, h), preprocess);
 
         // Extract keypoints (after class scores)
         let kpt_start = 4 + num_classes;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -271,6 +271,12 @@ pub fn array_to_image(arr: &Array3<u8>) -> Result<DynamicImage> {
     Ok(DynamicImage::ImageRgb8(img_buffer))
 }
 
+/// Convert a center-form box `(cx, cy, w, h)` to corner form `[x1, y1, x2, y2]`.
+#[inline]
+pub(crate) fn xywh_to_xyxy(cx: f32, cy: f32, w: f32, h: f32) -> [f32; 4] {
+    [cx - w / 2.0, cy - h / 2.0, cx + w / 2.0, cy + h / 2.0]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Extract xywh_to_xyxy and scale_and_clip_box; apply them to the segment and pose candidate loops, which held an identical center->corner->scale->clip block.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refactors bounding box postprocessing in `ultralytics/inference` to reduce duplicated code and make segmentation and pose outputs more consistent ✅📦

### 📊 Key Changes
- Added a new utility function, `xywh_to_xyxy`, in `src/utils.rs` to convert boxes from center format to corner format 🔄
- Added a helper function, `scale_and_clip_box`, in `src/postprocessing.rs` to:
  - scale boxes back from inference space to the original image size
  - clip boxes to valid image boundaries ✂️🖼️
- Updated **segmentation** postprocessing to use the new shared helpers instead of manually computing box coordinates
- Updated **pose** postprocessing to use the same shared box conversion, scaling, and clipping flow
- Improved inline comments and code readability, making the postprocessing pipeline easier to follow 🧹

### 🎯 Purpose & Impact
- Reduces duplicated logic, which lowers the chance of bugs and makes future maintenance easier 🛠️
- Makes box handling more consistent across different tasks like **segmentation** and **pose** 🤝
- Improves code clarity for contributors, especially when updating or debugging postprocessing behavior
- Helps ensure bounding boxes are correctly transformed and clipped before results are returned, which can improve reliability for end users 📍
- This is mainly a **code quality and consistency** update, so users likely won’t see major API changes, but they may benefit from more dependable inference outputs over time 🚀