### PR TITLE
fix(annotate): guard label drawing against zero-width rect

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -381,6 +381,13 @@ fn draw_label(
         .ceil() as i32;
     let text_h = scale.y.ceil() as i32;
 
+    // A missing or degenerate font can produce a zero-width label. imageproc's
+    // Rect::of_size panics on a zero dimension, and an empty label has nothing
+    // to draw, so bail out early.
+    if text_w <= 0 || text_h <= 0 {
+        return;
+    }
+
     let mut text_x = anchor_x;
     let mut text_y = anchor_y - text_h;
 


### PR DESCRIPTION
`draw_label` builds an imageproc `Rect` with `of_size(text_w, text_h)`. imageproc panics with "width must be strictly positive" when a dimension is 0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a safety check to prevent crashes when drawing empty or invalid annotation labels 🛡️

### 📊 Key Changes
- Added an early return in `draw_label()` when computed label text width or height is zero or negative.
- Prevents `imageproc::Rect::of_size` from being called with invalid dimensions.
- Handles cases caused by missing, broken, or degenerate fonts, as well as empty labels.

### 🎯 Purpose & Impact
- Improves annotation stability by avoiding runtime panics during label rendering ✅
- Makes inference visualization more robust across different font and label inputs.
- Users benefit from fewer crashes when generating annotated outputs, especially in edge cases involving invalid fonts or blank labels 🚀