### PR TITLE
Bump taiki-e/install-action from v2.81.9 to v2.81.10 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.9 to v2.81.10 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI, bumping the pinned `taiki-e/install-action` version from `v2.81.9` to `v2.81.10`.

### 📊 Key Changes
- Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` to a newer pinned commit
- This update specifically affects the CI step that installs `cargo-llvm-cov` for Rust code coverage

### 🎯 Purpose & Impact
- 🛡️ Keeps CI dependencies current with the latest upstream fixes and improvements
- 🔒 Maintains pinned-action security and reproducibility by using a specific commit hash
- ⚙️ Helps ensure the Rust coverage tooling setup remains reliable in automated testing
- 👀 Minimal user-facing impact, but improves maintenance and stability for contributors and CI infrastructure