### PR TITLE
Support baked argmax semantic ONNX output, update semantic assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,7 +2613,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ High-performance YOLO inference library written in Rust. This library provides a
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/Ultralytics/)
 [![codecov](https://codecov.io/github/ultralytics/inference/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/inference)
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
+[![arXiv](https://img.shields.io/badge/arXiv-2606.03748-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2606.03748)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B)](https://docs.rs/ultralytics-inference)
 [![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+[![License](https://img.shields.io/crates/l/ultralytics-inference?label=license&color=blue)](https://github.com/ultralytics/inference/blob/main/LICENSE)
 [![dependency status](https://deps.rs/repo/github/ultralytics/inference/status.svg)](https://deps.rs/repo/github/ultralytics/inference)
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ High-performance YOLO inference library written in Rust. This library provides a
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
-[![docs.rs](https://img.shields.io/badge/docs.rs-latest-CE422B?logo=docs.rs&logoColor=white)](https://docs.rs/ultralytics-inference)
+[![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B)](https://docs.rs/ultralytics-inference)
 [![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![dependency status](https://deps.rs/repo/github/ultralytics/inference/status.svg)](https://deps.rs/repo/github/ultralytics/inference)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.23 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.24 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -192,7 +192,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.23 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.24 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -288,7 +288,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.23"
+ultralytics-inference = "0.0.24"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,11 +13,13 @@
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/Ultralytics/)
 [![codecov](https://codecov.io/github/ultralytics/inference/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/inference)
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
+[![arXiv](https://img.shields.io/badge/arXiv-2606.03748-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2606.03748)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B)](https://docs.rs/ultralytics-inference)
 [![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+[![License](https://img.shields.io/crates/l/ultralytics-inference?label=license&color=blue)](https://github.com/ultralytics/inference/blob/main/LICENSE)
 [![dependency status](https://deps.rs/repo/github/ultralytics/inference/status.svg)](https://deps.rs/repo/github/ultralytics/inference)
 
 ## ✨ 功能

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.23 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.24 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -191,7 +191,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.23 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.24 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -287,7 +287,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.23"
+ultralytics-inference = "0.0.24"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
 
 [![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
-[![docs.rs](https://img.shields.io/badge/docs.rs-latest-CE422B?logo=docs.rs&logoColor=white)](https://docs.rs/ultralytics-inference)
+[![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B)](https://docs.rs/ultralytics-inference)
 [![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
 [![dependency status](https://deps.rs/repo/github/ultralytics/inference/status.svg)](https://deps.rs/repo/github/ultralytics/inference)

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -414,6 +414,8 @@ impl YoloModel {
         }
         let names: Arc<HashMap<usize, String>> = Arc::clone(&self.metadata.names);
         let inference_shape = (self.imgsz.0 as u32, self.imgsz.1 as u32);
+        // Postprocess time runs from output extraction to the postprocess call.
+        let speed = || Speed::new(t_inf - t_pre, t_post - t_inf, now_ms() - t_post);
 
         // Baked-argmax semantic models output a single `[B, H, W] uint8` class map
         // (ArgMax + Cast folded into the graph).
@@ -429,15 +431,13 @@ impl YoloModel {
             } else {
                 &shape
             };
-            let t_end = now_ms();
-            let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
             postprocess_semantic_mask(
                 data,
                 img_shape,
                 names,
                 orig_img,
                 String::new(),
-                speed,
+                speed(),
                 inference_shape,
             )
         } else {
@@ -453,8 +453,6 @@ impl YoloModel {
                         })?;
                 views.push((data, shape.iter().map(|&d| d as usize).collect()));
             }
-            let t_end = now_ms();
-            let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
             postprocess(
                 views,
                 self.metadata.task,
@@ -463,7 +461,7 @@ impl YoloModel {
                 names,
                 orig_img,
                 String::new(),
-                speed,
+                speed(),
                 inference_shape,
                 self.metadata.end2end,
                 self.metadata.kpt_shape,

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -201,9 +201,6 @@ pub struct YoloModel {
     imgsz: (usize, usize),
     /// Active device label (`"webgpu"` or `"cpu"`).
     device: &'static str,
-    /// `true` when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only
-    /// output is a `[B, H, W] uint8` class map.
-    semantic: bool,
 }
 
 #[wasm_bindgen]
@@ -342,25 +339,31 @@ impl YoloModel {
         device: Device,
     ) -> Result<Self, JsError> {
         let imgsz = metadata.imgsz.unwrap_or((DEFAULT_IMGSZ, DEFAULT_IMGSZ));
-        let (output_names, semantic) = {
-            let outputs = session.outputs();
-            let semantic = outputs.len() == 1
-                && matches!(
-                    outputs[0].dtype(),
-                    ValueType::Tensor { ty: TensorElementType::Uint8, shape, .. }
-                        if shape.len() == 3
-                );
-            let names: Vec<String> = outputs.iter().map(|o| o.name().to_string()).collect();
-            (names, semantic)
-        };
+        let output_names = session
+            .outputs()
+            .iter()
+            .map(|o| o.name().to_string())
+            .collect();
         Ok(Self {
             session,
             metadata,
             output_names,
             imgsz,
             device: device.label(),
-            semantic,
         })
+    }
+
+    /// Returns `true` when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only
+    /// output is a `[B, H, W] uint8` class map. Lets `run` skip f32 logits extraction
+    /// and use the dedicated semantic-mask postprocessor (matches native model.rs).
+    fn semantic_baked(&self) -> bool {
+        let outputs = self.session.outputs();
+        outputs.len() == 1
+            && matches!(
+                outputs[0].dtype(),
+                ValueType::Tensor { ty: TensorElementType::Uint8, shape, .. }
+                    if shape.len() == 3
+            )
     }
 
     /// Core async predict: decode -> preprocess -> `run_async` -> sync -> postprocess.
@@ -393,6 +396,9 @@ impl YoloModel {
             preprocess_image_with_precision(&dynimg, self.imgsz, self.metadata.stride, false)
         };
 
+        // Resolve the output dtype path before borrowing the session for inference.
+        let semantic_baked = self.semantic_baked();
+
         // Upload the NCHW f32 tensor into the ORT (WebGPU) context and run.
         let t_inf = now_ms();
         let input = Tensor::from_array(pre.tensor.clone()).map_err(map_ort)?;
@@ -419,7 +425,7 @@ impl YoloModel {
 
         // Baked-argmax semantic models output a single `[B, H, W] uint8` class map
         // (ArgMax + Cast folded into the graph).
-        let results = if self.semantic {
+        let results = if semantic_baked {
             let name = &self.output_names[0];
             let (shape, data) = outputs[name.as_str()]
                 .try_extract_tensor::<u8>()

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use ndarray::Array3;
 use ort::ep::WebGPU;
 use ort::session::{RunOptions, Session};
-use ort::value::Tensor;
+use ort::value::{Tensor, TensorElementType, ValueType};
 use ort_web::sync_outputs;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use ultralytics_inference::metadata::ModelMetadata;
-use ultralytics_inference::postprocessing::postprocess;
+use ultralytics_inference::postprocessing::{postprocess, postprocess_semantic_mask};
 use ultralytics_inference::preprocessing::{
     preprocess_image_center_crop, preprocess_image_with_precision,
 };
@@ -201,6 +201,10 @@ pub struct YoloModel {
     imgsz: (usize, usize),
     /// Active device label (`"webgpu"` or `"cpu"`).
     device: &'static str,
+    /// `true` when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only
+    /// output is a `[B, H, W] uint8` class map. Lets us skip f32 logits extraction
+    /// and feed the dedicated semantic-mask postprocessor (matches native model.rs).
+    semantic: bool,
 }
 
 #[wasm_bindgen]
@@ -339,17 +343,24 @@ impl YoloModel {
         device: Device,
     ) -> Result<Self, JsError> {
         let imgsz = metadata.imgsz.unwrap_or((DEFAULT_IMGSZ, DEFAULT_IMGSZ));
-        let output_names = session
-            .outputs()
-            .iter()
-            .map(|o| o.name().to_string())
-            .collect();
+        let (output_names, semantic) = {
+            let outputs = session.outputs();
+            let semantic = outputs.len() == 1
+                && matches!(
+                    outputs[0].dtype(),
+                    ValueType::Tensor { ty: TensorElementType::Uint8, shape, .. }
+                        if shape.len() == 3
+                );
+            let names: Vec<String> = outputs.iter().map(|o| o.name().to_string()).collect();
+            (names, semantic)
+        };
         Ok(Self {
             session,
             metadata,
             output_names,
             imgsz,
             device: device.label(),
+            semantic,
         })
     }
 
@@ -397,40 +408,63 @@ impl YoloModel {
             .await
             .map_err(err_ctx("failed to sync outputs"))?;
 
-        // Borrow each output's data directly (no copy, important for the large
-        // semantic logits, ~160 MB) and feed it to the shared postprocessor while
-        // `outputs` is still alive.
         let t_post = now_ms();
-        let mut views: Vec<(&[f32], Vec<usize>)> = Vec::with_capacity(self.output_names.len());
-        for name in &self.output_names {
-            let (shape, data) = outputs[name.as_str()]
-                .try_extract_tensor::<f32>()
-                .map_err(|e| JsError::new(&format!("failed to extract output '{name}': {e}")))?;
-            views.push((data, shape.iter().map(|&d| d as usize).collect()));
-        }
-
         let mut config = InferenceConfig::new().with_confidence(conf).with_iou(iou);
         if let Some(classes) = classes {
             config = config.with_classes(classes.into_iter().map(|c| c as usize).collect());
         }
         let names: Arc<HashMap<usize, String>> = Arc::clone(&self.metadata.names);
         let inference_shape = (self.imgsz.0 as u32, self.imgsz.1 as u32);
-        let t_end = now_ms();
-        let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
 
-        let results = postprocess(
-            views,
-            self.metadata.task,
-            &pre,
-            &config,
-            names,
-            orig_img,
-            String::new(),
-            speed,
-            inference_shape,
-            self.metadata.end2end,
-            self.metadata.kpt_shape,
-        );
+        // Baked-argmax semantic models output a single `[B, H, W] uint8` class map
+        // (ArgMax + Cast folded into the graph). Extract it as `u8` and feed the
+        // dedicated semantic-mask postprocessor instead of the f32 logits path.
+        let results = if self.semantic {
+            let name = &self.output_names[0];
+            let (shape, data) = outputs[name.as_str()]
+                .try_extract_tensor::<u8>()
+                .map_err(|e| JsError::new(&format!("failed to extract output '{name}': {e}")))?;
+            let shape: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+            // Drop the leading batch dim so the shape is `[H, W]` (or pass through).
+            let img_shape: &[usize] = if shape.len() == 3 { &shape[1..] } else { &shape };
+            let t_end = now_ms();
+            let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
+            postprocess_semantic_mask(
+                data,
+                img_shape,
+                names,
+                orig_img,
+                String::new(),
+                speed,
+                inference_shape,
+            )
+        } else {
+            // Borrow each output's data directly (no copy) and feed it to the shared
+            // f32 postprocessor while `outputs` is still alive.
+            let mut views: Vec<(&[f32], Vec<usize>)> =
+                Vec::with_capacity(self.output_names.len());
+            for name in &self.output_names {
+                let (shape, data) = outputs[name.as_str()].try_extract_tensor::<f32>().map_err(
+                    |e| JsError::new(&format!("failed to extract output '{name}': {e}")),
+                )?;
+                views.push((data, shape.iter().map(|&d| d as usize).collect()));
+            }
+            let t_end = now_ms();
+            let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
+            postprocess(
+                views,
+                self.metadata.task,
+                &pre,
+                &config,
+                names,
+                orig_img,
+                String::new(),
+                speed,
+                inference_shape,
+                self.metadata.end2end,
+                self.metadata.kpt_shape,
+            )
+        };
         let payload = JsResults::from_results(&results, self.metadata.task);
         to_js(&payload, "results")
     }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -426,7 +426,11 @@ impl YoloModel {
                 .map_err(|e| JsError::new(&format!("failed to extract output '{name}': {e}")))?;
             let shape: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
             // Drop the leading batch dim so the shape is `[H, W]` (or pass through).
-            let img_shape: &[usize] = if shape.len() == 3 { &shape[1..] } else { &shape };
+            let img_shape: &[usize] = if shape.len() == 3 {
+                &shape[1..]
+            } else {
+                &shape
+            };
             let t_end = now_ms();
             let speed = Speed::new(t_inf - t_pre, t_post - t_inf, t_end - t_post);
             postprocess_semantic_mask(
@@ -441,12 +445,14 @@ impl YoloModel {
         } else {
             // Borrow each output's data directly (no copy) and feed it to the shared
             // f32 postprocessor while `outputs` is still alive.
-            let mut views: Vec<(&[f32], Vec<usize>)> =
-                Vec::with_capacity(self.output_names.len());
+            let mut views: Vec<(&[f32], Vec<usize>)> = Vec::with_capacity(self.output_names.len());
             for name in &self.output_names {
-                let (shape, data) = outputs[name.as_str()].try_extract_tensor::<f32>().map_err(
-                    |e| JsError::new(&format!("failed to extract output '{name}': {e}")),
-                )?;
+                let (shape, data) =
+                    outputs[name.as_str()]
+                        .try_extract_tensor::<f32>()
+                        .map_err(|e| {
+                            JsError::new(&format!("failed to extract output '{name}': {e}"))
+                        })?;
                 views.push((data, shape.iter().map(|&d| d as usize).collect()));
             }
             let t_end = now_ms();

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -202,8 +202,7 @@ pub struct YoloModel {
     /// Active device label (`"webgpu"` or `"cpu"`).
     device: &'static str,
     /// `true` when the ONNX has `ArgMax` + `Cast(uint8)` baked in, so the only
-    /// output is a `[B, H, W] uint8` class map. Lets us skip f32 logits extraction
-    /// and feed the dedicated semantic-mask postprocessor (matches native model.rs).
+    /// output is a `[B, H, W] uint8` class map.
     semantic: bool,
 }
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -416,8 +416,7 @@ impl YoloModel {
         let inference_shape = (self.imgsz.0 as u32, self.imgsz.1 as u32);
 
         // Baked-argmax semantic models output a single `[B, H, W] uint8` class map
-        // (ArgMax + Cast folded into the graph). Extract it as `u8` and feed the
-        // dedicated semantic-mask postprocessor instead of the f32 logits path.
+        // (ArgMax + Cast folded into the graph).
         let results = if self.semantic {
             let name = &self.output_names[0];
             let (shape, data) = outputs[name.as_str()]

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -65,6 +65,8 @@ struct JsProbs {
     top1conf: f32,
     top5conf: Vec<f32>,
     name: String,
+    /// Display names for each `top5` class, so `annotate` can draw the full list.
+    top5names: Vec<String>,
     color: String,
 }
 
@@ -160,6 +162,7 @@ impl JsResults {
             top1conf: p.top1conf(),
             top5conf: p.top5conf(),
             name: name(p.top1()),
+            top5names: p.top5().into_iter().map(name).collect(),
             color: hex(p.top1()),
         });
 

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -90,7 +90,7 @@ pub(crate) struct JsResults {
     /// `Uint16Array`. The IGNORE sentinel `65535` marks background or
     /// class-filtered pixels.
     #[serde(with = "serde_bytes")]
-    semantic: Vec<u8>,
+    semantic_mask: Vec<u8>,
     /// Per-stage timing in ms: `{ preprocess, inference, postprocess }`.
     speed: JsSpeed,
 }
@@ -175,7 +175,7 @@ impl JsResults {
             keypoints,
             probs,
             masks: build_mask_overlay(r),
-            semantic: r.semantic_mask.as_ref().map_or_else(Vec::new, |sem| {
+            semantic_mask: r.semantic_mask.as_ref().map_or_else(Vec::new, |sem| {
                 let mut bytes = Vec::with_capacity(sem.data.len() * 2);
                 for &v in &sem.data {
                     bytes.extend_from_slice(&v.to_le_bytes());

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -27,9 +27,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.23", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.24", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.23", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.24", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` — no extra flags needed.
@@ -59,7 +59,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.23", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.24", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -894,10 +894,6 @@ fn draw_classification(
 
             for &class_id in &top_indices {
                 let score = probs.data[class_id];
-                if score < 0.01 {
-                    continue;
-                }
-
                 let class_name = result.names.get(&class_id).map_or("class", String::as_str);
 
                 let label = format!("{class_name} {score:.2}");

--- a/web/README.md
+++ b/web/README.md
@@ -7,7 +7,8 @@
 [![npm version](https://img.shields.io/npm/v/@ultralytics/yolo?logo=npm&logoColor=white&label=npm&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
 [![npm downloads](https://img.shields.io/npm/dm/@ultralytics/yolo?logo=npm&logoColor=white&label=downloads&color=CB3837)](https://www.npmjs.com/package/@ultralytics/yolo)
 [![CI](https://github.com/ultralytics/inference/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/inference/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/ultralytics/inference/blob/main/LICENSE)
+[![License](https://img.shields.io/npm/l/@ultralytics/yolo?label=license&color=blue)](https://github.com/ultralytics/inference/blob/main/LICENSE)
+[![arXiv](https://img.shields.io/badge/arXiv-2606.03748-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2606.03748)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/web/README.md
+++ b/web/README.md
@@ -135,7 +135,7 @@ Field names match the Rust/Ultralytics `Results` API 1-1:
 | `keypoints`        | `{ points: [x, y, conf][], color }[]`                     | pose                  |
 | `probs`            | `{ top1, top5, top1conf, top5conf, name, color } \| null` | classify              |
 | `masks`            | `Uint8Array` (RGBA overlay, `width*height*4`)             | segment, semantic     |
-| `semantic`         | `Uint16Array` (class id per pixel, `width*height`)        | semantic              |
+| `semantic_mask`    | `Uint16Array` (class id per pixel, `width*height`)        | semantic              |
 | `speed`            | `{ preprocess, inference, postprocess }` ms               | all                   |
 
 `model.names` is the class id to name map (like `model.names` in Python). Every

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -76,6 +76,8 @@ export interface Probs {
   top1conf: number;
   top5conf: number[];
   name: string;
+  /** Display names for each {@link top5} class. */
+  top5names: string[];
   color: string;
 }
 
@@ -380,7 +382,7 @@ function textColorFor(hex: string): string {
  * Draw inference results onto a canvas, on top of the source image.
  *
  * Handles every task: axis-aligned boxes, oriented boxes (OBB), pose keypoints
- * with the COCO skeleton, and a top-1 banner for classification. The canvas is
+ * with the COCO skeleton, and a top-5 list for classification. The canvas is
  * resized to the original image dimensions so detection coordinates line up.
  *
  * ```ts
@@ -496,9 +498,19 @@ export async function annotate(
     ctx.lineWidth = lineWidth;
   }
 
-  // Classification: top-1 banner.
-  if (results.probs) {
-    label(`${results.probs.name} ${(results.probs.top1conf * 100).toFixed(1)}%`, 0, fontSize + 8, results.probs.color);
+  // Classification: top-5 list on a translucent black panel (matches the native
+  // and Python renderers, which list the top classes rather than a single banner).
+  if (results.probs && showLabels) {
+    const { top5, top5conf, top5names } = results.probs;
+    const lines = top5.map((_, i) => `${top5names[i] ?? top5[i]} ${top5conf[i].toFixed(2)}`);
+    const pad = Math.round(fontSize * 0.3);
+    const lineH = Math.round(fontSize * 1.25);
+    const boxW = Math.max(...lines.map((t) => ctx.measureText(t).width)) + pad * 2;
+    const boxH = lines.length * lineH + pad * 2;
+    ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+    ctx.fillRect(pad, pad, boxW, boxH);
+    ctx.fillStyle = "#ffffff";
+    lines.forEach((t, i) => ctx.fillText(t, pad * 2, pad * 2 + i * lineH));
   }
 }
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -104,7 +104,7 @@ export interface Results {
    * `undefined` for other tasks. The sentinel `65535` marks background or
    * class-filtered pixels. The `masks` overlay is its renderable form.
    */
-  semantic?: Uint16Array;
+  semantic_mask?: Uint16Array;
   speed: Speed;
 }
 
@@ -165,13 +165,13 @@ function resolveModel(src: string): string {
 }
 
 /**
- * Reinterpret the wasm payload's little-endian `semantic` bytes as a
+ * Reinterpret the wasm payload's little-endian `semantic_mask` bytes as a
  * `Uint16Array` of class ids (a zero-copy view), leaving every other field as-is.
  */
 function decodeResults(raw: unknown): Results {
-  const r = raw as Results & { semantic?: Uint8Array | Uint16Array };
-  const sem = r.semantic as Uint8Array | undefined;
-  r.semantic = sem && sem.length ? new Uint16Array(sem.buffer, sem.byteOffset, sem.length / 2) : undefined;
+  const r = raw as Results & { semantic_mask?: Uint8Array | Uint16Array };
+  const sem = r.semantic_mask as Uint8Array | undefined;
+  r.semantic_mask = sem && sem.length ? new Uint16Array(sem.buffer, sem.byteOffset, sem.length / 2) : undefined;
   return r as Results;
 }
 


### PR DESCRIPTION

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR releases `ultralytics-inference` `0.0.24` 🚀, improving web/browser inference for semantic segmentation and classification visualization while also refreshing package/docs metadata.

### 📊 Key Changes
- Bumped the Rust and web package versions from `0.0.23` to `0.0.24` 📦
- Added smarter web handling for semantic segmentation models that output a precomputed class map (`uint8`) instead of raw float outputs 🧠
- Updated web inference to route these semantic outputs through a dedicated semantic mask postprocessing path, matching native behavior 🌐
- Renamed the web results field from `semantic` to `semantic_mask` for clearer API naming and consistency 🏷️
- Expanded classification results in the web payload to include `top5names`, not just class IDs and scores 📋
- Improved browser annotation for classification: it now shows a top-5 list instead of only a top-1 banner 🎨
- Removed the native annotation threshold that hid low-confidence top classification entries, allowing fuller top-class display 🔍
- Refreshed README/docs badges and dependency examples, including updated docs.rs/license badges and an arXiv badge 📚

### 🎯 Purpose & Impact
- Better support for semantic segmentation models in the browser means fewer output-format issues and more reliable results for web users ✅
- Matching web behavior with native inference reduces inconsistencies across platforms, making integrations easier 🤝
- The `semantic_mask` rename makes the output clearer for developers consuming the web API, though it may require small client-side updates if they used the old field name ⚠️
- Showing top-5 classification results gives users richer and more informative predictions, especially for close or ambiguous classes 👀
- The `0.0.24` release also improves project polish through clearer docs and package metadata, making adoption a bit smoother for new users ✨
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
