### PR TITLE
Bump actions/cache from v5.0.5 to v6.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Cache FFmpeg
         id: cache-ffmpeg
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ffmpeg
           key: windows-ffmpeg-${{ env.FFMPEG_VERSION }}


### PR DESCRIPTION
Bump actions/cache from v5.0.5 to v6.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions cache dependency used for FFmpeg in CI, moving `actions/cache` from v5.0.5 to v6.0.0.

### 📊 Key Changes
- ⬆️ Upgraded the `actions/cache` GitHub Action in `.github/workflows/ci.yml`
- 🎬 The change affects the **FFmpeg cache step** in the Windows CI workflow
- 🔒 Updated the pinned action reference to a newer commit corresponding to `actions/cache` v6.0.0

### 🎯 Purpose & Impact
- 🚀 Keeps CI dependencies up to date with the latest `actions/cache` release
- 🛡️ Improves maintainability and may bring security, reliability, or compatibility improvements from the newer action version
- 🧪 Has **no direct effect on inference features or user-facing functionality**, but helps ensure the project’s automated testing and build pipeline remain healthy and current