### PR TITLE
Scope Codecov OIDC permission to coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ name: CI
 
 permissions:
   contents: read
-  id-token: write
 
 on:
   push:
@@ -182,6 +181,9 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary
- keep workflow-wide permissions at contents: read
- move id-token: write to only the coverage job that uploads to Codecov

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML parse OK"'
- actionlint .github/workflows/ci.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR tightens GitHub Actions permissions by limiting `id-token: write` access to only the coverage job that needs it.

### 📊 Key Changes
- Removed `id-token: write` from the global workflow permissions in `.github/workflows/ci.yml`.
- Added job-specific permissions for the `coverage` job:
  - `contents: read`
  - `id-token: write`
- Left other CI jobs without unnecessary OpenID Connect token access.

### 🎯 Purpose & Impact
- 🔒 Improves security by following the principle of least privilege, so only the coverage job gets elevated token permissions.
- 🛡️ Reduces the risk of accidental misuse or exposure of sensitive GitHub Actions capabilities in unrelated jobs.
- ⚙️ Keeps CI behavior functionally the same for coverage reporting, while making the workflow configuration safer and more maintainable.
- 📉 Low-risk change overall, with impact mainly focused on better security hygiene rather than feature changes.