### PR TITLE
Bump taiki-e/install-action from v2.81.5 to v2.81.6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2.81.5
+        uses: taiki-e/install-action@59012be0884e296ca2da49b530610e72c49039ad # v2.81.6
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.5 to v2.81.6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the workflow current with a newer patch release.

### 📊 Key Changes
- Updated the CI workflow in `.github/workflows/ci.yml`
- Bumped the `taiki-e/install-action` GitHub Action from `v2.81.5` to `v2.81.6`
- This action is used during CI to install the Rust coverage tool `cargo-llvm-cov`

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest patch-level improvements
- 🛡️ May include small bug fixes, security updates, or reliability improvements from the upstream action
- 🚀 Helps maintain stable and predictable Rust coverage setup in automated tests
- 👥 Minimal user-facing impact, but beneficial for developers by improving CI maintenance and consistency