### PR TITLE
Bump actions/setup-python from v6.2.0 to v6.3.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0


### PR DESCRIPTION
Bump actions/setup-python from v6.2.0 to v6.3.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small but important CI maintenance update by upgrading the GitHub Action used to set up Python in the publish workflow.

### 📊 Key Changes
- ⬆️ Updated `actions/setup-python` in `.github/workflows/publish.yml`
  - From `v6.2.0`
  - To `v6.3.0`
- 🛠️ The change affects the automated publishing pipeline, not the inference code itself.
- 🔒 The workflow continues to use a pinned commit hash, helping keep CI runs stable and reproducible.

### 🎯 Purpose & Impact
- ✅ Keeps the publishing workflow up to date with the latest fixes and improvements from `actions/setup-python`.
- 🚀 May improve reliability or compatibility of Python setup during release and publish jobs.
- 👥 No direct user-facing product changes, but it helps maintain a healthier and more dependable release process for the repository.
- 📦 Low-risk maintenance update that supports smoother CI/CD operations overall.