### PR TITLE
Reduce CI log noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,4 +210,6 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./lcov.info
+          disable_search: true
+          plugins: noop
           flags: template_coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
## Summary

- disable Codecov workspace search when uploading the generated lcov.info
- disable setup-uv caching in the publish check job that installs with uv --no-cache\n\n## Validation
- actionlint .github/workflows/ci.yml .github/workflows/publish.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes small but important CI/CD workflow updates to improve build reliability and make coverage and publishing behavior more predictable.

### 📊 Key Changes
- ✅ Updated the Codecov step in `.github/workflows/ci.yml` to:
  - disable automatic file searching with `disable_search: true`
  - disable extra Codecov plugins with `plugins: noop`
- 🚀 Updated `.github/workflows/publish.yml` to turn off caching for `setup-uv` using `enable-cache: false`
- 🛠️ These changes affect GitHub Actions only, with no direct changes to inference code or user-facing features

### 🎯 Purpose & Impact
- 📉 Reduces the chance of CI coverage uploads picking up unintended files or behaving inconsistently
- 🔒 Makes Codecov reporting more explicit and controlled, which can improve debugging and reliability
- 📦 Disabling `uv` cache in the publish workflow helps avoid stale dependency/cache issues during package publishing
- 🤝 Improves maintainability of the release pipeline by favoring predictable automation over implicit behavior
- 👥 End users likely won’t see feature changes directly, but maintainers should benefit from more stable CI and publishing workflows