### PR TITLE
build(deps): ⬆️  bump miniz_oxide from 0.8 to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -701,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -1405,6 +1405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,7 +1823,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2646,7 +2655,7 @@ dependencies = [
  "half",
  "image",
  "js-sys",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "ndarray",
  "ort",
  "ort-web",

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -46,7 +46,7 @@ serde_bytes = "0.11"
 serde-wasm-bindgen = "0.6"
 # Read the `metadata.json` embedded in a single-file `.tflite` (see tflite_meta).
 serde_json = "1"
-miniz_oxide = "0.8"
+miniz_oxide = "0.9"
 console_error_panic_hook = "0.1"
 ndarray = "0.17"
 half = "2.7"


### PR DESCRIPTION
Bumps the web crate's `miniz_oxide` from 0.8 to 0.9 (used for the `.tflite` metadata inflate). The `decompress_to_vec_with_limit` API is unchanged and the wasm builds and clippies clean.

Note: `image`'s PNG decoder still depends on 0.8, so the lockfile carries both versions until `image` bumps.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the `miniz_oxide` dependency in the web crate from `0.8` to `0.9`, mainly to keep compression-related tooling current and compatible.

### 📊 Key Changes
- Bumped `miniz_oxide` in `crates/web/Cargo.toml` from `0.8` to `0.9` 📦
- Updated the corresponding lockfile entries in `Cargo.lock` to reflect the new resolved dependency versions 🔄
- No application logic or API behavior changes were introduced in the diff shown ✅

### 🎯 Purpose & Impact
- Keeps the web crate’s dependency stack more up to date and maintainable 🛠️
- May bring upstream fixes, compatibility improvements, or minor performance/stability benefits from the newer `miniz_oxide` release 🚀
- Low-risk change for users, since it is limited to a dependency version bump rather than feature or code-path changes 👍
- Helps reduce technical debt and supports healthier long-term builds in the `ultralytics/inference` web components 🌐
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
