### PR TITLE
Bump taiki-e/install-action from v2.82.4 to v2.82.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: wasm-pack
 
@@ -279,7 +279,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.4 to v2.82.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Action used to install Rust tooling in CI and npm publishing workflows, keeping the repository’s automation slightly more current and reliable.

### 📊 Key Changes
- Updated `taiki-e/install-action` from `v2.82.4` to `v2.82.5` in GitHub workflows.
- Applied the update in the main CI workflow at `.github/workflows/ci.yml`.
- Applied the same update in the npm publish workflow at `.github/workflows/npm-publish.yml`.
- The updated action is used for installing:
  - `wasm-pack`
  - `cargo-llvm-cov`

### 🎯 Purpose & Impact
- 🚀 Keeps CI and release automation aligned with the latest patch version of the install action.
- 🛠️ Helps maintain stable installation of Rust/WebAssembly-related tools used for testing, coverage, and packaging.
- 📦 Reduces the chance of workflow issues caused by outdated action versions.
- ✅ Low-risk infrastructure improvement with no direct changes to product features or runtime behavior for end users.