### PR TITLE
docs: document ultralytics quantize export argument for ONNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ ultralytics-inference help
 ### Export a YOLO Model to ONNX
 
 ```bash
-# Using Ultralytics CLI
+# Using Ultralytics CLI (FP32, default)
 yolo export model=yolo26n.pt format=onnx
+
+# FP16 (half precision) — ~50% smaller model
+yolo export model=yolo26n.pt format=onnx quantize=16
 ```
 
 ```python
@@ -103,8 +106,18 @@ yolo export model=yolo26n.pt format=onnx
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-model.export(format="onnx")
+model.export(format="onnx")                 # FP32 (default)
+model.export(format="onnx", quantize=16)    # FP16 (half precision)
 ```
+
+> **Precision / quantization:** Ultralytics ≥8.4 uses a single `quantize`
+> argument instead of the deprecated `half=True` / `int8=True` flags. For ONNX
+> the supported values are `32`/`fp32` (FP32, the default), `16`/`fp16` (FP16),
+> and `8`/`int8` (INT8 — requires a calibration dataset via `data=`). The old
+> `half=True` (→ `quantize=16`) and `int8=True` (→ `quantize=8`) still work but
+> emit a deprecation warning. See the
+> [export docs](https://docs.ultralytics.com/modes/export) and the
+> [ONNX integration guide](https://docs.ultralytics.com/integrations/onnx).
 
 ### Run Inference
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ yolo export model=yolo26n.pt format=onnx quantize=16
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-model.export(format="onnx")                 # FP32 (default)
-model.export(format="onnx", quantize=16)    # FP16 (half precision)
+model.export(format="onnx")  # FP32 (default)
+model.export(format="onnx", quantize=16)  # FP16 (half precision)
 ```
 
 > **Precision / quantization:** Ultralytics ≥8.4 uses a single `quantize`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,8 +106,8 @@ yolo export model=yolo26n.pt format=onnx quantize=16
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-model.export(format="onnx")                 # FP32（默认）
-model.export(format="onnx", quantize=16)    # FP16（半精度）
+model.export(format="onnx")  # FP32（默认）
+model.export(format="onnx", quantize=16)  # FP16（半精度）
 ```
 
 > **精度 / 量化：** Ultralytics ≥8.4 使用统一的 `quantize` 参数，取代已弃用的

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,8 +94,11 @@ ultralytics-inference help
 ### 将 YOLO 模型导出为 ONNX
 
 ```bash
-# 使用 Ultralytics CLI
+# 使用 Ultralytics CLI（FP32，默认）
 yolo export model=yolo26n.pt format=onnx
+
+# FP16（半精度）——模型体积约小 50%
+yolo export model=yolo26n.pt format=onnx quantize=16
 ```
 
 ```python
@@ -103,8 +106,17 @@ yolo export model=yolo26n.pt format=onnx
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-model.export(format="onnx")
+model.export(format="onnx")                 # FP32（默认）
+model.export(format="onnx", quantize=16)    # FP16（半精度）
 ```
+
+> **精度 / 量化：** Ultralytics ≥8.4 使用统一的 `quantize` 参数，取代已弃用的
+> `half=True` / `int8=True` 标志。对于 ONNX，支持的取值为 `32`/`fp32`（FP32，默认）、
+> `16`/`fp16`（FP16）和 `8`/`int8`（INT8——需通过 `data=` 提供校准数据集）。旧的
+> `half=True`（→ `quantize=16`）和 `int8=True`（→ `quantize=8`）仍可用，但会
+> 触发弃用警告。详见
+> [导出文档](https://docs.ultralytics.com/modes/export) 和
+> [ONNX 集成指南](https://docs.ultralytics.com/integrations/onnx)。
 
 ### 运行推理
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,8 @@
 //! ```
 //!
 //! Add `quantize=16` for an FP16 (half-precision) ONNX, or `quantize=8` for INT8
-//! (Ultralytics >= 8.4; replaces the deprecated `half`/`int8` flags).
+//! (which also needs a calibration dataset via `data=`). Requires Ultralytics
+//! >= 8.4; `quantize` replaces the deprecated `half`/`int8` flags.
 //!
 //! The task is auto-detected from ONNX metadata:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@
 //! yolo export model=yolo26n-sem.pt format=onnx
 //! ```
 //!
+//! Add `quantize=16` for an FP16 (half-precision) ONNX, or `quantize=8` for INT8
+//! (Ultralytics >= 8.4; replaces the deprecated `half`/`int8` flags).
+//!
 //! The task is auto-detected from ONNX metadata:
 //!
 //! ```no_run

--- a/web/README.md
+++ b/web/README.md
@@ -158,8 +158,8 @@ the native renderer. None of this is duplicated in JS.
   ```python
   from ultralytics import YOLO
 
-  YOLO("yolo26n.pt").export(format="onnx")                 # FP32 (default)
-  YOLO("yolo26n.pt").export(format="onnx", quantize=16)    # FP16 (~50% smaller)
+  YOLO("yolo26n.pt").export(format="onnx")  # FP32 (default)
+  YOLO("yolo26n.pt").export(format="onnx", quantize=16)  # FP16 (~50% smaller)
   ```
 
   > Ultralytics ≥8.4 uses the `quantize` argument instead of the deprecated

--- a/web/README.md
+++ b/web/README.md
@@ -158,8 +158,13 @@ the native renderer. None of this is duplicated in JS.
   ```python
   from ultralytics import YOLO
 
-  YOLO("yolo26n.pt").export(format="onnx")
+  YOLO("yolo26n.pt").export(format="onnx")                 # FP32 (default)
+  YOLO("yolo26n.pt").export(format="onnx", quantize=16)    # FP16 (~50% smaller)
   ```
+
+  > Ultralytics ≥8.4 uses the `quantize` argument instead of the deprecated
+  > `half=True` / `int8=True` flags. For ONNX the supported values are
+  > `32`/`fp32` (default), `16`/`fp16`, and `8`/`int8`.
 
 - **Runtime assets**: on first load, `ort-web` fetches the ONNX Runtime Web wasm
   bundle (~25 MB, browser-cached afterward) from `cdn.pyke.io`. If you set a


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates the documentation to clearly explain ONNX export precision options, especially the new `quantize` parameter for FP16 and INT8 exports.

### 📊 Key Changes
- Added **FP16 ONNX export examples** to the main `README.md`, Chinese `README.zh-CN.md`, Rust crate docs, and `web/README.md` 🛠️
- Clarified that **FP32 is the default** export format when using ONNX
- Documented the new unified **`quantize` argument**:
  - `quantize=32` / `fp32` for full precision
  - `quantize=16` / `fp16` for half precision
  - `quantize=8` / `int8` for INT8 export
- Explained that **older flags** like `half=True` and `int8=True` are now **deprecated** but still supported with warnings ⚠️
- Added an important note that **INT8 export requires a calibration dataset** via `data=`
- Included links to the relevant Ultralytics export and ONNX documentation for easier follow-up reading 🔗

### 🎯 Purpose & Impact
- Helps users export YOLO26 models to ONNX with the **correct and current syntax**, reducing confusion ✅
- Makes it easier to discover that **FP16 exports can significantly reduce model size** for deployment 🚀
- Improves consistency across **Python, CLI, Rust, web, and Chinese-language docs** 🌍
- Smooths migration to **Ultralytics 8.4+** by explaining the shift from old precision flags to `quantize`
- Lowers the chance of export mistakes, especially for users trying **INT8 quantization**, which has extra setup requirements 🎯