### PR TITLE
Bump codecov/codecov-action from v6.0.1 to v7.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
         run: cargo llvm-cov --features annotate,video,visualize --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./lcov.info
           disable_search: true


### PR DESCRIPTION
Bump codecov/codecov-action from v6.0.1 to v7.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions Codecov step from `codecov-action` v6.0.1 to v7.0.0 in the CI workflow.

### 📊 Key Changes
- ⬆️ Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml`
  - From `codecov/codecov-action` **v6.0.1**
  - To `codecov/codecov-action` **v7.0.0**
- 🧪 The change only affects the **coverage upload step** in CI after Rust coverage is generated.
- 🛠️ Existing coverage upload settings, such as using `./lcov.info` and disabling search, remain unchanged.

### 🎯 Purpose & Impact
- ✅ Keeps the CI pipeline up to date with the latest Codecov GitHub Action release.
- 🔐 May improve security, compatibility, and long-term maintenance by using a newer pinned action version.
- 📈 Helps ensure continued reliability of test coverage reporting without changing application behavior.
- 👥 For most users, this has **no direct product impact**, but it supports a healthier and more maintainable development workflow behind the scenes.