### PR TITLE
Restrict release workflow to the main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/inference'
+    if: github.repository == 'ultralytics/inference' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/inference' && github.ref == 'refs/heads/main'
+    if: github.repository == 'ultralytics/inference' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/inference' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
+    if: github.repository == 'ultralytics/inference' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 🛠️ Summary

Restricts the release workflow to the `main` branch by adding `github.ref == 'refs/heads/main'` to the `check` job condition.

Previously a `workflow_dispatch` run from a feature branch could tag and create a release from a commit that never landed on `main` (the checkout defaults to the dispatched ref). This guard closes that gap while leaving normal push-to-main and main dispatch behavior unchanged. Part of a cross-repo release-workflow hardening pass (see ultralytics/template#91).

## 🧪 Testing

- YAML validated. Push-to-main and main-dispatch paths are unaffected; only non-main dispatch is now skipped.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tightens the publish workflow so releases only run from the `main` branch of `ultralytics/inference` 🚀

### 📊 Key Changes
- Updated the GitHub Actions `publish.yml` workflow condition.
- The `check` job now runs only when:
  - The repository is `ultralytics/inference`
  - The Git ref is `refs/heads/main`

### 🎯 Purpose & Impact
- Prevents publishing workflows from running on non-`main` branches 🛡️
- Reduces the risk of accidental or premature releases 📦
- Improves CI/CD safety and release control for maintainers ✅