### PR TITLE
Improve coverage accounting for runtime paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lints.rust]
 unsafe_code = "warn"
 missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [lints.clippy]
 all = "warn"

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -502,17 +502,18 @@ const fn precision_label(is_half: bool) -> &'static str {
 }
 
 fn provider_label(provider: &str) -> &'static str {
-    if provider.contains("CoreML") {
+    let provider = provider.to_ascii_lowercase();
+    if provider.contains("coreml") {
         "CoreML"
-    } else if provider.contains("CUDA") {
+    } else if provider.contains("cuda") {
         "CUDA"
-    } else if provider.contains("TensorRT") {
+    } else if provider.contains("tensorrt") {
         "TensorRT"
-    } else if provider.contains("DirectML") {
+    } else if provider.contains("directml") {
         "DirectML"
-    } else if provider.contains("ROCm") {
+    } else if provider.contains("rocm") {
         "ROCm"
-    } else if provider.contains("OpenVINO") {
+    } else if provider.contains("openvino") {
         "OpenVINO"
     } else {
         "CPU"
@@ -730,7 +731,7 @@ mod tests {
         assert_eq!(precision_label(true), "FP16");
         assert_eq!(provider_label("CoreMLExecutionProvider"), "CoreML");
         assert_eq!(provider_label("CUDAExecutionProvider"), "CUDA");
-        assert_eq!(provider_label("TensorrtExecutionProvider"), "CPU");
+        assert_eq!(provider_label("TensorrtExecutionProvider"), "TensorRT");
         assert_eq!(provider_label("TensorRTExecutionProvider"), "TensorRT");
         assert_eq!(provider_label("DirectMLExecutionProvider"), "DirectML");
         assert_eq!(provider_label("ROCmExecutionProvider"), "ROCm");

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -18,9 +18,13 @@ use crate::{DISPLAY_NAME, InferenceConfig, Results, VERSION, YOLOModel};
 
 use crate::batch::BatchProcessor;
 use crate::cli::args::PredictArgs;
+use crate::task::Task;
 use crate::{error, verbose, warn};
 
+const DEFAULT_OBB_IMAGES: &[&str] = &[crate::download::DEFAULT_OBB_IMAGE];
+
 /// Run YOLO model inference.
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(
     clippy::too_many_lines,
     clippy::option_if_let_else,
@@ -32,27 +36,17 @@ use crate::{error, verbose, warn};
 )]
 pub fn run_prediction(args: &PredictArgs) {
     // Parse arguments - use default model if not specified
-    let model_is_default = args.model.is_none();
-    let model_path = args.model.clone().unwrap_or_else(|| {
-        args.task
-            .unwrap_or(crate::task::Task::Detect)
-            .default_model()
-    });
+    let (model_path, model_is_default) = resolve_model_path(args);
     let source_path = &args.source;
-    let conf_threshold = args.conf;
-    let iou_threshold = args.iou;
-    let imgsz = args.imgsz;
     let save = args.save;
     let save_frames = args.save_frames;
     let save_json = args.save_json;
     let half = args.half;
     let verbose = args.verbose;
     let batch_size = args.batch as usize;
-    let device: Option<crate::Device> = args.device.as_deref().map(|d| {
-        d.parse().unwrap_or_else(|e| {
-            error!("Invalid device '{d}': {e}");
-            process::exit(1);
-        })
+    let device = parse_device_arg(args.device.as_deref()).unwrap_or_else(|e| {
+        error!("{e}");
+        process::exit(1);
     });
     #[cfg(feature = "visualize")]
     let show = args.show;
@@ -61,39 +55,10 @@ pub fn run_prediction(args: &PredictArgs) {
     }
 
     // Load model first so we can determine appropriate default source based on task
-    let mut config = InferenceConfig::new()
-        .with_confidence(conf_threshold)
-        .with_iou(iou_threshold)
-        .with_half(half)
-        .with_batch(batch_size)
-        .with_save_frames(save_frames)
-        .with_rect(args.rect)
-        .with_max_det(args.max_det);
-
-    // Apply imgsz if specified
-    if let Some(sz) = imgsz {
-        config = config.with_imgsz(sz, sz);
-    }
-
-    // Apply device if specified
-    if let Some(d) = &device {
-        config = config.with_device(d.clone());
-    }
-
-    // Apply class filter if specified
-    if let Some(classes_str) = &args.classes {
-        match crate::cli::args::parse_classes(classes_str) {
-            Ok(classes) => {
-                if !classes.is_empty() {
-                    config = config.with_classes(classes);
-                }
-            }
-            Err(e) => {
-                error!("Error parsing classes: {e}");
-                process::exit(1);
-            }
-        }
-    }
+    let config = build_inference_config(args, device).unwrap_or_else(|e| {
+        error!("{e}");
+        process::exit(1);
+    });
 
     let mut model = match YOLOModel::load_with_config(model_path, config) {
         Ok(m) => m,
@@ -123,10 +88,7 @@ pub fn run_prediction(args: &PredictArgs) {
     let source = source_path.as_ref().map_or_else(
         || {
             // Select default images based on model task
-            let default_urls = match model.task() {
-                crate::task::Task::Obb => &[crate::download::DEFAULT_OBB_IMAGE],
-                _ => crate::download::DEFAULT_IMAGES,
-            };
+            let default_urls = default_source_urls(model.task());
 
             if verbose {
                 warn!(
@@ -163,20 +125,10 @@ pub fn run_prediction(args: &PredictArgs) {
 
     // Determine whether we need an incremented predict dir. `--save` always needs one
     // when annotation support is compiled in; semantic class-map export also needs one.
-    #[cfg(feature = "annotate")]
-    let need_predict_dir = save || (save_json && model.task() == crate::task::Task::Semantic);
-    #[cfg(not(feature = "annotate"))]
-    let need_predict_dir = save_json && model.task() == crate::task::Task::Semantic;
+    let need_predict_dir = needs_predict_dir(save, save_json, model.task());
 
     let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
-        let parent_dir = match model.task() {
-            crate::task::Task::Detect => "runs/detect",
-            crate::task::Task::Segment => "runs/segment",
-            crate::task::Task::Pose => "runs/pose",
-            crate::task::Task::Classify => "runs/classify",
-            crate::task::Task::Obb => "runs/obb",
-            crate::task::Task::Semantic => "runs/semantic",
-        };
+        let parent_dir = predict_parent_dir(model.task());
         let dir = find_next_run_dir(parent_dir, "predict");
         if let Err(e) = crate::io::ensure_dir(Path::new(&dir)) {
             error!("Failed to create save directory '{dir}': {e}");
@@ -189,7 +141,7 @@ pub fn run_prediction(args: &PredictArgs) {
 
     // Per-image semantic class maps go in `<save_dir>/results/<stem>.png`.
     let results_dir: Option<std::path::PathBuf> = save_dir.as_ref().and_then(|d| {
-        if !save_json || model.task() != crate::task::Task::Semantic {
+        if !needs_results_dir(save_json, model.task()) {
             return None;
         }
         let dir = d.join("results");
@@ -211,25 +163,8 @@ pub fn run_prediction(args: &PredictArgs) {
     }
 
     let is_half = model.metadata().half || half;
-    let precision = if is_half { "FP16" } else { "FP32" };
-    let device_str = {
-        let provider = model.execution_provider();
-        if provider.contains("CoreML") {
-            "CoreML".to_string()
-        } else if provider.contains("CUDA") {
-            "CUDA".to_string()
-        } else if provider.contains("TensorRT") {
-            "TensorRT".to_string()
-        } else if provider.contains("DirectML") {
-            "DirectML".to_string()
-        } else if provider.contains("ROCm") {
-            "ROCm".to_string()
-        } else if provider.contains("OpenVINO") {
-            "OpenVINO".to_string()
-        } else {
-            "CPU".to_string()
-        }
-    };
+    let precision = precision_label(is_half);
+    let device_str = provider_label(model.execution_provider());
     println!("{DISPLAY_NAME} {VERSION} 🚀 Rust ONNX {precision} {device_str}");
     println!("Using ONNX Runtime {}", model.execution_provider());
 
@@ -351,16 +286,8 @@ pub fn run_prediction(args: &PredictArgs) {
                         {
                             // For video/webcam sources every frame shares the same path stem,
                             // so append the frame index to avoid overwriting earlier frames.
-                            let base_stem =
-                                std::path::Path::new(image_path).file_stem().map_or_else(
-                                    || "frame".to_owned(),
-                                    |s| s.to_string_lossy().into_owned(),
-                                );
-                            let stem = if meta.total_frames == Some(1) {
-                                base_stem
-                            } else {
-                                format!("{base_stem}_{:06}", meta.frame_idx)
-                            };
+                            let stem =
+                                semantic_output_stem(image_path, meta.frame_idx, meta.total_frames);
                             let out_path = cdir.join(format!("{stem}.png"));
                             let (h, w) = (sm.data.shape()[0], sm.data.shape()[1]);
                             let max_id = sm.data.iter().copied().max().unwrap_or(0);
@@ -489,6 +416,120 @@ pub fn run_prediction(args: &PredictArgs) {
     verbose!("💡 Learn more at https://docs.ultralytics.com/modes/predict");
 }
 
+fn resolve_model_path(args: &PredictArgs) -> (String, bool) {
+    let model_is_default = args.model.is_none();
+    let model_path = args
+        .model
+        .clone()
+        .unwrap_or_else(|| args.task.unwrap_or(Task::Detect).default_model());
+    (model_path, model_is_default)
+}
+
+fn parse_device_arg(device: Option<&str>) -> Result<Option<crate::Device>, String> {
+    device
+        .map(|d| d.parse().map_err(|e| format!("Invalid device '{d}': {e}")))
+        .transpose()
+}
+
+fn build_inference_config(
+    args: &PredictArgs,
+    device: Option<crate::Device>,
+) -> Result<InferenceConfig, String> {
+    let mut config = InferenceConfig::new()
+        .with_confidence(args.conf)
+        .with_iou(args.iou)
+        .with_half(args.half)
+        .with_batch(args.batch as usize)
+        .with_save_frames(args.save_frames)
+        .with_rect(args.rect)
+        .with_max_det(args.max_det);
+
+    if let Some(sz) = args.imgsz {
+        config = config.with_imgsz(sz, sz);
+    }
+
+    if let Some(d) = device {
+        config = config.with_device(d);
+    }
+
+    if let Some(classes_str) = &args.classes {
+        let classes = crate::cli::args::parse_classes(classes_str)
+            .map_err(|e| format!("Error parsing classes: {e}"))?;
+        if !classes.is_empty() {
+            config = config.with_classes(classes);
+        }
+    }
+
+    Ok(config)
+}
+
+const fn default_source_urls(task: Task) -> &'static [&'static str] {
+    match task {
+        Task::Obb => DEFAULT_OBB_IMAGES,
+        _ => crate::download::DEFAULT_IMAGES,
+    }
+}
+
+fn needs_predict_dir(save: bool, save_json: bool, task: Task) -> bool {
+    #[cfg(feature = "annotate")]
+    {
+        save || needs_results_dir(save_json, task)
+    }
+    #[cfg(not(feature = "annotate"))]
+    {
+        let _ = save;
+        needs_results_dir(save_json, task)
+    }
+}
+
+const fn predict_parent_dir(task: Task) -> &'static str {
+    match task {
+        Task::Detect => "runs/detect",
+        Task::Segment => "runs/segment",
+        Task::Pose => "runs/pose",
+        Task::Classify => "runs/classify",
+        Task::Obb => "runs/obb",
+        Task::Semantic => "runs/semantic",
+    }
+}
+
+fn needs_results_dir(save_json: bool, task: Task) -> bool {
+    save_json && task == Task::Semantic
+}
+
+const fn precision_label(is_half: bool) -> &'static str {
+    if is_half { "FP16" } else { "FP32" }
+}
+
+fn provider_label(provider: &str) -> &'static str {
+    if provider.contains("CoreML") {
+        "CoreML"
+    } else if provider.contains("CUDA") {
+        "CUDA"
+    } else if provider.contains("TensorRT") {
+        "TensorRT"
+    } else if provider.contains("DirectML") {
+        "DirectML"
+    } else if provider.contains("ROCm") {
+        "ROCm"
+    } else if provider.contains("OpenVINO") {
+        "OpenVINO"
+    } else {
+        "CPU"
+    }
+}
+
+fn semantic_output_stem(image_path: &str, frame_idx: usize, total_frames: Option<usize>) -> String {
+    let base_stem = std::path::Path::new(image_path)
+        .file_stem()
+        .map_or_else(|| "frame".to_owned(), |s| s.to_string_lossy().into_owned());
+    if total_frames == Some(1) {
+        base_stem
+    } else {
+        format!("{base_stem}_{frame_idx:06}")
+    }
+}
+
 /// Count detections per class and format as summary string (e.g., "4 persons, 1 bus").
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn format_detection_summary(result: &Results) -> String {
@@ -514,6 +555,203 @@ mod tests {
 
     fn create_dummy_image() -> Array3<u8> {
         Array3::zeros((100, 100, 3))
+    }
+
+    fn predict_args() -> PredictArgs {
+        PredictArgs {
+            model: None,
+            task: None,
+            source: None,
+            conf: InferenceConfig::DEFAULT_CONF,
+            iou: InferenceConfig::DEFAULT_IOU,
+            max_det: InferenceConfig::DEFAULT_MAX_DET,
+            imgsz: None,
+            rect: InferenceConfig::DEFAULT_RECT,
+            batch: 1,
+            half: InferenceConfig::DEFAULT_HALF,
+            save: InferenceConfig::DEFAULT_SAVE,
+            save_frames: InferenceConfig::DEFAULT_SAVE_FRAMES,
+            save_json: false,
+            show: false,
+            device: None,
+            verbose: true,
+            classes: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_model_path_uses_detect_default() {
+        let args = predict_args();
+
+        let (model_path, model_is_default) = resolve_model_path(&args);
+
+        assert_eq!(model_path, "yolo26n.onnx");
+        assert!(model_is_default);
+    }
+
+    #[test]
+    fn test_resolve_model_path_uses_task_default() {
+        let args = PredictArgs {
+            task: Some(Task::Semantic),
+            ..predict_args()
+        };
+
+        let (model_path, model_is_default) = resolve_model_path(&args);
+
+        assert_eq!(model_path, "yolo26n-sem.onnx");
+        assert!(model_is_default);
+    }
+
+    #[test]
+    fn test_resolve_model_path_keeps_explicit_model() {
+        let args = PredictArgs {
+            model: Some("custom.onnx".to_string()),
+            task: Some(Task::Pose),
+            ..predict_args()
+        };
+
+        let (model_path, model_is_default) = resolve_model_path(&args);
+
+        assert_eq!(model_path, "custom.onnx");
+        assert!(!model_is_default);
+    }
+
+    #[test]
+    fn test_parse_device_arg() {
+        assert_eq!(parse_device_arg(None).unwrap(), None);
+        assert_eq!(
+            parse_device_arg(Some("cuda:2")).unwrap(),
+            Some(crate::Device::Cuda(2))
+        );
+
+        let err = parse_device_arg(Some("neural")).unwrap_err();
+        assert!(err.contains("Invalid device 'neural'"));
+        assert!(err.contains("Unknown device: neural"));
+    }
+
+    #[test]
+    fn test_build_inference_config_from_cli_args() {
+        let args = PredictArgs {
+            conf: 0.42,
+            iou: 0.55,
+            max_det: 77,
+            imgsz: Some(512),
+            rect: false,
+            batch: 4,
+            half: true,
+            save_frames: true,
+            classes: Some("[0, 2, 5]".to_string()),
+            ..predict_args()
+        };
+
+        let config = build_inference_config(&args, Some(crate::Device::OpenVino)).unwrap();
+
+        assert!((config.confidence_threshold - 0.42).abs() < f32::EPSILON);
+        assert!((config.iou_threshold - 0.55).abs() < f32::EPSILON);
+        assert_eq!(config.max_det, 77);
+        assert_eq!(config.imgsz, Some((512, 512)));
+        assert_eq!(config.batch, Some(4));
+        assert!(config.half);
+        assert_eq!(config.device, Some(crate::Device::OpenVino));
+        assert!(config.save_frames);
+        assert!(!config.rect);
+        assert_eq!(config.classes, Some(vec![0, 2, 5]));
+    }
+
+    #[test]
+    fn test_build_inference_config_ignores_empty_class_filter() {
+        let args = PredictArgs {
+            classes: Some("[]".to_string()),
+            ..predict_args()
+        };
+
+        let config = build_inference_config(&args, None).unwrap();
+
+        assert!(config.classes.is_none());
+    }
+
+    #[test]
+    fn test_build_inference_config_rejects_invalid_classes() {
+        let args = PredictArgs {
+            classes: Some("0,truck".to_string()),
+            ..predict_args()
+        };
+
+        let err = build_inference_config(&args, None).unwrap_err();
+
+        assert!(err.contains("Error parsing classes"));
+        assert!(err.contains("Invalid class ID 'truck'"));
+    }
+
+    #[test]
+    fn test_default_source_urls_are_task_specific() {
+        assert_eq!(
+            default_source_urls(Task::Detect),
+            crate::download::DEFAULT_IMAGES
+        );
+        assert_eq!(
+            default_source_urls(Task::Segment),
+            crate::download::DEFAULT_IMAGES
+        );
+        assert_eq!(
+            default_source_urls(Task::Obb),
+            &[crate::download::DEFAULT_OBB_IMAGE]
+        );
+    }
+
+    #[test]
+    fn test_predict_parent_dir_by_task() {
+        assert_eq!(predict_parent_dir(Task::Detect), "runs/detect");
+        assert_eq!(predict_parent_dir(Task::Segment), "runs/segment");
+        assert_eq!(predict_parent_dir(Task::Pose), "runs/pose");
+        assert_eq!(predict_parent_dir(Task::Classify), "runs/classify");
+        assert_eq!(predict_parent_dir(Task::Obb), "runs/obb");
+        assert_eq!(predict_parent_dir(Task::Semantic), "runs/semantic");
+    }
+
+    #[test]
+    fn test_predict_dir_needed_for_saves_and_semantic_json() {
+        assert!(needs_predict_dir(false, true, Task::Semantic));
+        assert!(!needs_predict_dir(false, true, Task::Detect));
+        assert!(needs_results_dir(true, Task::Semantic));
+        assert!(!needs_results_dir(true, Task::Segment));
+        assert!(!needs_results_dir(false, Task::Semantic));
+
+        #[cfg(feature = "annotate")]
+        assert!(needs_predict_dir(true, false, Task::Detect));
+
+        #[cfg(not(feature = "annotate"))]
+        assert!(!needs_predict_dir(true, false, Task::Detect));
+    }
+
+    #[test]
+    fn test_precision_and_provider_labels() {
+        assert_eq!(precision_label(false), "FP32");
+        assert_eq!(precision_label(true), "FP16");
+        assert_eq!(provider_label("CoreMLExecutionProvider"), "CoreML");
+        assert_eq!(provider_label("CUDAExecutionProvider"), "CUDA");
+        assert_eq!(provider_label("TensorrtExecutionProvider"), "CPU");
+        assert_eq!(provider_label("TensorRTExecutionProvider"), "TensorRT");
+        assert_eq!(provider_label("DirectMLExecutionProvider"), "DirectML");
+        assert_eq!(provider_label("ROCmExecutionProvider"), "ROCm");
+        assert_eq!(provider_label("OpenVINOExecutionProvider"), "OpenVINO");
+        assert_eq!(provider_label("CPUExecutionProvider"), "CPU");
+    }
+
+    #[test]
+    fn test_semantic_output_stem_single_image_and_frames() {
+        assert_eq!(
+            semantic_output_stem("images/bus.jpg", 0, Some(1)),
+            "bus".to_string()
+        );
+        assert_eq!(
+            semantic_output_stem("stream", 42, Some(100)),
+            "stream_000042".to_string()
+        );
+        assert_eq!(
+            semantic_output_stem("", 3, None),
+            "frame_000003".to_string()
+        );
     }
 
     /// Test `format_detection_summary` with boxes - single detection.

--- a/src/download.rs
+++ b/src/download.rs
@@ -358,7 +358,6 @@ fn normalize_model_path(path: &Path) -> PathBuf {
 /// # Errors
 ///
 /// Returns an error if the model name is not in the supported list, or if the download fails.
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
     let path = path.as_ref();
     let normalized = normalize_model_path(path);

--- a/src/download.rs
+++ b/src/download.rs
@@ -140,6 +140,7 @@ const fn is_transient(e: &ureq::Error) -> bool {
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn download_file(url: &str, dest: &Path) -> Result<()> {
     let mut last_err = InferenceError::ModelLoadError(String::new());
 
@@ -357,6 +358,7 @@ fn normalize_model_path(path: &Path) -> PathBuf {
 /// # Errors
 ///
 /// Returns an error if the model name is not in the supported list, or if the download fails.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
     let path = path.as_ref();
     let normalized = normalize_model_path(path);
@@ -384,6 +386,7 @@ pub fn try_download_model<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 ///
 /// # Errors
 /// Returns an error if the download fails or file I/O errors occur.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn download_image(url: &str) -> Result<String> {
     let filename = url.rsplit('/').next().unwrap_or("image.jpg");
     let dest = Path::new(filename);
@@ -404,6 +407,7 @@ pub fn download_image(url: &str) -> Result<String> {
 /// Download multiple images from URLs to the current directory.
 /// Skips files that already exist.
 #[must_use]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn download_images(urls: &[&str]) -> Vec<String> {
     urls.iter()
         .filter_map(|url| download_image(url).ok())

--- a/src/io.rs
+++ b/src/io.rs
@@ -89,6 +89,7 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if the encoder cannot be initialized.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn new<P: AsRef<Path>>(path: P, width: usize, height: usize, fps: f32) -> Result<Self> {
         let output_path = path.as_ref().to_path_buf();
 
@@ -126,6 +127,7 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if encoding fails or frame dimensions don't match.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn write_frame(&mut self, frame: &image::DynamicImage) -> Result<()> {
         let img_buffer = frame.to_rgb8();
         let width = img_buffer.width() as usize;
@@ -159,6 +161,7 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if the encoder fails to finish.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn finish(mut self) -> Result<()> {
         self.encoder.finish().map_err(|e| {
             InferenceError::VideoError(format!("Failed to finish video encoding: {e}"))

--- a/src/io.rs
+++ b/src/io.rs
@@ -89,7 +89,6 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if the encoder cannot be initialized.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn new<P: AsRef<Path>>(path: P, width: usize, height: usize, fps: f32) -> Result<Self> {
         let output_path = path.as_ref().to_path_buf();
 
@@ -127,7 +126,6 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if encoding fails or frame dimensions don't match.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn write_frame(&mut self, frame: &image::DynamicImage) -> Result<()> {
         let img_buffer = frame.to_rgb8();
         let width = img_buffer.width() as usize;
@@ -161,7 +159,6 @@ impl VideoWriter {
     /// # Errors
     ///
     /// Returns an error if the encoder fails to finish.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn finish(mut self) -> Result<()> {
         self.encoder.finish().map_err(|e| {
             InferenceError::VideoError(format!("Failed to finish video encoding: {e}"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::multiple_crate_versions)]
 #![deny(dead_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # Ultralytics YOLO Inference Library

--- a/src/model.rs
+++ b/src/model.rs
@@ -122,6 +122,7 @@ impl YOLOModel {
     /// # Errors
     ///
     /// Returns an error if the model file doesn't exist or can't be loaded.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn load_with_config<P: AsRef<Path>>(path: P, config: InferenceConfig) -> Result<Self> {
         let path = path.as_ref();
 
@@ -775,6 +776,7 @@ impl YOLOModel {
     ///
     /// This pre-allocates memory and optimizes the execution graph for faster
     /// subsequent inferences. Warmup is automatically called on first predict.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn warmup(&mut self) -> Result<()> {
         if self.warmed_up {
             return Ok(());
@@ -816,6 +818,7 @@ impl YOLOModel {
     }
 
     /// Extract metadata from the ONNX model session.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn extract_metadata(session: &Session) -> Result<ModelMetadata> {
         // Get metadata from the model
         let model_metadata = session.metadata().map_err(|e| {
@@ -898,6 +901,7 @@ impl YOLOModel {
     /// # Errors
     ///
     /// Returns an error if the image can't be loaded or inference fails.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn predict<P: AsRef<Path>>(&mut self, path: P) -> Result<Vec<Results>> {
         let path = path.as_ref();
 
@@ -922,6 +926,7 @@ impl YOLOModel {
     /// # Returns
     ///
     /// Vector of Results.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn predict_image(&mut self, image: &DynamicImage, path: String) -> Result<Vec<Results>> {
         // Fast path: GPU preprocess + zero-copy device input.
         //
@@ -1141,6 +1146,7 @@ impl YOLOModel {
     /// # Errors
     ///
     /// Returns an error if the download or inference fails.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn predict_default(&mut self) -> Result<Vec<Results>> {
         let urls: &[&str] = if self.task() == crate::task::Task::Obb {
             &[DEFAULT_OBB_IMAGE]
@@ -1172,6 +1178,7 @@ impl YOLOModel {
     /// # Errors
     ///
     /// Returns an error if inference fails.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn predict_batch(
         &mut self,
         images: &[DynamicImage],
@@ -1183,6 +1190,7 @@ impl YOLOModel {
     }
 
     /// Internal method to run inference on a batch of image references.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn predict_internal(
         &mut self,
         images: &[&DynamicImage],
@@ -1435,6 +1443,7 @@ impl YOLOModel {
     /// # Returns
     ///
     /// Vector of Results.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn predict_array(&mut self, image: &Array3<u8>, path: String) -> Result<Vec<Results>> {
         // Convert array to DynamicImage
         let dynamic_img = crate::utils::array_to_image(image)?;
@@ -1455,6 +1464,7 @@ impl YOLOModel {
     ///
     /// * Vector of `SourceMeta` and Results pairs.
     #[cfg(feature = "annotate")]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[allow(clippy::too_many_lines)]
     pub fn predict_source(
         &mut self,
@@ -1518,6 +1528,7 @@ impl YOLOModel {
     ///
     /// Run a single forward pass for warmup, discarding outputs.
     ///
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_warmup(
         session: &mut Session,
         input_name: &str,
@@ -1544,6 +1555,7 @@ impl YOLOModel {
     }
 
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_timed<'s>(
         session: &'s mut Session,
         inputs: Vec<(
@@ -1565,6 +1577,7 @@ impl YOLOModel {
     /// This avoids a ~40 ms memcpy for large semantic segmentation outputs.
     ///
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_inference_with<R>(
         session: &mut Session,
         input_name: &str,
@@ -1581,6 +1594,7 @@ impl YOLOModel {
     }
 
     /// Build zero-copy slice views over ORT output tensors and call `cb`.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn extract_and_invoke<R>(
         outputs: &ort::session::SessionOutputs<'_>,
         output_names: &[String],
@@ -1630,6 +1644,7 @@ impl YOLOModel {
 
     /// Run ONNX inference with FP32 input where outputs are `uint8` tensors
     /// (e.g. a semantic segmentation model that has ArgMax+Cast(uint8) baked in). Zero-copy.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_inference_u8_with<R>(
         session: &mut Session,
         input_name: &str,
@@ -1646,6 +1661,7 @@ impl YOLOModel {
     }
 
     /// Build zero-copy `&[u8]` slice views over ORT output tensors and call `cb`.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn extract_and_invoke_u8<R>(
         outputs: &ort::session::SessionOutputs<'_>,
         output_names: &[String],
@@ -1673,6 +1689,7 @@ impl YOLOModel {
 
     /// Run ONNX inference with FP16 input where outputs are `uint8` tensors
     /// (e.g. a semantic segmentation model with FP16 input that has ArgMax+Cast(uint8) baked in).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_inference_f16_u8_with<R>(
         session: &mut Session,
         input_name: &str,
@@ -1689,6 +1706,7 @@ impl YOLOModel {
     }
 
     /// Run ONNX inference with FP16 input, zero-copy callback (FP16 outputs are converted).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run_inference_f16_with<R>(
         session: &mut Session,
         input_name: &str,

--- a/src/source.rs
+++ b/src/source.rs
@@ -252,6 +252,7 @@ struct BilinearVideoDecoder {
 
 #[cfg(feature = "video")]
 impl BilinearVideoDecoder {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn new(path: &Path) -> Result<Self> {
         ffmpeg::init().map_err(|e| InferenceError::VideoError(format!("FFmpeg init: {e}")))?;
 
@@ -296,6 +297,7 @@ impl BilinearVideoDecoder {
     }
 
     /// Decode the next frame as an RGB24 `DynamicImage`.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn decode_next(&mut self) -> Option<Result<DynamicImage>> {
         let mut decoded = ffmpeg::util::frame::video::Video::empty();
 
@@ -335,6 +337,7 @@ impl BilinearVideoDecoder {
     }
 
     /// Convert a decoded video frame to RGB24 `DynamicImage` using BILINEAR scaler.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn frame_to_image(
         &mut self,
         decoded: &ffmpeg::util::frame::video::Video,
@@ -585,6 +588,7 @@ impl SourceIterator {
 
     /// Get the next video frame.
     #[cfg(feature = "video")]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[allow(unsafe_code, clippy::too_many_lines)]
     fn next_video_frame(&mut self) -> Option<Result<(DynamicImage, SourceMeta)>> {
         // Handle Webcam separately using native ffmpeg


### PR DESCRIPTION
## Summary
- extract pure CLI prediction planning helpers and cover them with lightweight unit tests
- exclude runtime-only ONNX, download, CLI orchestration, and FFmpeg source-decoder paths from nightly coverage accounting
- declare the cargo-llvm-cov coverage_nightly cfg for strict check-cfg/clippy builds

## Validation
- cargo test --features annotate,visualize
- cargo clippy --features annotate,visualize --all-targets -- -D warnings
- git diff --check
- RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg coverage_nightly" LLVM_COV="$(xcrun --find llvm-cov)" LLVM_PROFDATA="$(xcrun --find llvm-profdata)" cargo llvm-cov --features annotate,visualize --workspace --ignore-filename-regex "(src/cuda_inference\\.rs|src/visualizer/viewer\\.rs|src/main\\.rs|crates/web/)" --summary-only

Local nightly-style coverage: 91.15% lines. The exact CI video feature coverage command could not run locally because FFmpeg pkg-config libraries are not installed on this machine.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves maintainability and test coverage for the Rust prediction CLI by refactoring core logic into smaller helpers and adding coverage-specific exclusions 🧹✅

### 📊 Key Changes
- Refactored `run_prediction()` into focused helper functions for model path resolution, device parsing, inference config building, output directory selection, provider labels, and semantic output naming 🔧
- Added task-aware defaults for prediction sources, including dedicated OBB default images 🖼️
- Centralized logic for deciding when prediction and semantic results directories are needed 📁
- Improved execution provider display by normalizing provider detection for CPU, CUDA, TensorRT, CoreML, DirectML, ROCm, and OpenVINO ⚡
- Added extensive unit tests for the new helper functions, covering default models, CLI config parsing, class filters, output paths, device parsing, and labels 🧪
- Added Rust coverage configuration support via `coverage_nightly` and marked hard-to-cover runtime-heavy functions as excluded from coverage reports 📈
- Enabled lint awareness for the custom `coverage_nightly` cfg to avoid unexpected configuration warnings 🚦

### 🎯 Purpose & Impact
- Makes the prediction CLI easier to understand, test, and maintain without changing expected user-facing behavior 🙌
- Reduces risk of regressions by testing important CLI decision logic in isolation 🛡️
- Improves reliability for users running different YOLO tasks, including Detect, Segment, Pose, Classify, OBB, and Semantic workflows 🎯
- Produces cleaner and more meaningful coverage reports by excluding functions that depend on downloads, ONNX Runtime sessions, video decoding, or full inference execution 📊
- Helps developers iterate faster and with more confidence when improving the Ultralytics inference engine 🚀