### PR TITLE
refactor: dedup tensor reshape, coord scaling, image-to-tensor, render scale

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -29,6 +29,22 @@ pub const fn get_class_color(class_id: usize) -> Rgb<u8> {
     Rgb(color)
 }
 
+/// Dynamic render scale derived from image size (reference 640x640).
+///
+/// Returns the scale factor and the base line thickness. Callers derive the
+/// font size or marker radius from the factor as needed.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn render_scale(width: u32, height: u32) -> (f32, i32) {
+    let max_dim = width.max(height) as f32;
+    let scale_factor = (max_dim / 640.0).max(1.0);
+    let thickness = (1.0 * scale_factor).round().max(1.0) as i32;
+    (scale_factor, thickness)
+}
+
 /// Return the next unused run directory under `base` with the given `prefix`.
 ///
 /// Tries `<base>/<prefix>` first, then `<base>/<prefix>2`, `<base>/<prefix>3`, and so on
@@ -438,12 +454,8 @@ fn draw_label(
 fn draw_detection(img: &mut image::RgbImage, result: &Results, font: Option<&FontRef>) {
     let (width, height) = img.dimensions();
 
-    // Calculate dynamic scale factor based on image size (reference 640x640)
-    let max_dim = width.max(height) as f32;
-    let scale_factor = (max_dim / 640.0).max(1.0);
-
-    // Scale thickness and font size
-    let thickness = (1.0 * scale_factor).round().max(1.0) as i32;
+    // Dynamic scale factor and thickness based on image size (reference 640x640)
+    let (scale_factor, thickness) = render_scale(width, height);
     let font_scale = (11.0 * scale_factor).max(10.0); // Min font size 10
 
     if let Some(ref boxes) = result.boxes {
@@ -654,12 +666,8 @@ fn draw_pose(
 ) {
     let (width, height) = img.dimensions();
 
-    // Calculate dynamic scale factor based on image size (reference 640x640)
-    let max_dim = width.max(height) as f32;
-    let scale_factor = (max_dim / 640.0).max(1.0);
-
-    // Scale thickness and radius
-    let thickness = (1.0 * scale_factor).round().max(1.0) as i32;
+    // Dynamic scale factor and thickness based on image size (reference 640x640)
+    let (scale_factor, thickness) = render_scale(width, height);
     let radius = (3.0 * scale_factor).round() as i32;
 
     if let Some(ref keypoints) = result.keypoints {
@@ -727,12 +735,8 @@ fn draw_pose(
 fn draw_obb(img: &mut image::RgbImage, result: &Results, font: Option<&FontRef>) {
     let (width, height) = img.dimensions();
 
-    // Calculate dynamic scale factor based on image size (reference 640x640)
-    let max_dim = width.max(height) as f32;
-    let scale_factor = (max_dim / 640.0).max(1.0);
-
-    // Scale thickness and font size
-    let thickness = (1.0 * scale_factor).round().max(1.0) as i32;
+    // Dynamic scale factor and thickness based on image size (reference 640x640)
+    let (scale_factor, thickness) = render_scale(width, height);
     let font_scale = (11.0 * scale_factor).max(10.0); // Min font size 10
 
     if let Some(ref obb) = result.obb {

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -360,6 +360,27 @@ fn scale_and_clip_box(xyxy: &[f32; 4], preprocess: &PreprocessResult) -> [f32; 4
     clip_coords(&scaled, preprocess.orig_shape)
 }
 
+/// Reshape a flat model output into a `[preds, features]` 2D array.
+///
+/// When `is_transposed` the data is already laid out `[preds, features]`;
+/// otherwise it is `[features, preds]` and gets transposed. Returns an empty
+/// array on shape mismatch, matching the per-task fallbacks.
+fn output_to_2d(
+    data: &[f32],
+    num_preds: usize,
+    features: usize,
+    is_transposed: bool,
+) -> Array2<f32> {
+    if is_transposed {
+        Array2::from_shape_vec((num_preds, features), data.to_vec())
+            .unwrap_or_else(|_| Array2::zeros((0, 0)))
+    } else {
+        let arr = Array2::from_shape_vec((features, num_preds), data.to_vec())
+            .unwrap_or_else(|_| Array2::zeros((0, 0)));
+        arr.t().to_owned()
+    }
+}
+
 #[derive(Clone, Copy)]
 struct Candidate {
     bbox: [f32; 4],
@@ -749,14 +770,7 @@ fn postprocess_segment(
     }
 
     // Convert to 2D [preds, features]
-    let output_2d = if is_transposed {
-        Array2::from_shape_vec((num_preds, expected_features), output0.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)))
-    } else {
-        let arr = Array2::from_shape_vec((expected_features, num_preds), output0.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)));
-        arr.t().to_owned()
-    };
+    let output_2d = output_to_2d(output0, num_preds, expected_features, is_transposed);
 
     // Filter and NMS
     let mut candidates = Vec::new(); // (bbox, score, class, original_index)
@@ -968,14 +982,7 @@ fn postprocess_pose(
     }
 
     // Convert to 2D [preds, features]
-    let output_2d = if is_transposed {
-        Array2::from_shape_vec((num_preds, actual_features), output.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)))
-    } else {
-        let arr = Array2::from_shape_vec((actual_features, num_preds), output.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)));
-        arr.t().to_owned()
-    };
+    let output_2d = output_to_2d(output, num_preds, actual_features, is_transposed);
 
     if output_2d.is_empty() {
         return results;
@@ -1218,14 +1225,7 @@ fn postprocess_obb(
     }
 
     // Convert to 2D [preds, features]
-    let output_2d = if is_transposed {
-        Array2::from_shape_vec((num_preds, actual_features), output.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)))
-    } else {
-        let arr = Array2::from_shape_vec((actual_features, num_preds), output.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)));
-        arr.t().to_owned()
-    };
+    let output_2d = output_to_2d(output, num_preds, actual_features, is_transposed);
 
     if output_2d.is_empty() {
         return results;
@@ -1328,25 +1328,6 @@ fn postprocess_obb(
 // Coordinates are in the letterboxed model-input space, so we still scale/pad-correct
 // them back to original-image space. No NMS, no class-score matrix.
 
-/// Helper: scale a model-space xyxy box to original image coordinates.
-#[inline]
-fn scale_xyxy(
-    x1: f32,
-    y1: f32,
-    x2: f32,
-    y2: f32,
-    preprocess: &PreprocessResult,
-) -> (f32, f32, f32, f32) {
-    let (scale_y, scale_x) = preprocess.scale;
-    let (pad_top, pad_left) = preprocess.padding;
-    (
-        (x1 - pad_left) / scale_x,
-        (y1 - pad_top) / scale_y,
-        (x2 - pad_left) / scale_x,
-        (y2 - pad_top) / scale_y,
-    )
-}
-
 /// Post-process YOLO26 end-to-end detection output `[1, max_det, 6]`.
 #[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
 fn postprocess_detect_end2end(
@@ -1387,12 +1368,15 @@ fn postprocess_detect_end2end(
         if !config.keep_class(cls) {
             continue;
         }
-        let (x1, y1, x2, y2) = scale_xyxy(
-            output[base],
-            output[base + 1],
-            output[base + 2],
-            output[base + 3],
-            preprocess,
+        let [x1, y1, x2, y2] = scale_coords(
+            &[
+                output[base],
+                output[base + 1],
+                output[base + 2],
+                output[base + 3],
+            ],
+            preprocess.scale,
+            preprocess.padding,
         );
         flat.extend_from_slice(&[
             x1.clamp(0.0, max_w),
@@ -1475,12 +1459,15 @@ fn postprocess_segment_end2end(
         if !config.keep_class(cls) {
             continue;
         }
-        let (x1, y1, x2, y2) = scale_xyxy(
-            output0[base],
-            output0[base + 1],
-            output0[base + 2],
-            output0[base + 3],
-            preprocess,
+        let [x1, y1, x2, y2] = scale_coords(
+            &[
+                output0[base],
+                output0[base + 1],
+                output0[base + 2],
+                output0[base + 3],
+            ],
+            preprocess.scale,
+            preprocess.padding,
         );
         flat_boxes.extend_from_slice(&[
             x1.clamp(0.0, max_w),
@@ -1591,12 +1578,15 @@ fn postprocess_pose_end2end(
         if !config.keep_class(cls) {
             continue;
         }
-        let (x1, y1, x2, y2) = scale_xyxy(
-            output[base],
-            output[base + 1],
-            output[base + 2],
-            output[base + 3],
-            preprocess,
+        let [x1, y1, x2, y2] = scale_coords(
+            &[
+                output[base],
+                output[base + 1],
+                output[base + 2],
+                output[base + 3],
+            ],
+            preprocess.scale,
+            preprocess.padding,
         );
         flat_boxes.extend_from_slice(&[
             x1.clamp(0.0, max_w),

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -493,20 +493,35 @@ fn calculate_letterbox_params(
 ///
 /// Array4 with shape (1, 3, H, W) and values in [0, 1].
 fn image_to_tensor(image: &RgbImage) -> Array4<f32> {
+    image_to_tensor_generic(image, 0.0, |v| f32::from(v) / 255.0)
+}
+
+/// Convert an RGB image to a normalized NCHW tensor, planar (CHW) layout.
+///
+/// Shared structure for the f32 and f16 variants: allocates the `(1, 3, H, W)`
+/// tensor, splits it into per-channel slices, and fills each pixel with
+/// `convert` applied to the source byte. The caller supplies the element type's
+/// zero value and the per-byte conversion so each variant keeps its exact
+/// arithmetic (the f16 path hoists its scale constant into the closure).
+fn image_to_tensor_generic<T: Clone>(
+    image: &RgbImage,
+    zero: T,
+    mut convert: impl FnMut(u8) -> T,
+) -> Array4<T> {
     let (width, height) = image.dimensions();
     let (w, h) = (width as usize, height as usize);
     let pixels = image.as_raw();
 
-    let mut tensor = Array4::zeros((1, 3, h, w));
+    let mut tensor = Array4::from_elem((1, 3, h, w), zero);
 
     // Get mutable slices for each channel for faster access
     let (r_slice, rest) = tensor.as_slice_mut().unwrap().split_at_mut(h * w);
     let (g_slice, b_slice) = rest.split_at_mut(h * w);
 
     for (i, chunk) in pixels.chunks_exact(3).enumerate() {
-        r_slice[i] = f32::from(chunk[0]) / 255.0;
-        g_slice[i] = f32::from(chunk[1]) / 255.0;
-        b_slice[i] = f32::from(chunk[2]) / 255.0;
+        r_slice[i] = convert(chunk[0]);
+        g_slice[i] = convert(chunk[1]);
+        b_slice[i] = convert(chunk[2]);
     }
 
     tensor
@@ -524,25 +539,11 @@ fn image_to_tensor(image: &RgbImage) -> Array4<f32> {
 ///
 /// Array4 with shape (1, 3, H, W) and f16 values in [0, 1].
 fn image_to_tensor_f16(image: &RgbImage) -> Array4<f16> {
-    let (width, height) = image.dimensions();
-    let (w, h) = (width as usize, height as usize);
-    let pixels = image.as_raw();
-
-    let mut tensor = Array4::from_elem((1, 3, h, w), f16::ZERO);
-
-    let (r_slice, rest) = tensor.as_slice_mut().unwrap().split_at_mut(h * w);
-    let (g_slice, b_slice) = rest.split_at_mut(h * w);
-
     // Precompute 1/255 as f16 for direct conversion
     let scale = f16::from_f32(1.0 / 255.0);
-
-    for (i, chunk) in pixels.chunks_exact(3).enumerate() {
-        r_slice[i] = f16::from_f32(f32::from(chunk[0])) * scale;
-        g_slice[i] = f16::from_f32(f32::from(chunk[1])) * scale;
-        b_slice[i] = f16::from_f32(f32::from(chunk[2])) * scale;
-    }
-
-    tensor
+    image_to_tensor_generic(image, f16::ZERO, move |v| {
+        f16::from_f32(f32::from(v)) * scale
+    })
 }
 
 /// Convert a `DynamicImage` to an HWC ndarray.


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR mainly refactors shared image rendering, preprocessing, and postprocessing logic to reduce duplicate code and improve consistency across detection, pose, segmentation, and OBB workflows.

### 📊 Key Changes
- ♻️ Added a shared `render_scale()` helper in `annotate.rs` to compute dynamic annotation scaling based on image size.
- 🖍️ Updated detection, pose, and OBB drawing code to reuse the same scaling logic for line thickness, font size, and keypoint radius.
- 📦 Added a shared `output_to_2d()` helper in `postprocessing.rs` to standardize reshaping model outputs into 2D arrays.
- 🔁 Replaced repeated output reshaping code in segmentation, pose, and OBB postprocessing with the new shared helper.
- ✂️ Removed the separate `scale_xyxy()` helper and switched end-to-end detection, segmentation, and pose paths to use the existing `scale_coords()` utility instead.
- 🧪 Refactored image-to-tensor conversion in `preprocessing.rs` by introducing a generic `image_to_tensor_generic()` helper.
- ⚡ Simplified both `f32` and `f16` tensor conversion paths to reuse the same core logic while preserving their specific numeric handling.

### 🎯 Purpose & Impact
- ✅ Improves maintainability by centralizing repeated logic, making the codebase easier to read and update.
- 🤝 Increases consistency across multiple inference tasks, reducing the chance of behavior drifting between features.
- 🐛 Lowers the risk of bugs by removing duplicated implementations for scaling, reshaping, and tensor conversion.
- 🚀 Makes future optimization and feature work easier, since common logic now lives in shared helpers.
- 👀 End users should see little to no change in functionality, but developers benefit from cleaner, more reliable internals.