### PR TITLE
fix(cuda-preprocess): surface GPU EP load failure instead of bind_input panic

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -349,7 +349,9 @@ impl YOLOModel {
                          `InferenceConfig::with_cuda_preprocess(false)`."
                     ))
                 } else {
-                    InferenceError::ModelLoadError(format!("Failed to set execution providers: {e}"))
+                    InferenceError::ModelLoadError(format!(
+                        "Failed to set execution providers: {e}"
+                    ))
                 }
             })?;
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -328,7 +328,29 @@ impl YOLOModel {
                 provider_name
             );
             session_builder = session_builder.with_execution_providers(eps).map_err(|e| {
-                InferenceError::ModelLoadError(format!("Failed to set execution providers: {e}"))
+                // The GPU EPs are marked `error_on_failure` only on the
+                // cuda-preprocess fast path (see `build_cuda_ep`), so a dlopen
+                // failure surfaces here as a clear, actionable error instead of
+                // silently falling back to CPU and then panicking later at
+                // `bind_input` with "no data transfer registered" (#251).
+                let gpu = matches!(
+                    provider_name,
+                    "CUDAExecutionProvider" | "TensorRTExecutionProvider"
+                );
+                if gpu {
+                    InferenceError::ModelLoadError(format!(
+                        "{provider_name} failed to load, so the cuda-preprocess fast path \
+                         cannot run on the GPU: {e}\n\
+                         Hint: ensure the matching CUDA runtime and cuDNN 9 (plus TensorRT 10 \
+                         for TensorRt) are installed and on the library path. If the bundled \
+                         ONNX Runtime picked the wrong CUDA major version, rebuild with \
+                         `ORT_CUDA_VERSION=12` or `ORT_CUDA_VERSION=13` to match your CUDA \
+                         install. To use CPU preprocessing instead, set \
+                         `InferenceConfig::with_cuda_preprocess(false)`."
+                    ))
+                } else {
+                    InferenceError::ModelLoadError(format!("Failed to set execution providers: {e}"))
+                }
             })?;
         }
         // CPU is the default - no warning needed when no accelerators are registered
@@ -509,8 +531,16 @@ impl YOLOModel {
         // ORT inference enqueued behind the preprocess kernel without an
         // explicit synchronize. SAFETY: caller (load_with_config) keeps the
         // CudaStreamHandle alive for the lifetime of the Session.
+        //
+        // `error_on_failure()` is set ONLY on the cuda-preprocess arm: when the
+        // fast path is active we feed ORT a CUDA *device pointer*, so a silent
+        // CPU fallback (e.g. missing libcudnn.so.9 / CUDA-version mismatch in the
+        // bundled ORT provider) would leave the input node on CPU and panic at
+        // bind_input with "no data transfer registered". Failing loudly here
+        // surfaces the real cause (#251). The `None` arm keeps the default
+        // graceful multi-EP fallback for the plain CUDA path.
         match compute_stream {
-            Some(s) => unsafe { ep.with_compute_stream(s).build() },
+            Some(s) => unsafe { ep.with_compute_stream(s).build().error_on_failure() },
             None => ep.build(),
         }
     }
@@ -551,9 +581,11 @@ impl YOLOModel {
             .with_timing_cache_path(cache_str)
             .with_max_workspace_size(4 * 1024 * 1024 * 1024)
             .with_builder_optimization_level(5);
-        // SAFETY: see build_cuda_ep above.
+        // SAFETY: see build_cuda_ep above. `error_on_failure()` is scoped to the
+        // cuda-preprocess arm for the same reason documented there: a silent CPU
+        // fallback while we hand ORT a device pointer panics at bind_input (#251).
         match compute_stream {
-            Some(s) => unsafe { ep.with_compute_stream(s).build() },
+            Some(s) => unsafe { ep.with_compute_stream(s).build().error_on_failure() },
             None => ep.build(),
         }
     }


### PR DESCRIPTION
When the bundled ONNX Runtime GPU provider can't be loaded a CUDA major mismatch (cu12 vs cu13) or an unfound libcudnn.so.9 / libnvinfer.so.10 ORT silently falls back to the CPU EP. The cuda-preprocess fast path doesn't notice and still hands ORT a CUDA device pointer, so inference fails with the cryptic "bind_input: There's no data transfer registered for copying tensors from Device:[DeviceType:1] to Device:[DeviceType:0]" (#251).

Fix: #251

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves GPU startup error handling in `ultralytics/inference`, making CUDA/TensorRT failures clearer and preventing confusing crashes when using the CUDA preprocessing fast path.

### 📊 Key Changes
- Added **more specific model load errors** when `CUDAExecutionProvider` or `TensorRTExecutionProvider` fails to initialize.
- Introduced **fail-fast behavior** for GPU execution providers when the **CUDA preprocessing fast path** is enabled.
- Prevented silent fallback from GPU to CPU in cases where preprocessing still passes a **GPU device pointer** to ONNX Runtime.
- Added **actionable troubleshooting hints** in error messages, including:
  - checking CUDA runtime and **cuDNN 9**
  - installing **TensorRT 10** for TensorRT usage
  - rebuilding with `ORT_CUDA_VERSION=12` or `ORT_CUDA_VERSION=13` if the bundled ONNX Runtime uses the wrong CUDA major version
  - disabling CUDA preprocessing with `InferenceConfig::with_cuda_preprocess(false)` to use CPU preprocessing instead
- Updated inline code comments to clarify **why `error_on_failure()` is only used in the CUDA preprocess path**.

### 🎯 Purpose & Impact
- ✅ **Fixes a confusing failure mode** where missing or mismatched GPU libraries could previously trigger a later crash like `"no data transfer registered"` instead of showing the real problem.
- 🔍 Makes GPU setup issues **much easier to diagnose** for developers and users by surfacing the root cause earlier.
- 🚀 Improves reliability for workflows using **CUDA-accelerated preprocessing**, especially on systems with custom CUDA/cuDNN/TensorRT installs.
- 🧠 Preserves the existing **graceful fallback behavior** for the standard non-fast-path CUDA flow, so only the risky path becomes strict.
- 👥 Overall, this should reduce debugging time and make GPU deployment in `ultralytics/inference` more predictable and user-friendly.