### PR TITLE
refactor(web): label results with the declared task, drop task_of

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -514,7 +514,7 @@ impl YoloModel {
             self.metadata.end2end,
             self.metadata.kpt_shape,
         );
-        let payload = JsResults::from_results(&results);
+        let payload = JsResults::from_results(&results, self.metadata.task);
         serde_wasm_bindgen::to_value(&payload)
             .map_err(|e| JsError::new(&format!("failed to serialize results: {e}")))
     }
@@ -606,8 +606,10 @@ struct JsResults {
 }
 
 impl JsResults {
-    /// Convert core [`Results`] into the serializable JS payload.
-    fn from_results(r: &Results) -> Self {
+    /// Convert core [`Results`] into the serializable JS payload, labeling it with
+    /// the model's declared `task` (the caller already holds it, so there is no
+    /// need to guess it back from which result fields are populated).
+    fn from_results(r: &Results, task: Task) -> Self {
         // Class id -> display name and palette color, shared by every detection type.
         let name = |c: usize| r.names.get(&c).cloned().unwrap_or_default();
         let hex = |c: usize| Color::from_index(c).to_hex();
@@ -674,7 +676,7 @@ impl JsResults {
         });
 
         Self {
-            task: format!("{:?}", task_of(r)).to_lowercase(),
+            task: format!("{task:?}").to_lowercase(),
             width: r.orig_shape.1,
             height: r.orig_shape.0,
             boxes,
@@ -749,23 +751,6 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
     }
 
     Vec::new()
-}
-
-/// Infer the task label from which result fields are populated.
-fn task_of(r: &Results) -> Task {
-    if r.obb.is_some() {
-        Task::Obb
-    } else if r.keypoints.is_some() {
-        Task::Pose
-    } else if r.masks.is_some() {
-        Task::Segment
-    } else if r.probs.is_some() {
-        Task::Classify
-    } else if r.semantic_mask.is_some() {
-        Task::Semantic
-    } else {
-        Task::Detect
-    }
 }
 
 /// The Ultralytics pose drawing scheme: skeleton connectivity plus the per-limb


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes the web inference output use the model’s declared task directly instead of guessing it from result contents, improving accuracy and consistency in JavaScript responses.

### 📊 Key Changes
- Updated `JsResults::from_results()` to accept the model’s `task` as an explicit argument.
- Changed the inference flow to pass `self.metadata.task` when building the JS result payload.
- Replaced inferred task labeling with direct task labeling using the model metadata.
- Removed the old `task_of()` helper, which tried to guess the task by checking which result fields were populated.
- Added clearer inline documentation explaining why using the declared task is more reliable. 📝

### 🎯 Purpose & Impact
- Improves correctness by ensuring result payloads are labeled with the actual model task, not a best guess. ✅
- Prevents edge cases where task detection could be wrong if multiple fields are empty or overlap in unexpected ways.
- Simplifies the codebase by removing unnecessary task inference logic. 🧹
- Makes web and JavaScript integrations more predictable for developers consuming inference results.
- Helps downstream apps display or handle outputs more reliably across tasks like detection, segmentation, pose, classification, and OBB. 🚀