### PR TITLE
✈️ ultralytics-inference 🐪 version to 0.0.22 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,7 +2671,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.21"
+version = "0.0.22"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.21 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.22 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -179,7 +179,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.21 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.22 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -275,7 +275,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.21"
+ultralytics-inference = "0.0.22"
 ```
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ Default features (enabled unless `--no-default-features` is passed): `annotate`,
 
 ## 🌐 Browser / WebGPU (WASM)
 
+[![npm version](https://img.shields.io/npm/v/@ultralytics/yolo?logo=npm&logoColor=white&label=npm&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
+[![npm downloads](https://img.shields.io/npm/dm/@ultralytics/yolo?logo=npm&logoColor=white&label=downloads&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
+
 The same engine runs in the browser on **WebGPU**, compiled to WebAssembly. The
 forward pass executes on the official ONNX Runtime Web build, bridged through
 [`ort-web`](https://ort.pyke.io/backends/web), while the shared Rust

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.21 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.22 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -179,7 +179,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.21 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.22 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -275,7 +275,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.21"
+ultralytics-inference = "0.0.22"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -468,6 +468,9 @@ cargo build --release --features "cuda,tensorrt"
 
 ## 🌐 浏览器 / WebGPU（WASM）
 
+[![npm version](https://img.shields.io/npm/v/@ultralytics/yolo?logo=npm&logoColor=white&label=npm&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
+[![npm downloads](https://img.shields.io/npm/dm/@ultralytics/yolo?logo=npm&logoColor=white&label=downloads&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
+
 同一套引擎可编译为 WebAssembly，在浏览器中通过 **WebGPU** 运行。前向推理由官方
 ONNX Runtime Web 构建执行，并通过
 [`ort-web`](https://ort.pyke.io/backends/web) 桥接到 Rust；预处理与后处理复用

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.21"
+version = "0.0.22"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -27,9 +27,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.19", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.22", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.19", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.22", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` — no extra flags needed.
@@ -59,7 +59,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.19", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.22", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ultralytics-inference",
-  "version": "0.0.19",
+  "name": "@ultralytics/yolo",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ultralytics-inference",
-      "version": "0.0.19",
+      "name": "@ultralytics/yolo",
+      "version": "0.0.22",
       "license": "AGPL-3.0",
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR bumps `ultralytics-inference` and its web package to `0.0.22`, while refreshing documentation and improving visibility for the browser/WebGPU npm package.

### 📊 Key Changes
- Updated the Rust crate version from `0.0.21` to `0.0.22` in:
  - `Cargo.toml`
  - `crates/web/Cargo.toml`
- Updated the browser package version from `0.0.21` to `0.0.22` in `web/package.json`.
- Refreshed README examples in both English and Chinese to show the new `0.0.22` release version.
- Updated installation snippets in the docs to use the latest package version instead of older references.
- Fixed CUDA documentation examples to point to `0.0.22` rather than `0.0.19` ⚙️
- Added npm badges to the browser/WebGPU README sections, showing package version and download stats for `@ultralytics/yolo` 📦
- Regenerated lock files (`Cargo.lock` and `web/package-lock.json`) to match the new release state.

### 🎯 Purpose & Impact
- Keeps the Rust crate, web package, and documentation aligned under the new `0.0.22` release ✅
- Makes installation and setup less error-prone by ensuring users copy current version numbers from the docs 🛠️
- Improves discoverability and trust for the browser/WebGPU package with visible npm status badges 🌐
- Suggests this is primarily a release and documentation sync PR, with little to no direct runtime behavior change for end users 🔄
- Helps developers adopt the latest `ultralytics-inference` release more smoothly across native Rust and browser-based workflows 🚀
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
