### PR TITLE
Add AGENTS.md agent guidance and fix documentation drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, etc.) when working with code in this repository. CLAUDE.md is a symlink to this file.
+
+## Core Principles (CRITICAL)
+
+Respecting these principles is critical for every PR.
+
+**Less is more. The simplest solution is the best solution.**
+
+The action hierarchy for every change: **Delete > Replace > Add**. The best code change is a deletion. The second best is modifying what exists. Adding new code is the last resort.
+
+1. **Minimal**: The simplest solution that works. Do not over-engineer, over-abstract, or add code just in case. Three similar lines beat a premature abstraction. Avoid error handling for impossible states, feature flags, compatibility shims, or policy scaffolding unless they are truly required.
+2. **Solve at the source**: Do not hack fixes. Solve problems at their root. If something is broken, fix or remove the broken thing. Never patch over a broken abstraction, add workarounds, or add synchronization code for state that should not be duplicated.
+3. **Delete ruthlessly**: When replacing code, delete what it replaced. Remove unused imports, functions, types, files, and commented-out code. Git preserves history. Run the repo's relevant dead-code or cleanup check when available.
+4. **Replace > Add**: Modify existing code over adding new code. Edit existing files, extend existing components or functions with minimal parameters, and reuse existing utilities. If creating a new file, first prove it cannot fit cleanly in an existing file.
+5. **Check existing**: Search the entire repo before creating anything new. If a feature, component, helper, responder, workflow, or utility already solves a similar problem, reuse or adapt it and delete the duplicate path.
+6. **Deduplicate**: Do not duplicate existing code when updating the repo. Consolidate or refactor duplicates you find when it is in scope and low risk.
+7. **Zero Regression**: Do not break existing features or workflows unless the PR intentionally removes them with evidence.
+8. **Production ready**: All changes must be thoroughly debugged, validated, and production ready.
+
+**When fixing bugs, ask: "What can I delete?" before "What can I replace?" before "What should I add?"**
+
+## PR Workflow
+
+After opening a PR:
+
+1. Wait for the automated PR review and auto-format commit from Ultralytics Actions (`format.yml`), then pull and address every finding.
+2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations — use the Codex CLI, one fresh `codex exec` run per round. Fix, push, and repeat until a fresh run reports LGTM.
+3. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never force-push, reset, or revert commits you did not author.
+4. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
+
+## Commands
+
+```bash
+# Build (native; default features = annotate + visualize)
+cargo build
+
+# Run all tests as CI does on Linux/Windows (macOS CI uses "coreml,annotate")
+cargo test --no-default-features --features annotate
+
+# Run one test by name filter (add -- --ignored --exact for the network e2e tests)
+cargo test --no-default-features --features annotate test_boxes_creation
+
+# Lint exactly as CI (ci.yml `test` job; macOS swaps in "coreml,annotate")
+cargo clippy --all-targets --no-default-features --features annotate -- -D warnings
+
+# Format (checked with --check in ci.yml and format.yml)
+cargo fmt --all
+
+# Coverage exactly as CI (ci.yml `coverage` job: nightly toolchain, cargo-llvm-cov, FFmpeg dev libs)
+cargo llvm-cov --features annotate,video,visualize --workspace --lcov --output-path lcov.info --ignore-filename-regex '(src/cuda_inference\.rs|src/visualizer/viewer\.rs|src/main\.rs|crates/web/)'
+
+# Wasm checks (ci.yml `wasm` job)
+cargo build -p ultralytics-inference --lib --no-default-features --target wasm32-unknown-unknown
+cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
+
+# npm package build (wasm-pack + tsc)
+cd web && npm ci && npm run build
+
+# Python tooling (only used in CI, e.g. ultralytics-actions): always uv, never bare pip
+uv pip install --system ultralytics-actions
+```
+
+- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0 Linux containers (`--features annotate,video`); video builds on macOS/Windows; `wasm`; `coverage` (nightly) uploads to Codecov.
+- MSRV is Rust 1.89 (`rust-version` in Cargo.toml), edition 2024.
+- First native build downloads ONNX Runtime binaries (ort `download-binaries` feature), so builds need network once.
+
+## Architecture
+
+Rust workspace with two crates plus an npm wrapper, all versioned together from the root `Cargo.toml`:
+
+- Root crate `ultralytics-inference`: YOLO inference library (`src/lib.rs`) and CLI binary (`src/main.rs`, thin wrapper over `src/cli/`). Pipeline: `source.rs` (images/dirs/globs/video/webcam) → `preprocessing.rs` (SIMD letterbox) → `model.rs` (`YOLOModel`, the ONNX Runtime session via `ort`, configured by `inference.rs`'s `InferenceConfig`) → `postprocessing.rs` → `results.rs` (`Results`/`Boxes`/`Masks`/`Keypoints`/`Probs`/`SemanticMask`, mirroring the Ultralytics Python API). `model.rs` reads embedded ONNX metadata (`metadata.rs`) and auto-downloads known YOLOv8/YOLO11/YOLO26 models and sample images (`download.rs`).
+- `crates/web` (`ultralytics-inference-web`, `publish = false`): wasm32-only WebGPU bindings via `ort-web`. Excluded from `default-members`, so plain `cargo build`/`cargo test` from the root skip it; it only builds for `--target wasm32-unknown-unknown`.
+- `web/`: npm package `@ultralytics/yolo` — TypeScript wrapper (`web/src/index.ts`) over the wasm-pack output of `crates/web`, with an optional LiteRT.js backend for `.tflite` models.
+- GPU/accelerator features (`cuda`, `tensorrt`, `coreml`, …) gate no public API; docs.rs builds with `annotate,visualize,video` only (see `[package.metadata.docs.rs]`).
+- Release gating: on every push to main, `publish.yml` reads the version from `Cargo.toml` — if tag `v{version}` does not exist it tags, creates a GitHub release, and publishes to crates.io; `npm-publish.yml` likewise publishes `@ultralytics/yolo` if that version is missing from npm. So merging a version bump to main releases both packages.
+
+## Conventions
+
+- Every source file starts with the `Ultralytics 🚀 AGPL-3.0 License` header — Ultralytics Actions adds them automatically; don't add or revert manually.
+- Ultralytics Actions (`format.yml`) also runs Prettier (YAML/JSON/Markdown), codespell, and a nightly `cargo fmt` check on PRs; expect it to push an auto-format commit to your PR branch.
+- Lints are strict: clippy `all`/`pedantic`/`nursery`/`cargo` plus `missing_docs` and `unsafe_code` warn at the workspace level (CI promotes to errors with `-D warnings`), and `src/lib.rs` denies `dead_code` — document all public items and delete unused code.
+- Unit tests live inline in `src/` modules; integration tests in `tests/integration_test.rs`. The e2e tests that download models/images (e.g. `test_run_prediction_e2e`) are `#[ignore]`d — run them explicitly with `-- --ignored`; macOS CI runs `test_coreml_model_loads_and_warms_up` this way. Note the non-ignored `src/batch.rs` tests also auto-download `yolo26n.onnx` on first run, so the plain test suite needs network until that file is cached.
+- Version bumps update root `Cargo.toml`, `crates/web/Cargo.toml`, and `web/package.json` together; merging the bump to main auto-tags and publishes (see Architecture).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ inference/
 │   ├── inference.rs        # InferenceConfig
 │   ├── batch.rs            # Batch processing pipeline
 │   ├── device.rs           # Device enum (CPU, CUDA, CoreML, etc.)
+│   ├── cuda_inference.rs   # Fused CUDA preprocess kernel (cuda-preprocess feature)
+│   ├── parallel.rs         # Rayon parallelism shims (sequential on wasm)
 │   ├── download.rs         # Model and asset downloading
 │   ├── annotate.rs         # Image annotation (bounding boxes, instance masks, keypoints, semantic overlay)
 │   ├── io.rs               # Result saving (images, videos)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,25 +223,25 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 **CLI 选项：**
 
-| 选项            | 简写 | 说明                                                                                                                     | 默认值                            |
-| --------------- | ---- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| `--model`       | `-m` | ONNX 模型文件路径；若为已知 YOLOv8/YOLO11/YOLO26 名称则自动下载                                                          | `yolo26n.onnx`                    |
-| `--task`        |      | 任务类型（`detect`、`segment`、`pose`、`obb`、`classify`、`semantic`\*）；省略 `--model` 时选择 nano 模型                | `detect`                          |
-| `--source`      | `-s` | 输入源（图片、目录、glob、视频、摄像头索引或 URL）                                                                       | 与任务相关的 Ultralytics URL 资源 |
-| `--conf`        |      | 置信度阈值                                                                                                               | `0.25`                            |
-| `--iou`         |      | NMS IoU 阈值                                                                                                             | `0.7`                             |
-| `--max-det`     |      | 最大检测数量                                                                                                             | `300`                             |
-| `--imgsz`       |      | 推理图片尺寸                                                                                                             | 模型元数据                        |
-| `--rect`        |      | 启用矩形推理（最小填充）                                                                                                 | `true`                            |
-| `--batch`       |      | 推理 batch size                                                                                                          | `1`                               |
-| `--half`        |      | 使用 FP16 半精度推理                                                                                                     | `false`                           |
-| `--save`        |      | 将标注结果保存到 runs/\<task\>/predict                                                                                   | `true`                            |
-| `--save-frames` |      | 为视频输入保存单帧（而不是视频文件）                                                                                     | `false`                           |
-| `--save-json`   |      | 保存语义分割类别图 PNG，便于外部评估                                                                                     | `false`                           |
-| `--show`        |      | 在窗口中显示结果                                                                                                         | `false`                           |
+| 选项            | 简写 | 说明                                                                                                                                       | 默认值                            |
+| --------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `--model`       | `-m` | ONNX 模型文件路径；若为已知 YOLOv8/YOLO11/YOLO26 名称则自动下载                                                                            | `yolo26n.onnx`                    |
+| `--task`        |      | 任务类型（`detect`、`segment`、`pose`、`obb`、`classify`、`semantic`\*）；省略 `--model` 时选择 nano 模型                                  | `detect`                          |
+| `--source`      | `-s` | 输入源（图片、目录、glob、视频、摄像头索引或 URL）                                                                                         | 与任务相关的 Ultralytics URL 资源 |
+| `--conf`        |      | 置信度阈值                                                                                                                                 | `0.25`                            |
+| `--iou`         |      | NMS IoU 阈值                                                                                                                               | `0.7`                             |
+| `--max-det`     |      | 最大检测数量                                                                                                                               | `300`                             |
+| `--imgsz`       |      | 推理图片尺寸                                                                                                                               | 模型元数据                        |
+| `--rect`        |      | 启用矩形推理（最小填充）                                                                                                                   | `true`                            |
+| `--batch`       |      | 推理 batch size                                                                                                                            | `1`                               |
+| `--half`        |      | 使用 FP16 半精度推理                                                                                                                       | `false`                           |
+| `--save`        |      | 将标注结果保存到 runs/\<task\>/predict                                                                                                     | `true`                            |
+| `--save-frames` |      | 为视频输入保存单帧（而不是视频文件）                                                                                                       | `false`                           |
+| `--save-json`   |      | 保存语义分割类别图 PNG，便于外部评估                                                                                                       | `false`                           |
+| `--show`        |      | 在窗口中显示结果                                                                                                                           | `false`                           |
 | `--device`      |      | 设备字符串，例如 cpu、cuda:0、coreml、directml:0、openvino、tensorrt:0、rocm:0、xnnpack；启用 feature 后可选择更多提供方（见 Features 表） | `cpu`                             |
-| `--verbose`     |      | 显示详细输出                                                                                                             | `true`                            |
-| `--classes`     |      | 按类别 ID 过滤，例如 `0`、`"0,1,2"` 或 `"[0, 1, 2]"`                                                                     | 所有类别                          |
+| `--verbose`     |      | 显示详细输出                                                                                                                               | `true`                            |
+| `--classes`     |      | 按类别 ID 过滤，例如 `0`、`"0,1,2"` 或 `"[0, 1, 2]"`                                                                                       | 所有类别                          |
 
 **任务和模型解析：**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,7 +239,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--save-frames` |      | 为视频输入保存单帧（而不是视频文件）                                                                                     | `false`                           |
 | `--save-json`   |      | 保存语义分割类别图 PNG，便于外部评估                                                                                     | `false`                           |
 | `--show`        |      | 在窗口中显示结果                                                                                                         | `false`                           |
-| `--device`      |      | 设备字符串，例如 cpu、cuda:0、coreml、directml:0、openvino、tensorrt:0、rocm:0、xnnpack；启用 feature 后可选择更多提供方 | `cpu`                             |
+| `--device`      |      | 设备字符串，例如 cpu、cuda:0、coreml、directml:0、openvino、tensorrt:0、rocm:0、xnnpack；启用 feature 后可选择更多提供方（见 Features 表） | `cpu`                             |
 | `--verbose`     |      | 显示详细输出                                                                                                             | `true`                            |
 | `--classes`     |      | 按类别 ID 过滤，例如 `0`、`"0,1,2"` 或 `"[0, 1, 2]"`                                                                     | 所有类别                          |
 
@@ -397,6 +397,8 @@ inference/
 │   ├── inference.rs        # InferenceConfig
 │   ├── batch.rs            # Batch 处理流程
 │   ├── device.rs           # Device 枚举（CPU, CUDA, CoreML 等）
+│   ├── cuda_inference.rs   # 融合 CUDA 预处理 kernel（cuda-preprocess feature）
+│   ├── parallel.rs         # Rayon 并行抽象（wasm 上为顺序执行）
 │   ├── download.rs         # 模型和资源下载
 │   ├── annotate.rs         # 图片标注（边界框、实例 mask、关键点、语义叠加）
 │   ├── io.rs               # 结果保存（图片、视频）

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -166,8 +166,7 @@ the CPU path runs and the flag is silently ignored:
 - `cuda_preprocess` is `true` (the default),
 - the device is `Cuda(_)`, `TensorRt(_)`, or unset (auto-detect),
 - the task is not `Classify` (which uses center-crop, not letterbox),
-- the model takes an FP32 input tensor (FP16-input models keep the CPU path),
-- the model input is square (H == W).
+- the model takes an FP32 input tensor (FP16-input models keep the CPU path).
 
 It is wired into `predict_image` specifically (single-frame). `predict_batch`
 and the multi-image batch path always use CPU preprocess.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -24,7 +24,7 @@ use clap::{Args, Parser, Subcommand};
     --save-frames          Save individual frames for video input (instead of video file)
     --save-json            Save semantic segmentation class-map PNGs for external evaluation
     --show                 Display results in a window [default: false]
-    --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, xnnpack)
+    --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, rocm:0, xnnpack)
     --verbose              Show verbose output [default: true]
     --classes <CLASSES>    Filter by class IDs (e.g., "0", "0,1,2", "[0, 1]")
 
@@ -118,7 +118,7 @@ pub struct PredictArgs {
     #[arg(long, default_value_t = false)]
     pub show: bool,
 
-    /// Device to use (cpu, cuda:0, mps, coreml, directml:0, openvino, tensorrt:0, etc.)
+    /// Device to use (cpu, cuda:0, coreml, directml:0, openvino, tensorrt:0, rocm:0, xnnpack)
     #[arg(long)]
     pub device: Option<String>,
 

--- a/web/README.md
+++ b/web/README.md
@@ -135,17 +135,17 @@ only). A value containing a `/` or a scheme is used as a URL/path as-is.
 
 Field names match the Rust/Ultralytics `Results` API 1-1:
 
-| Field              | Type                                                      | Tasks                 |
-| ------------------ | --------------------------------------------------------- | --------------------- |
-| `task`             | `string`                                                  | all                   |
-| `width` / `height` | `number`                                                  | all                   |
-| `boxes`            | `{ x1, y1, x2, y2, conf, cls, name, color }[]`            | detect, segment, pose |
-| `obb`              | `{ x, y, w, h, angle, conf, cls, name, color }[]`         | obb                   |
-| `keypoints`        | `{ points: [x, y, conf][], color }[]`                     | pose                  |
+| Field              | Type                                                                 | Tasks                 |
+| ------------------ | -------------------------------------------------------------------- | --------------------- |
+| `task`             | `string`                                                             | all                   |
+| `width` / `height` | `number`                                                             | all                   |
+| `boxes`            | `{ x1, y1, x2, y2, conf, cls, name, color }[]`                       | detect, segment, pose |
+| `obb`              | `{ x, y, w, h, angle, conf, cls, name, color }[]`                    | obb                   |
+| `keypoints`        | `{ points: [x, y, conf][], color }[]`                                | pose                  |
 | `probs`            | `{ top1, top5, top1conf, top5conf, name, top5names, color } \| null` | classify              |
-| `masks`            | `Uint8Array` (RGBA overlay, `width*height*4`)             | segment, semantic     |
-| `semantic_mask`    | `Uint16Array` (class id per pixel, `width*height`)        | semantic              |
-| `speed`            | `{ preprocess, inference, postprocess }` ms               | all                   |
+| `masks`            | `Uint8Array` (RGBA overlay, `width*height*4`)                        | segment, semantic     |
+| `semantic_mask`    | `Uint16Array` (class id per pixel, `width*height`)                   | semantic              |
+| `speed`            | `{ preprocess, inference, postprocess }` ms                          | all                   |
 
 `model.names` is the class id to name map (like `model.names` in Python). Every
 detection carries its Ultralytics palette `color`, and `annotate()` draws the

--- a/web/README.md
+++ b/web/README.md
@@ -142,7 +142,7 @@ Field names match the Rust/Ultralytics `Results` API 1-1:
 | `boxes`            | `{ x1, y1, x2, y2, conf, cls, name, color }[]`            | detect, segment, pose |
 | `obb`              | `{ x, y, w, h, angle, conf, cls, name, color }[]`         | obb                   |
 | `keypoints`        | `{ points: [x, y, conf][], color }[]`                     | pose                  |
-| `probs`            | `{ top1, top5, top1conf, top5conf, name, color } \| null` | classify              |
+| `probs`            | `{ top1, top5, top1conf, top5conf, name, top5names, color } \| null` | classify              |
 | `masks`            | `Uint8Array` (RGBA overlay, `width*height*4`)             | segment, semantic     |
 | `semantic_mask`    | `Uint16Array` (class id per pixel, `width*height`)        | semantic              |
 | `speed`            | `{ preprocess, inference, postprocess }` ms               | all                   |


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds AI-agent contributor guidance and refreshes documentation for CUDA preprocessing, device options, project structure, and web classification outputs 📚✨

### 📊 Key Changes
- Added `AGENTS.md` with repository-specific guidance for AI coding agents, including workflow rules, core development principles, build/test commands, architecture notes, and release conventions 🤖
- Added `CLAUDE.md` as a symlink to `AGENTS.md` so Claude-based tools can reuse the same instructions 🔗
- Updated README project trees to include `cuda_inference.rs` and `parallel.rs`, clarifying CUDA preprocessing and wasm-safe parallelism modules 🧩
- Updated CUDA docs to remove the square-input requirement for fused CUDA preprocessing, indicating broader supported input shapes 🚀
- Updated CLI help text and Chinese README device descriptions to include `rocm:0` and `xnnpack` device options 🖥️
- Updated web README result schema to document `top5names` in classification probabilities 🌐

### 🎯 Purpose & Impact
- Improves contributor and AI-agent onboarding with clearer rules for making minimal, production-ready changes ✅
- Keeps documentation aligned with current code behavior and supported hardware backends, reducing confusion for users ⚙️
- Clarifies CUDA preprocessing capabilities, helping users better understand when GPU preprocessing may be used ⚡
- Improves multilingual and web package documentation accuracy for CLI and JavaScript users 🌍
- No runtime code changes are introduced, so the PR is low risk and primarily improves maintainability and user guidance 🛡️