### PR TITLE
docs(cuda): add CUDA 13.3 to supported toolkits

### DIFF
--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -15,7 +15,7 @@
 | Component              | Tested      | How to verify                                                                                                            |
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
 | NVIDIA driver          | 580+        | `nvidia-smi`                                                                                                             |
-| CUDA toolkit           | 11.4 – 13.2 | `nvcc --version` _(toolkit only required for `cuda-preprocess`; `cuda` and `tensorrt` ship their EP libs through `ort`)_ |
+| CUDA toolkit           | 11.4 – 13.3 | `nvcc --version` _(toolkit only required for `cuda-preprocess`; `cuda` and `tensorrt` ship their EP libs through `ort`)_ |
 | TensorRT               | 10.x        | `ldconfig -p \| grep libnvinfer` (only for `tensorrt` / `cuda-preprocess`)                                               |
 | GPU compute capability | sm_70+      | `nvidia-smi --query-gpu=compute_cap --format=csv`                                                                        |
 
@@ -53,7 +53,7 @@ export PATH=/usr/local/cuda/bin:$PATH
 export CUDARC_CUDA_VERSION=13020
 ```
 
-Supported toolkits: 11.4, 11.5, 11.6, 11.7, 11.8, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2. (Full list and feature names: [cudarc Cargo.toml](https://github.com/chelsea0x3b/cudarc/blob/main/Cargo.toml).)
+Supported toolkits: 11.4, 11.5, 11.6, 11.7, 11.8, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3. (Full list and feature names: [cudarc Cargo.toml](https://github.com/chelsea0x3b/cudarc/blob/main/Cargo.toml).)
 
 If you need to pin a specific version at compile time instead, override the cudarc dep in your project's `Cargo.toml`:
 


### PR DESCRIPTION
cudarc 0.19.8 adds the cuda-13030 feature, so the cuda-preprocess fast path now builds against the CUDA 13.3 toolkit. Extend both the requirements table and the supported-toolkits list accordingly.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the CUDA documentation to add support for CUDA Toolkit 13.3 in `ultralytics/inference`.

### 📊 Key Changes
- 📚 Updated `docs/CUDA.md` to expand the tested CUDA Toolkit range from **11.4–13.2** to **11.4–13.3**.
- ✅ Added **CUDA 13.3** to the explicit list of supported toolkits in the installation/setup documentation.
- 🔍 Kept the existing clarification that the CUDA toolkit is only required for `cuda-preprocess`, while `cuda` and `tensorrt` rely on execution provider libraries shipped through `ort`.

### 🎯 Purpose & Impact
- 🚀 Ensures the documentation reflects compatibility with the latest CUDA Toolkit version supported by the project.
- 🙌 Helps developers using newer NVIDIA CUDA environments avoid confusion during setup.
- 🧭 Reduces documentation drift by aligning the stated supported versions with actual dependency support.
- ⚠️ This is a documentation-focused change, so it likely has **no direct runtime impact**, but it improves setup reliability and user confidence.