### PR TITLE
Bump taiki-e/install-action from v2.81.6 to v2.81.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@59012be0884e296ca2da49b530610e72c49039ad # v2.81.6
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.6 to v2.81.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use a newer patch version of the `taiki-e/install-action` used for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Updated the pinned commit hash from `v2.81.6` to `v2.81.7`
- The change affects the CI step that installs `cargo-llvm-cov` for Rust code coverage reporting 🦀

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping a GitHub Action dependency up to date 🔄
- May include small fixes or reliability improvements from the upstream action
- Helps maintain secure, reproducible workflows by continuing to pin the action to a specific commit 🔒
- No direct product or API changes for end users; impact is limited to internal development and CI stability ✅