### PR TITLE
Bump taiki-e/install-action from v2.82.6 to v2.82.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: wasm-pack
 
@@ -279,7 +279,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.6 to v2.82.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates GitHub Actions tooling for Rust/WASM builds and coverage from `taiki-e/install-action` v2.82.6 to v2.82.7 🔧

### 📊 Key Changes
- Updated `taiki-e/install-action` in CI workflow for installing `wasm-pack` 🧱
- Updated `taiki-e/install-action` in CI workflow for installing `cargo-llvm-cov` 📈
- Updated the same `wasm-pack` installer action in the npm publish workflow 📦
- Changes are pinned by commit hash for reproducible and secure workflow execution 🔒

### 🎯 Purpose & Impact
- Keeps CI and release automation up to date with the latest patch version ✅
- Improves reliability and maintainability of Rust/WASM build, test, coverage, and npm publishing pipelines 🚀
- No direct user-facing behavior changes expected; impact is mainly behind the scenes for developers and release infrastructure 🛠️