### PR TITLE
Fix Codecov badge upload auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -211,5 +212,7 @@ jobs:
         with:
           files: ./lcov.info
           disable_search: true
+          fail_ci_if_error: true
           plugins: noop
           flags: template_coverage
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
-[![codecov](https://codecov.io/gh/ultralytics/inference/graph/badge.svg?token=AVE5n6yvnf)](https://codecov.io/gh/ultralytics/inference)
+[![codecov](https://codecov.io/github/ultralytics/inference/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/inference)
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
-[![codecov](https://codecov.io/gh/ultralytics/inference/graph/badge.svg?token=AVE5n6yvnf)](https://codecov.io/gh/ultralytics/inference)
+[![codecov](https://codecov.io/github/ultralytics/inference/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/inference)
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)


### PR DESCRIPTION
## Summary
- switch README Codecov badges to the public documented `github`/`branch/main` badge URL
- authenticate Codecov uploads with GitHub OIDC
- fail CI when the Codecov upload command errors instead of silently continuing

## Evidence
- Current README badge endpoint returns `unknown`
- Codecov repo API reports coverage totals, but current `main` head commit `8cacfc153c946bbfe273921d9ee7ea9e7aee03ca` has `totals: null` and its upload remains in `state: started`

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR improves Codecov integration in CI and updates README badges so coverage reporting is more secure, reliable, and up to date.

### 📊 Key Changes
- Added `id-token: write` permission to the GitHub Actions CI workflow to support secure Codecov authentication with OIDC 🔑
- Enabled `use_oidc: true` in the Codecov upload step, replacing token-based authentication with a more secure approach 🛡️
- Added `fail_ci_if_error: true` so CI now fails if coverage upload encounters an error, making reporting issues visible immediately 🚨
- Updated the Codecov badge URL in both `README.md` and `README.zh-CN.md` to the current badge and dashboard links 🔄
- Removed the old token-based badge URL format from the documentation 🧹

### 🎯 Purpose & Impact
- Improves CI security by using GitHub’s OIDC authentication instead of relying on a stored Codecov token 🔐
- Makes coverage reporting more dependable, since failed uploads will no longer silently pass ✅
- Keeps project documentation accurate by pointing users to the latest Codecov badge and coverage page 📈
- Has little to no effect on the Rust inference library’s runtime behavior, but strengthens project maintenance and visibility for contributors 👨‍💻👩‍💻