### PR TITLE
perf: share preprocessing X-LUT via Arc to avoid per-call clone

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use wide::f32x8;
 
-use fast_image_resize::images::Image;
+use fast_image_resize::images::{Image, ImageRef};
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
 use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Zip, s};
 use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSliceMut};
@@ -635,9 +635,8 @@ fn apply_mask_proto(
         .map(|&v| 1.0 / (1.0 + (-v).exp()))
         .collect();
     let src_bytes: &[u8] = bytemuck::cast_slice(&f32_data);
-    let Ok(src_image) =
-        Image::from_vec_u8(mw as u32, mh as u32, src_bytes.to_vec(), PixelType::F32)
-    else {
+    // Borrow the sigmoid buffer directly instead of copying it into an owned image.
+    let Ok(src_image) = ImageRef::new(mw as u32, mh as u32, src_bytes, PixelType::F32) else {
         return;
     };
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -656,7 +656,6 @@ fn apply_mask_proto(
         .map(|&v| 1.0 / (1.0 + (-v).exp()))
         .collect();
     let src_bytes: &[u8] = bytemuck::cast_slice(&f32_data);
-    // Borrow the sigmoid buffer directly instead of copying it into an owned image.
     let Ok(src_image) = ImageRef::new(mw as u32, mh as u32, src_bytes, PixelType::F32) else {
         return;
     };

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -200,7 +200,6 @@ fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Arc<Vec<XLutEntry>> {
         let mut cache = cache.borrow_mut();
 
         if let Some(lut) = cache.get(&key) {
-            // Cache hit: bump the refcount instead of cloning the whole table.
             return Arc::clone(lut);
         }
 

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -22,6 +22,7 @@
 
 use std::cell::RefCell;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use half::f16;
 use image::{DynamicImage, GenericImageView, RgbImage};
@@ -58,7 +59,7 @@ type XLutEntry = (usize, usize, i32, i32);
 type XLutKey = (u32, u32);
 
 thread_local! {
-    static X_LUT_CACHE: RefCell<LruCache<XLutKey, Vec<XLutEntry>>> =
+    static X_LUT_CACHE: RefCell<LruCache<XLutKey, Arc<Vec<XLutEntry>>>> =
         RefCell::new(LruCache::new(NonZeroUsize::new(LUT_CACHE_SIZE).unwrap()));
 }
 
@@ -192,35 +193,38 @@ pub fn preprocess_image_with_precision(
 ///
 /// Weight computation matches `OpenCV`'s `resize.cpp`:
 /// `cbuf[0] = saturate_cast<short>((1-fx) * 2048); cbuf[1] = 2048 - cbuf[0];`
-fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Vec<XLutEntry> {
+fn get_or_compute_x_lut(src_w: u32, dst_w: u32) -> Arc<Vec<XLutEntry>> {
     let key = (src_w, dst_w);
 
     X_LUT_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
 
         if let Some(lut) = cache.get(&key) {
-            return lut.clone();
+            // Cache hit: bump the refcount instead of cloning the whole table.
+            return Arc::clone(lut);
         }
 
         let scale_x = src_w as f32 / dst_w as f32;
         let src_w_max = (src_w - 1) as i32;
 
-        let lut: Vec<XLutEntry> = (0..dst_w)
-            .map(|dx| {
-                let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
-                let x0 = sx.floor() as i32;
-                // Match OpenCV: cbuf[0] = saturate_cast<short>((1-fx)*SCALE),
-                //               cbuf[1] = SCALE - cbuf[0]
-                let fx_f = sx - x0 as f32;
-                let fx_inv = ((1.0 - fx_f) * SCALE_INT as f32 + 0.5) as i32;
-                let fx = SCALE_INT - fx_inv;
-                let x0c = x0.clamp(0, src_w_max) as usize * 3;
-                let x1c = (x0 + 1).clamp(0, src_w_max) as usize * 3;
-                (x0c, x1c, fx_inv, fx)
-            })
-            .collect();
+        let lut: Arc<Vec<XLutEntry>> = Arc::new(
+            (0..dst_w)
+                .map(|dx| {
+                    let sx = ((dx as f32 + 0.5) * scale_x - 0.5).max(0.0);
+                    let x0 = sx.floor() as i32;
+                    // Match OpenCV: cbuf[0] = saturate_cast<short>((1-fx)*SCALE),
+                    //               cbuf[1] = SCALE - cbuf[0]
+                    let fx_f = sx - x0 as f32;
+                    let fx_inv = ((1.0 - fx_f) * SCALE_INT as f32 + 0.5) as i32;
+                    let fx = SCALE_INT - fx_inv;
+                    let x0c = x0.clamp(0, src_w_max) as usize * 3;
+                    let x1c = (x0 + 1).clamp(0, src_w_max) as usize * 3;
+                    (x0c, x1c, fx_inv, fx)
+                })
+                .collect(),
+        );
 
-        cache.put(key, lut.clone());
+        cache.put(key, Arc::clone(&lut));
         lut
     })
 }


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves image preprocessing and mask postprocessing efficiency in `ultralytics/inference` by reducing unnecessary memory copies and making cached resize lookup tables cheaper to reuse 🚀

### 📊 Key Changes
- Replaced `Image::from_vec_u8(... src_bytes.to_vec() ...)` with `ImageRef::new(...)` in mask postprocessing, avoiding an extra buffer allocation and copy 🧠
- Updated the preprocessing X-axis resize lookup table cache to store `Arc<Vec<XLutEntry>>` instead of plain `Vec<XLutEntry>` 📦
- Changed the lookup-table retrieval logic to use `Arc::clone(...)`, allowing shared reuse of cached data without duplicating the full vector 🔄
- Added the required `Arc` import and adjusted function signatures to return shared cached LUTs instead of owned vectors 🛠️

### 🎯 Purpose & Impact
- Reduces memory overhead during postprocessing, especially when resizing segmentation masks 🎭
- Improves performance by avoiding repeated copying of large lookup tables in preprocessing ⚡
- Makes cached resize data more efficient to share, which can help in high-throughput or multi-image inference workloads 📈
- Keeps behavior the same for users while making inference internals leaner and more scalable ✅