### PR TITLE
Bump taiki-e/install-action from v2.82.2 to v2.82.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: wasm-pack
 
@@ -256,7 +256,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # macos-latest's default Xcode 16.4 toolchain is missing libclang_rt.osx.a,
+      # which breaks CoreML test linking (ld: library 'clang_rt.osx' not found).
+      # Pin to a known-good Xcode until the runner image is fixed.
+      - name: Select Xcode (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          for v in 16.3 16.2 16.1; do
+            if [ -d "/Applications/Xcode_${v}.app" ]; then
+              sudo xcode-select -s "/Applications/Xcode_${v}.app"
+              break
+            fi
+          done
+          xcodebuild -version
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # macos-latest's default Xcode 16.4 toolchain is missing libclang_rt.osx.a,
+      # which breaks linking (ld: library 'clang_rt.osx' not found).
+      # Pin to a known-good Xcode until the runner image is fixed.
+      - name: Select Xcode (macOS)
+        run: |
+          for v in 16.3 16.2 16.1; do
+            if [ -d "/Applications/Xcode_${v}.app" ]; then
+              sudo xcode-select -s "/Applications/Xcode_${v}.app"
+              break
+            fi
+          done
+          xcodebuild -version
+
       - name: Install dependencies
         run: brew install ffmpeg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,7 @@ jobs:
       - name: Select Xcode (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          sel=""
-          for p in /Applications/Xcode_16.3.app /Applications/Xcode_16.2.app /Applications/Xcode_16.1.app /Applications/Xcode_26*.app; do
-            for d in $p; do [ -d "$d" ] && { sel="$d"; break 2; }; done
-          done
-          [ -n "$sel" ] && sudo xcode-select -s "$sel"
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -vE 'beta|16\.4' | sort -V | tail -1)"
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
@@ -140,11 +136,7 @@ jobs:
       # otherwise a cache built under one image's Xcode dangles on another.
       - name: Select Xcode (macOS)
         run: |
-          sel=""
-          for p in /Applications/Xcode_16.3.app /Applications/Xcode_16.2.app /Applications/Xcode_16.1.app /Applications/Xcode_26*.app; do
-            for d in $p; do [ -d "$d" ] && { sel="$d"; break 2; }; done
-          done
-          [ -n "$sel" ] && sudo xcode-select -s "$sel"
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -vE 'beta|16\.4' | sort -V | tail -1)"
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # macos-latest's default Xcode 16.4 toolchain is missing libclang_rt.osx.a,
-      # which breaks CoreML test linking (ld: library 'clang_rt.osx' not found).
-      # Pin to a known-good Xcode until the runner image is fixed.
+      # macos-latest's default Xcode 16.4 toolchain dangles libclang_rt.osx.a
+      # (ld: library 'clang_rt.osx' not found). Select a present, known-good
+      # Xcode and export its version so the Rust cache key is scoped to it -
+      # otherwise a cache built under one image's Xcode dangles on another.
       - name: Select Xcode (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          for v in 16.3 16.2 16.1; do
-            if [ -d "/Applications/Xcode_${v}.app" ]; then
-              sudo xcode-select -s "/Applications/Xcode_${v}.app"
-              break
-            fi
+          sel=""
+          for p in /Applications/Xcode_16.3.app /Applications/Xcode_16.2.app /Applications/Xcode_16.1.app /Applications/Xcode_26*.app; do
+            for d in $p; do [ -d "$d" ] && { sel="$d"; break 2; }; done
           done
+          [ -n "$sel" ] && sudo xcode-select -s "$sel"
           xcodebuild -version
+          echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -58,6 +59,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
         run: rustup show
@@ -131,18 +134,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # macos-latest's default Xcode 16.4 toolchain is missing libclang_rt.osx.a,
-      # which breaks linking (ld: library 'clang_rt.osx' not found).
-      # Pin to a known-good Xcode until the runner image is fixed.
+      # macos-latest's default Xcode 16.4 toolchain dangles libclang_rt.osx.a
+      # (ld: library 'clang_rt.osx' not found). Select a present, known-good
+      # Xcode and export its version so the Rust cache key is scoped to it -
+      # otherwise a cache built under one image's Xcode dangles on another.
       - name: Select Xcode (macOS)
         run: |
-          for v in 16.3 16.2 16.1; do
-            if [ -d "/Applications/Xcode_${v}.app" ]; then
-              sudo xcode-select -s "/Applications/Xcode_${v}.app"
-              break
-            fi
+          sel=""
+          for p in /Applications/Xcode_16.3.app /Applications/Xcode_16.2.app /Applications/Xcode_16.1.app /Applications/Xcode_26*.app; do
+            for d in $p; do [ -d "$d" ] && { sel="$d"; break 2; }; done
           done
+          [ -n "$sel" ] && sudo xcode-select -s "$sel"
           xcodebuild -version
+          echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: brew install ffmpeg
@@ -156,7 +160,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}-xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
         run: rustup show

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.2 to v2.82.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves GitHub Actions reliability on macOS by selecting a stable Xcode version, isolating Rust caches by Xcode/FFmpeg version, and updating a build tool dependency.

### 📊 Key Changes
- 🍎 Added a new **macOS Xcode selection step** in CI workflows to avoid the default Xcode 16.4 toolchain, which can cause missing `clang_rt.osx` linker errors.
- 🧩 Exported the selected **Xcode version into the environment** so builds can track which toolchain was used.
- 💾 Updated **Rust cache keys** to include the Xcode version:
  - in general macOS CI jobs
  - in FFmpeg-related jobs, alongside the FFmpeg version
- 🔒 This prevents reuse of incompatible Rust build caches created under a different macOS/Xcode image.
- ⬆️ Bumped `taiki-e/install-action` from **v2.82.2** to **v2.82.3** in:
  - the main CI workflow
  - the npm publish workflow
- 🌐 Kept WebAssembly-related build steps current by updating the installer used for tools like `wasm-pack` and `cargo-llvm-cov`.

### 🎯 Purpose & Impact
- ✅ **More reliable macOS CI builds** by avoiding a known-bad Xcode setup that can break Rust linking.
- 🚀 **Fewer flaky failures** caused by cached artifacts built with a different Apple toolchain.
- 🧪 **More stable release and test pipelines**, especially for Rust, FFmpeg, and WebAssembly components.
- 👩‍💻 **Better developer experience** since contributors and maintainers should spend less time troubleshooting inconsistent CI errors.
- 📦 **Safer automation for publishing** by keeping build tooling slightly more up to date.