### PR TITLE
fix: draw pose keypoints at conf>=0.25 to match Ultralytics 

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -20,9 +20,6 @@ use std::path::{Path, PathBuf};
 const ASSETS_URL: &str = "https://github.com/ultralytics/assets/releases/download/v0.0.0";
 
 /// Minimum keypoint confidence for drawing a keypoint or skeleton limb.
-///
-/// Matches Ultralytics' `Annotator.kpts` default (`conf_thres = 0.25`); a higher
-/// value drops valid-but-uncertain keypoints (e.g. occluded upper bodies).
 const KPT_CONF_THRES: f32 = 0.25;
 
 /// Return the RGB color assigned to a class ID.

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -19,6 +19,12 @@ use std::path::{Path, PathBuf};
 /// Assets URL for downloading fonts
 const ASSETS_URL: &str = "https://github.com/ultralytics/assets/releases/download/v0.0.0";
 
+/// Minimum keypoint confidence for drawing a keypoint or skeleton limb.
+///
+/// Matches Ultralytics' `Annotator.kpts` default (`conf_thres = 0.25`); a higher
+/// value drops valid-but-uncertain keypoints (e.g. occluded upper bodies).
+const KPT_CONF_THRES: f32 = 0.25;
+
 /// Return the RGB color assigned to a class ID.
 ///
 /// Cycles through the 20-entry Ultralytics palette so every class gets a
@@ -685,7 +691,7 @@ fn draw_pose(
                 let y2 = kpt_data[[person_idx, kpt_b, 1]];
                 let conf2 = kpt_data[[person_idx, kpt_b, 2]];
 
-                if conf1 > 0.5 && conf2 > 0.5 {
+                if conf1 >= KPT_CONF_THRES && conf2 >= KPT_CONF_THRES {
                     let color_idx = limb_colors[limb_idx % limb_colors.len()];
                     let color = Rgb(POSE_COLORS[color_idx]);
                     draw_line_segment(img, x1, y1, x2, y2, color, thickness);
@@ -697,7 +703,12 @@ fn draw_pose(
                 let y = kpt_data[[person_idx, kpt_idx, 1]];
                 let conf = kpt_data[[person_idx, kpt_idx, 2]];
 
-                if conf > 0.5 && x >= 0.0 && y >= 0.0 && x < width as f32 && y < height as f32 {
+                if conf >= KPT_CONF_THRES
+                    && x >= 0.0
+                    && y >= 0.0
+                    && x < width as f32
+                    && y < height as f32
+                {
                     let color_idx = kpt_colors[kpt_idx % kpt_colors.len()];
                     let color = Rgb(POSE_COLORS[color_idx]);
                     draw_filled_circle(img, x as i32, y as i32, radius, color);


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🦴 This PR improves pose annotation rendering by lowering and centralizing the keypoint confidence threshold, so more valid keypoints and skeleton connections are drawn consistently.

### 📊 Key Changes
- Added a new shared constant, `KPT_CONF_THRES`, set to `0.25` in `src/annotate.rs`.
- Replaced the hardcoded pose drawing threshold of `0.5` with `KPT_CONF_THRES`.
- Applied the new threshold to both:
  - skeleton limb drawing between keypoints
  - individual keypoint circle drawing
- Kept existing image-boundary checks for keypoint rendering to avoid drawing outside the image.

### 🎯 Purpose & Impact
- 🎯 Makes pose visualizations more complete by showing lower-confidence, but still useful, keypoints and limb connections.
- 🔄 Improves consistency and maintainability by using one shared threshold instead of repeating hardcoded values.
- 👀 Helps users better inspect pose model outputs, especially in harder scenes where keypoint confidence may be moderate rather than high.
- ⚠️ May result in slightly more visual clutter or noisier annotations, since more low-confidence pose elements will now be displayed.