### PR TITLE
Bump taiki-e/install-action from v2.81.3 to v2.81.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2.81.5
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.3 to v2.81.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step used to install `cargo-llvm-cov` in CI, keeping the Rust coverage tool setup current and more reliable.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Changed the pinned GitHub Action commit from `v2.81.3` to `v2.81.5`
- This affects the CI step that installs `cargo-llvm-cov` for Rust code coverage reporting

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest patch-level improvements
- 🔒 Maintains secure, reproducible builds by continuing to pin the action to a specific commit
- 🛠️ May improve reliability or compatibility of Rust coverage tooling in automated tests
- 👥 Low-risk change for users, with impact mainly on maintainers and CI stability rather than runtime behavior