### PR TITLE
📝 docs(web): clearer LiteRT.js setup and examples

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -213,11 +213,13 @@ code as above:
 
 ```html
 <script type="importmap">
-  { "imports": {
-    "@ultralytics/yolo": "https://esm.sh/@ultralytics/yolo",
-    "@litertjs/core": "https://esm.sh/@litertjs/core",
-    "@litertjs/wasm-utils": "https://esm.sh/@litertjs/wasm-utils"
-  } }
+  {
+    "imports": {
+      "@ultralytics/yolo": "https://esm.sh/@ultralytics/yolo",
+      "@litertjs/core": "https://esm.sh/@litertjs/core",
+      "@litertjs/wasm-utils": "https://esm.sh/@litertjs/wasm-utils"
+    }
+  }
 </script>
 ```
 

--- a/web/README.md
+++ b/web/README.md
@@ -97,9 +97,9 @@ async function frame() {
 <br>
 <br>
 
-Runs [YOLOv8](https://docs.ultralytics.com/models/yolov8),
-[YOLO11](https://docs.ultralytics.com/models/yolo11), and
-[YOLO26](https://docs.ultralytics.com/models/yolo26) ONNX exports for detection,
+Runs [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8),
+[Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11), and
+[Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26) ONNX exports for detection,
 segmentation, pose, OBB, classification, and semantic segmentation.
 
 Pass a bare ONNX name and it is **auto-downloaded** from the
@@ -110,8 +110,8 @@ same weights the native crate and Python use):
 await YOLO.load("yolo26n.onnx"); // auto-downloads from the release: .../download/v8.4.0/yolo26n.onnx
 ```
 
-Auto-download covers **yolo26**, **yolo11**, and **yolov8** in sizes `n/s/m/l/x`
-with task suffixes `-seg`, `-pose`, `-cls`, `-obb`, and `-sem` (semantic, yolo26
+Auto-download covers **Ultralytics YOLO26**, **Ultralytics YOLO11**, and **Ultralytics YOLOv8** in sizes `n/s/m/l/x`
+with task suffixes `-seg`, `-pose`, `-cls`, `-obb`, and `-sem` (semantic, Ultralytics YOLO26
 only). A value containing a `/` or a scheme is used as a URL/path as-is.
 
 > **CORS note:** GitHub release assets do not send `Access-Control-Allow-Origin`,
@@ -243,7 +243,7 @@ Notes:
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
-- **Export end2end-free models** (`end2end=False`): YOLO26 defaults to an
+- **Export end2end-free models** (`end2end=False`): Ultralytics YOLO26 defaults to an
   end-to-end, NMS-free head whose `int64` / `gather_nd` ops the LiteRT
   **WebGPU** delegate cannot run, so those exports silently fall back to CPU/wasm.
   Export them with `end2end=False` so the standard head is used and NMS runs in

--- a/web/README.md
+++ b/web/README.md
@@ -243,8 +243,8 @@ Notes:
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
-- **Export end2end-free models** (`end2end=False`): YOLO26 (and YOLOv10) default
-  to an end-to-end, NMS-free head whose `int64` / `gather_nd` ops the LiteRT
+- **Export end2end-free models** (`end2end=False`): YOLO26 defaults to an
+  end-to-end, NMS-free head whose `int64` / `gather_nd` ops the LiteRT
   **WebGPU** delegate cannot run, so those exports silently fall back to CPU/wasm.
   Export them with `end2end=False` so the standard head is used and NMS runs in
   this package's Rust, keeping inference on WebGPU:

--- a/web/README.md
+++ b/web/README.md
@@ -192,7 +192,8 @@ path.
 
 The backend is picked from the file extension: a `.tflite` runs on LiteRT.js, a
 `.onnx` on ONNX Runtime Web. The LiteRT.js wasm loads from a CDN by default, so
-the only setup is making the `@litertjs/core` module resolve.
+the only setup is making `@litertjs/core` resolve (along with its `@litertjs/wasm-utils`
+dependency, which npm installs automatically and the import map below lists explicitly).
 
 **With npm (a bundler):**
 

--- a/web/README.md
+++ b/web/README.md
@@ -211,16 +211,24 @@ CDN by default):
 - **The wasm assets** default to the jsDelivr CDN, so nothing to host. Override
   with `litertWasmUrl` only to self-host (copy `node_modules/@litertjs/core/wasm/`).
 
+Then it is the same API as the `ort` path, just a `.tflite` model:
+
 ```ts
 import { YOLO, annotate } from "@ultralytics/yolo";
 
-const model = await YOLO.load("/models/yolo26n.tflite"); // wasm from the CDN by default
-// Or self-host the wasm:
-// const model = await YOLO.load("/models/yolo26n.tflite", { litertWasmUrl: "/litert/" });
-
-const results = await model.predict(video); // same API, same Results
-console.log(model.device); // "webgpu" or "wasm"
+const model = await YOLO.load("/models/yolo26n.tflite"); // .tflite -> LiteRT.js, wasm from the CDN
+const results = await model.predict("bus.jpg");
+await annotate(document.querySelector("canvas"), "bus.jpg", results);
 ```
+
+For webcam or video, pass the `<video>` element each frame:
+
+```ts
+const results = await model.predict(video);
+await annotate(canvas, video, results);
+```
+
+To self-host the wasm instead of the CDN, pass `litertWasmUrl: "/litert/"` to `YOLO.load`.
 
 Notes:
 

--- a/web/README.md
+++ b/web/README.md
@@ -190,35 +190,35 @@ Only the inference engine changes; the preprocessing, postprocessing, drawing,
 and `Results` shape are the same shared Rust code, so output matches the `ort`
 path.
 
-It is picked automatically from the file extension: pass a `.tflite` to
-`YOLO.load` and it runs on LiteRT.js (a `.onnx` runs on ONNX Runtime Web). Two
-pieces of LiteRT.js are needed, and the **wasm needs no setup** (it loads from a
-CDN by default):
+The backend is picked from the file extension: a `.tflite` runs on LiteRT.js, a
+`.onnx` on ONNX Runtime Web. The LiteRT.js wasm loads from a CDN by default, so
+the only setup is making the `@litertjs/core` module resolve.
 
-- **The `@litertjs/core` module** must resolve. With a bundler, install it:
-  ```bash
-  npm install @litertjs/core
-  ```
-  With no build step, map it to a CDN instead (no install):
-  ```html
-  <script type="importmap">
-    { "imports": {
-      "@litertjs/core": "https://esm.sh/@litertjs/core",
-      "@litertjs/wasm-utils": "https://esm.sh/@litertjs/wasm-utils"
-    } }
-  </script>
-  ```
-- **The wasm assets** default to the jsDelivr CDN, so nothing to host. Override
-  with `litertWasmUrl` only to self-host (copy `node_modules/@litertjs/core/wasm/`).
+**With npm (a bundler):**
 
-Then it is the same API as the `ort` path, just a `.tflite` model:
+```bash
+npm install @ultralytics/yolo @litertjs/core
+```
 
 ```ts
 import { YOLO, annotate } from "@ultralytics/yolo";
 
-const model = await YOLO.load("/models/yolo26n.tflite"); // .tflite -> LiteRT.js, wasm from the CDN
+const model = await YOLO.load("/models/yolo26n.tflite"); // .tflite -> LiteRT.js
 const results = await model.predict("bus.jpg");
 await annotate(document.querySelector("canvas"), "bus.jpg", results);
+```
+
+**Without a build step (CDN):** map the modules to a CDN, then use the exact same
+code as above:
+
+```html
+<script type="importmap">
+  { "imports": {
+    "@ultralytics/yolo": "https://esm.sh/@ultralytics/yolo",
+    "@litertjs/core": "https://esm.sh/@litertjs/core",
+    "@litertjs/wasm-utils": "https://esm.sh/@litertjs/wasm-utils"
+  } }
+</script>
 ```
 
 For webcam or video, pass the `<video>` element each frame:
@@ -228,7 +228,8 @@ const results = await model.predict(video);
 await annotate(canvas, video, results);
 ```
 
-To self-host the wasm instead of the CDN, pass `litertWasmUrl: "/litert/"` to `YOLO.load`.
+The wasm loads from the jsDelivr CDN by default; pass `litertWasmUrl: "/litert/"` to
+`YOLO.load` to self-host it (copy `node_modules/@litertjs/core/wasm/`).
 
 Notes:
 

--- a/web/README.md
+++ b/web/README.md
@@ -191,21 +191,32 @@ and `Results` shape are the same shared Rust code, so output matches the `ort`
 path.
 
 It is picked automatically from the file extension: pass a `.tflite` to
-`YOLO.load` and it runs on LiteRT.js (a `.onnx` runs on ONNX Runtime Web). The
-only setup is the optional peer dependency.
+`YOLO.load` and it runs on LiteRT.js (a `.onnx` runs on ONNX Runtime Web). Two
+pieces of LiteRT.js are needed, and the **wasm needs no setup** (it loads from a
+CDN by default):
 
-```bash
-npm install @litertjs/core # optional peer dependency, only for .tflite models
-```
+- **The `@litertjs/core` module** must resolve. With a bundler, install it:
+  ```bash
+  npm install @litertjs/core
+  ```
+  With no build step, map it to a CDN instead (no install):
+  ```html
+  <script type="importmap">
+    { "imports": {
+      "@litertjs/core": "https://esm.sh/@litertjs/core",
+      "@litertjs/wasm-utils": "https://esm.sh/@litertjs/wasm-utils"
+    } }
+  </script>
+  ```
+- **The wasm assets** default to the jsDelivr CDN, so nothing to host. Override
+  with `litertWasmUrl` only to self-host (copy `node_modules/@litertjs/core/wasm/`).
 
 ```ts
 import { YOLO, annotate } from "@ultralytics/yolo";
 
-const model = await YOLO.load("/models/yolo26n.tflite", {
-  // LiteRT.js wasm assets; defaults to the jsDelivr CDN. Self-host by copying
-  // node_modules/@litertjs/core/wasm/ and pointing here (URL ending in `/`).
-  litertWasmUrl: "/litert/",
-});
+const model = await YOLO.load("/models/yolo26n.tflite"); // wasm from the CDN by default
+// Or self-host the wasm:
+// const model = await YOLO.load("/models/yolo26n.tflite", { litertWasmUrl: "/litert/" });
 
 const results = await model.predict(video); // same API, same Results
 console.log(model.device); // "webgpu" or "wasm"


### PR DESCRIPTION
Tidies up the LiteRT.js section of the web README:

- The wasm loads from the jsDelivr CDN by default, so `litertWasmUrl` is optional (it was shown as if required).
- Splits setup into an npm route and a no-build CDN (import map) route.
- The example now mirrors the ONNX quick-start, with a `bus.jpg` image and a webcam/video snippet.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refreshes the web README to clarify model branding and greatly improve setup instructions for running Ultralytics YOLO models in the browser with ONNX or TFLite/LiteRT.js 🚀

### 📊 Key Changes
- Updated README model names to use clearer **Ultralytics YOLOv8**, **Ultralytics YOLO11**, and **Ultralytics YOLO26** branding 🏷️
- Clarified that browser auto-download supports multiple Ultralytics model families, sizes, and task variants like detection, segmentation, pose, OBB, classification, and semantic segmentation 📦
- Reworked the **TFLite/LiteRT.js web usage docs** to better explain how backend selection works:
  - `.tflite` files use **LiteRT.js**
  - `.onnx` files use **ONNX Runtime Web**
- Added simpler installation instructions for **npm/bundler setups** with `@ultralytics/yolo` and `@litertjs/core` 🛠️
- Added a new **no-build-step/CDN example** using an import map, making browser usage easier for lightweight demos and prototypes 🌐
- Simplified code examples for loading models, running predictions, and annotating results on images or video 🎥
- Expanded guidance on LiteRT.js wasm loading:
  - default CDN behavior
  - how to self-host wasm assets if needed
- Improved notes around **TFLite export compatibility**, including:
  - required Ultralytics export version support
  - recommendation to export **Ultralytics YOLO26** with `end2end=False` for better WebGPU performance and to avoid CPU fallback ⚡

### 🎯 Purpose & Impact
- Makes the web documentation easier to follow for both new and experienced users 📘
- Reduces confusion around which runtime is used for `.onnx` vs `.tflite` models, helping developers set up browser inference faster ✅
- Lowers the barrier to entry for browser deployment by adding both **bundler** and **CDN-only** workflows 🙌
- Helps users avoid performance pitfalls when exporting TFLite models, especially for **Ultralytics YOLO26** on WebGPU ⚙️
- Improves consistency in Ultralytics branding and model naming across documentation, which makes the project feel clearer and more polished ✨