### PR TITLE
Bump astral-sh/setup-uv from v8.2.0 to v8.3.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: false
       - name: Install ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.2.0 to v8.3.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions `uv` setup action used for publishing from v8.2.0 to v8.3.0 🚀

### 📊 Key Changes
- Bumped `astral-sh/setup-uv` in `.github/workflows/publish.yml` from v8.2.0 to v8.3.0 🔧
- Updated the pinned commit hash for the action to improve reproducibility and supply-chain safety 🔒
- No changes to inference code, APIs, models, or user-facing functionality ✅

### 🎯 Purpose & Impact
- Keeps the release/publishing workflow up to date with the latest `setup-uv` improvements 📦
- Helps maintain reliable and secure CI/CD automation for package publishing ⚙️
- Users should see no direct behavior changes, but maintainers benefit from a more current build pipeline 🛠️