### PR TITLE
Bump taiki-e/install-action from v2.82.0 to v2.82.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
         with:
           tool: wasm-pack
 
@@ -256,7 +256,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.0 to v2.82.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used in CI and npm publishing workflows from `taiki-e/install-action` v2.82.0 to v2.82.1 for Rust/WebAssembly tooling.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in **`.github/workflows/ci.yml`**:
  - for installing `wasm-pack`
  - for installing `cargo-llvm-cov`
- Updated the same action in **`.github/workflows/npm-publish.yml`**:
  - for installing `wasm-pack`
- The change is limited to workflow dependency version bumps, with no application code modifications 🧩

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies current ⬆️
- May bring small reliability, compatibility, or security improvements from the newer action release 🛡️
- Helps keep Rust and WebAssembly build/publish pipelines stable for CI and npm package publishing ⚙️
- Low-risk change for users, since it only affects automation infrastructure and not inference functionality ✅