### PR TITLE
Bump actions/cache from v6.0.0 to v6.1.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Cache FFmpeg
         id: cache-ffmpeg
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ffmpeg
           key: windows-ffmpeg-${{ env.FFMPEG_VERSION }}


### PR DESCRIPTION
Bump actions/cache from v6.0.0 to v6.1.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions cache dependency in CI from `actions/cache` v6.0.0 to v6.1.0 to keep the repository’s Windows FFmpeg caching step current.

### 📊 Key Changes
- ⬆️ Updated the pinned `actions/cache` version in `.github/workflows/ci.yml`
- 🪟 Change applies specifically to the **Windows FFmpeg cache** step in the CI workflow
- 🔒 Keeps the workflow aligned with the latest patch release while preserving pinned-action security and reproducibility

### 🎯 Purpose & Impact
- 🚀 Helps maintain a reliable and up-to-date CI pipeline with the newest fixes from `actions/cache`
- 🛠️ May improve cache stability or compatibility for Windows-based CI jobs that use FFmpeg
- 🔐 Supports safer GitHub Actions usage by continuing to pin a specific commit rather than using a floating version
- 👥 Low user-facing impact, but beneficial for maintainers through smoother and more dependable automation