### PR TITLE
Bump taiki-e/install-action from v2.81.8 to v2.81.9 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.8 to v2.81.9 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI, moving it from `taiki-e/install-action` v2.81.8 to v2.81.9.

### 📊 Key Changes
- Bumped the pinned GitHub Action used in `.github/workflows/ci.yml` for installing `cargo-llvm-cov`.
- Updated the action commit hash from the version corresponding to `v2.81.8` to `v2.81.9`.
- No application code, model behavior, or inference logic was changed.

### 🎯 Purpose & Impact
- Improves 🔒 CI maintenance by keeping dependencies slightly more up to date.
- May include small fixes or reliability improvements in the install action used during test and coverage workflows.
- Has minimal user-facing impact 👀, but helps keep the project’s automation healthy and reproducible.
- Low-risk change ✅ since it only affects the CI setup, not runtime functionality.