### PR TITLE
Use Node.js 24 LTS in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       # Builds the wasm (wasm-pack) and the TypeScript wrapper.
       - name: Build npm package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - id: check_version
         # Single source of truth: the version in Cargo.toml. Publish only if that
         # exact version is not already on the npm registry.
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Sync package version from Cargo.toml


### PR DESCRIPTION
Bumps `actions/setup-node` from Node.js 20 to **24** (current Active LTS) in the wasm browser CI job and the npm publish workflow.

Node 24 is supported on GitHub-hosted runners and by `actions/setup-node`, and the package targets browsers/ESM so there is no Node runtime API surface affected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the repository’s GitHub Actions workflows to use Node.js 24 instead of Node.js 20 for CI and npm publishing.

### 📊 Key Changes
- ⬆️ Upgraded the Node.js version from `20` to `24` in the main CI workflow at `.github/workflows/ci.yml`.
- 📦 Updated the npm publish workflow at `.github/workflows/npm-publish.yml` to also use Node.js 24.
- 🛠️ Applied the version bump consistently across both build/test and package publishing steps.

### 🎯 Purpose & Impact
- 🚀 Keeps the project aligned with the latest Node.js runtime used in automated builds and release pipelines.
- ✅ Helps ensure compatibility with newer JavaScript tooling and dependencies.
- 🔒 Reduces the risk of environment drift between CI and publishing workflows by standardizing on the same Node version.
- 👥 For users, this likely has no direct API impact, but it can improve build reliability and future-proof the package release process.