### PR TITLE
Bump taiki-e/install-action from v2.81.11 to v2.82.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: wasm-pack
 
@@ -256,7 +256,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.11 to v2.82.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used in CI and npm publishing workflows, bumping `taiki-e/install-action` from v2.81.11 to v2.82.0.

### 📊 Key Changes
- Updated the pinned `taiki-e/install-action` version in `.github/workflows/ci.yml` ✅
- Updated the same action in `.github/workflows/npm-publish.yml` 📦
- These updates affect installation steps for:
  - `wasm-pack` in CI and npm publish workflows
  - `cargo-llvm-cov` in CI coverage jobs 🦀

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies current 🔄
- Helps ensure more reliable Rust and WebAssembly tool installation in automated pipelines ⚙️
- Reduces the chance of issues caused by older action versions, with minimal to no user-facing behavior changes 🛡️
- Primarily benefits developers and maintainers by making CI and package publishing a bit more robust 🚀