### PR TITLE
🚀 Release v0.0.26: LiteRT.js backend documentation fixes and file/blob support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,7 +2622,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.25 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -194,7 +194,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.25 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -290,7 +290,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.25"
+ultralytics-inference = "0.0.26"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,7 +173,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.25 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -193,7 +193,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.25 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -289,7 +289,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.25"
+ultralytics-inference = "0.0.26"
 ```
 
 ```toml

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -27,9 +27,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.25", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.26", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.25", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.26", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` — no extra flags needed.
@@ -59,7 +59,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.25", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.26", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump to 0.0.26. Highlights since 0.0.25:

- New optional LiteRT.js backend: run Ultralytics `.tflite` exports in the browser, auto-detected from the model, on WebGPU where supported.
- `YOLO.load` now accepts a `Blob`/`File`, so a dropped or picked model loads directly.
- Bumped `miniz_oxide` to 0.9.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 This PR is a version bump release that updates `ultralytics-inference` and related packages from `0.0.25` to `0.0.26`, with matching documentation and package metadata updates.

### 📊 Key Changes
- ⬆️ Updated the core Rust crate version in `Cargo.toml` from `0.0.25` to `0.0.26`.
- 🌐 Updated the web/WASM package version in `crates/web/Cargo.toml` to `0.0.26`.
- 📦 Updated the npm package `@ultralytics/yolo` in `web/package.json` to `0.0.26`.
- 📝 Refreshed README examples and installation snippets in both English and Chinese to reference `0.0.26`.
- ⚙️ Updated CUDA setup documentation so dependency examples now point to `0.0.26`.
- 🔒 Regenerated lockfiles (`Cargo.lock` and `web/package-lock.json`) to match the new release state.

### 🎯 Purpose & Impact
- 🚀 Prepares and publishes a new `0.0.26` release across Rust and web packages.
- ✅ Keeps versioning consistent across code, docs, CLI output, and package managers.
- 📚 Reduces user confusion by ensuring installation instructions match the latest release.
- 🧩 Makes it easier for developers to adopt the newest package version in Rust, CUDA, and browser-based workflows.
- ⚠️ This PR does **not** introduce visible feature changes or behavior changes by itself; its main impact is release packaging and documentation alignment.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
