### PR TITLE
ci: exclude Release Candidate Xcode on macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Some macos-runner Xcode toolchains dangle libclang_rt.osx.a (ld:
-      # library 'clang_rt.osx' not found): the old 16.4, and Release Candidate
-      # builds such as 26.x RC on the macOS 26 image. Select the newest present
-      # stable (non-beta, non-RC) Xcode and export its version so the Rust cache
-      # key is scoped to it - otherwise a cache built under one image's Xcode
-      # dangles on another.
       - name: Select Xcode (macOS)
         if: matrix.os == 'macos-latest'
         run: |
@@ -131,13 +125,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      # Some macos-runner Xcode toolchains dangle libclang_rt.osx.a (ld:
-      # library 'clang_rt.osx' not found): the old 16.4, and Release Candidate
-      # builds such as 26.x RC on the macOS 26 image. Select the newest present
-      # stable (non-beta, non-RC) Xcode and export its version so the Rust cache
-      # key is scoped to it - otherwise a cache built under one image's Xcode
-      # dangles on another.
       - name: Select Xcode (macOS)
         run: |
           sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -viE 'beta|release[ _]candidate|16\.4' | sort -V | tail -1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # macos-latest's default Xcode 16.4 toolchain dangles libclang_rt.osx.a
-      # (ld: library 'clang_rt.osx' not found). Select a present, known-good
-      # Xcode and export its version so the Rust cache key is scoped to it -
-      # otherwise a cache built under one image's Xcode dangles on another.
+      # Some macos-runner Xcode toolchains dangle libclang_rt.osx.a (ld:
+      # library 'clang_rt.osx' not found): the old 16.4, and Release Candidate
+      # builds such as 26.x RC on the macOS 26 image. Select the newest present
+      # stable (non-beta, non-RC) Xcode and export its version so the Rust cache
+      # key is scoped to it - otherwise a cache built under one image's Xcode
+      # dangles on another.
       - name: Select Xcode (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -vE 'beta|16\.4' | sort -V | tail -1)"
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -viE 'beta|release[ _]candidate|16\.4' | sort -V | tail -1)"
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
@@ -130,13 +132,15 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # macos-latest's default Xcode 16.4 toolchain dangles libclang_rt.osx.a
-      # (ld: library 'clang_rt.osx' not found). Select a present, known-good
-      # Xcode and export its version so the Rust cache key is scoped to it -
-      # otherwise a cache built under one image's Xcode dangles on another.
+      # Some macos-runner Xcode toolchains dangle libclang_rt.osx.a (ld:
+      # library 'clang_rt.osx' not found): the old 16.4, and Release Candidate
+      # builds such as 26.x RC on the macOS 26 image. Select the newest present
+      # stable (non-beta, non-RC) Xcode and export its version so the Rust cache
+      # key is scoped to it - otherwise a cache built under one image's Xcode
+      # dangles on another.
       - name: Select Xcode (macOS)
         run: |
-          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -vE 'beta|16\.4' | sort -V | tail -1)"
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | grep -viE 'beta|release[ _]candidate|16\.4' | sort -V | tail -1)"
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The macOS "Select Xcode" step excluded only `beta` and `16.4`, then picked the highest version. On the new macOS 26 runner image the highest is `Xcode_26.6_Release_Candidate_2`, whose toolchain is missing the darwin clang_rt libs, so linking fails with `ld: library 'clang_rt.osx' not found` (seen in the CoreML test job).

Runners still on macOS 15 pick a good Xcode, which is why this failed intermittently during the runner migration.

For fixing thisexclude Release Candidate builds (case-insensitive) so the selection falls back to the newest present stable Xcode. Applied to both Select Xcode steps.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves macOS CI reliability by avoiding beta, release candidate, and problematic Xcode versions during builds 🛠️

### 📊 Key Changes
- Updated the macOS Xcode selection logic in GitHub Actions CI workflows 🍎
- Now excludes:
  - Beta Xcode versions
  - Release Candidate Xcode versions
  - Xcode 16.4, which has known linker issues
- Made filtering case-insensitive to better catch variations like `Release Candidate` or `release_candidate`
- Removed outdated explanatory comments from the workflow for a cleaner CI configuration 🧹

### 🎯 Purpose & Impact
- Reduces macOS build failures caused by unstable or incompatible Xcode toolchains ✅
- Helps ensure Rust-related build caches are tied to a stable Xcode version 📦
- Improves CI consistency for contributors and maintainers working on `ultralytics/inference` 🚀
- No direct user-facing API changes, but users benefit from more reliable releases and faster development cycles ⚡