### PR TITLE
Add GPU CI workflow and CUDA tests for self hosted runners

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,0 +1,92 @@
+name: GPU CI
+
+permissions:
+  contents: read
+  id-token: write # Codecov OIDC upload
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref so the self-hosted pool is not tied up
+# by stale commits. PRs still run in parallel across runners; if the pool
+# saturates, switch to a global serial group or gate on a `gpu` label.
+concurrency:
+  group: gpu-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  # ORT downloads a CUDA-enabled runtime; this must match the runner's CUDA
+  # major (12 or 13). Wrong value makes the CUDA/TensorRT EP fall back to CPU,
+  # which the cuda-preprocess fast path turns into a hard error (see model.rs).
+  ORT_CUDA_VERSION: "12"
+
+jobs:
+  # CUDA execution-provider + fused GPU preprocess tests on self-hosted NVIDIA
+  # runners. Exercises src/cuda_inference.rs and the CUDA/TensorRT EP wiring,
+  # none of which the hosted-runner CI can reach.
+  gpu:
+    name: gpu / cuda-preprocess
+    runs-on: [self-hosted, Linux, X64, gpu-latest]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Fail fast before the long CUDA build if the GPU or toolkit is missing.
+      - name: GPU sanity check
+        run: |
+          nvidia-smi
+          nvcc --version
+
+      # Stable (like the `test` job), not nightly: clippy -D warnings must not
+      # trip on bleeding-edge nightly-only lints in unrelated code, and
+      # cargo-llvm-cov instruments on stable (file exclusions are done by regex,
+      # not the nightly coverage(off) attribute).
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: gpu-cuda
+
+      - name: Ensure toolchain
+        run: rustup show
+
+      # cuda-preprocess pulls in cuda + tensorrt + cudarc (nvcc-compiled kernel).
+      # --no-default-features drops the minifb visualizer (no display on the runner).
+      - name: Clippy (cuda-preprocess)
+        run: cargo clippy --all-targets --no-default-features --features annotate,cuda-preprocess -- -D warnings
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: cargo-llvm-cov
+
+      # One instrumented run doubles as the test suite and the coverage report.
+      # --include-ignored runs the GPU-gated integration tests; --test-threads=1
+      # serialises GPU access. Unlike the host coverage job this does NOT exclude
+      # src/cuda_inference.rs, so the fused kernel is counted here.
+      - name: Test + coverage
+        run: |
+          cargo llvm-cov --no-default-features --features annotate,cuda-preprocess \
+            --workspace --lcov --output-path lcov.info \
+            --ignore-filename-regex '(src/visualizer/viewer\.rs|src/main\.rs|crates/web/)' \
+            -- --include-ignored --test-threads=1
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          plugins: noop
+          flags: gpu
+          use_oidc: true

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -303,3 +303,198 @@ impl CudaPreprocessor {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Runs only on an NVIDIA GPU: the whole module is `cuda-preprocess`-gated,
+    // so these compile and execute exclusively on the GPU CI runner. Inline
+    // tests reach the preprocessor's private `stream`/`input_dev` fields to copy
+    // the kernel output back to the host and assert on it.
+    use super::*;
+
+    /// Padded background emitted by the kernel (`114/255`).
+    const PAD: f32 = 114.0 / 255.0;
+    /// Tolerance for GPU-computed float comparisons.
+    const EPS: f32 = 1e-4;
+
+    /// Open device 0 and build a preprocessor targeting `dst_h` x `dst_w`.
+    fn preprocessor(dst_h: usize, dst_w: usize) -> CudaPreprocessor {
+        let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
+        CudaPreprocessor::finalize(handle, dst_h, dst_w).expect("finalize preprocessor")
+    }
+
+    /// Build an HWC RGB buffer filled with a single solid color.
+    fn solid(h: usize, w: usize, r: u8, g: u8, b: u8) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(h * w * 3);
+        for _ in 0..h * w {
+            buf.extend_from_slice(&[r, g, b]);
+        }
+        buf
+    }
+
+    /// Copy the device input buffer back to the host as flat CHW f32 planes.
+    fn readback(pre: &CudaPreprocessor) -> Vec<f32> {
+        pre.stream
+            .clone_dtoh(&pre.input_dev)
+            .expect("device to host copy")
+    }
+
+    #[test]
+    fn stream_handle_open() {
+        let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
+        assert!(
+            !handle.raw_stream_ptr().is_null(),
+            "compute stream pointer must be non-null"
+        );
+    }
+
+    #[test]
+    fn preprocessor_finalize_allocates() {
+        let pre = preprocessor(640, 640);
+        assert_eq!(pre.dst_hw(), (640, 640));
+        assert_ne!(
+            pre.input_dev_ptr(),
+            0,
+            "device input buffer must be allocated"
+        );
+    }
+
+    #[test]
+    fn preprocess_square_geometry() {
+        let mut pre = preprocessor(640, 640);
+        let (src_h, src_w) = (480u32, 640u32);
+        let frame = solid(src_h as usize, src_w as usize, 200, 100, 50);
+
+        let geom = pre
+            .preprocess(&frame, src_h, src_w, false)
+            .expect("preprocess");
+
+        // 640/640 = 1.0 is the binding axis; the 480-tall image is centered.
+        assert!((geom.scale - 1.0).abs() < EPS, "scale = {}", geom.scale);
+        assert_eq!(geom.pad_x, 0);
+        assert_eq!(geom.pad_y, 80);
+
+        let host = readback(&pre);
+        assert!(
+            host.iter().all(|&v| (0.0..=1.0).contains(&v)),
+            "every output value must be normalized into [0, 1]"
+        );
+    }
+
+    #[test]
+    fn preprocess_non_square_target() {
+        let mut pre = preprocessor(384, 640);
+        assert_eq!(pre.dst_hw(), (384, 640));
+
+        // 640x640 into 384x640: scale 0.6 fills the width, pads the height to 0.
+        let frame = solid(640, 640, 10, 20, 30);
+        let geom = pre.preprocess(&frame, 640, 640, false).expect("preprocess");
+
+        assert_eq!(geom.pad_y, 0);
+        assert!(
+            geom.pad_x > 0,
+            "expected horizontal padding, got {}",
+            geom.pad_x
+        );
+    }
+
+    #[test]
+    fn preprocess_padding_value() {
+        let (dst, src_h, src_w) = (128usize, 64u32, 32u32);
+        let mut pre = preprocessor(dst, dst);
+        let frame = solid(src_h as usize, src_w as usize, 255, 255, 255);
+
+        let geom = pre
+            .preprocess(&frame, src_h, src_w, false)
+            .expect("preprocess");
+        assert!(
+            geom.pad_x > 0,
+            "expected horizontal padding, got {}",
+            geom.pad_x
+        );
+
+        // The top-left pixel is outside the resized image, so it is background.
+        let host = readback(&pre);
+        let hw = dst * dst;
+        for plane in 0..3 {
+            let v = host[plane * hw];
+            assert!(
+                (v - PAD).abs() < EPS,
+                "padding plane {plane} = {v}, want {PAD}"
+            );
+        }
+    }
+
+    #[test]
+    fn preprocess_center_normalize() {
+        let dst = 64usize;
+        let mut pre = preprocessor(dst, dst);
+        // Square input, no letterbox: every pixel is R=255, G=0, B=0.
+        let frame = solid(dst, dst, 255, 0, 0);
+        pre.preprocess(&frame, dst as u32, dst as u32, false)
+            .expect("preprocess");
+
+        let host = readback(&pre);
+        let hw = dst * dst;
+        let idx = (dst / 2) * dst + dst / 2;
+        assert!((host[idx] - 1.0).abs() < EPS, "R plane = {}", host[idx]);
+        assert!(host[hw + idx].abs() < EPS, "G plane = {}", host[hw + idx]);
+        assert!(
+            host[2 * hw + idx].abs() < EPS,
+            "B plane = {}",
+            host[2 * hw + idx]
+        );
+    }
+
+    #[test]
+    fn preprocess_bgr_swap() {
+        let dst = 64usize;
+        let frame = solid(dst, dst, 255, 0, 0); // byte order [255, 0, 0]
+        let hw = dst * dst;
+        let idx = (dst / 2) * dst + dst / 2;
+
+        let mut rgb = preprocessor(dst, dst);
+        rgb.preprocess(&frame, dst as u32, dst as u32, false)
+            .expect("rgb preprocess");
+        let rgb_host = readback(&rgb);
+
+        let mut bgr = preprocessor(dst, dst);
+        bgr.preprocess(&frame, dst as u32, dst as u32, true)
+            .expect("bgr preprocess");
+        let bgr_host = readback(&bgr);
+
+        // RGB reads byte[0]=255 into R; BGR reads the same byte into B.
+        assert!(
+            (rgb_host[idx] - 1.0).abs() < EPS,
+            "rgb R = {}",
+            rgb_host[idx]
+        );
+        assert!(bgr_host[idx].abs() < EPS, "bgr R = {}", bgr_host[idx]);
+        assert!(
+            (bgr_host[2 * hw + idx] - 1.0).abs() < EPS,
+            "bgr B = {}",
+            bgr_host[2 * hw + idx]
+        );
+    }
+
+    #[test]
+    fn preprocess_rejects_wrong_len() {
+        let mut pre = preprocessor(64, 64);
+        let bad = vec![0u8; 10]; // != 64 * 64 * 3
+        let err = pre
+            .preprocess(&bad, 64, 64, false)
+            .expect_err("wrong-length frame must be rejected");
+        assert!(matches!(err, InferenceError::InferenceError(_)));
+    }
+
+    #[test]
+    fn preprocess_frame_buffer_growth() {
+        let mut pre = preprocessor(128, 128);
+        // First a small frame, then a larger one to force `frame_dev` to grow.
+        let small = solid(32, 32, 1, 2, 3);
+        pre.preprocess(&small, 32, 32, false).expect("small frame");
+        let large = solid(256, 256, 4, 5, 6);
+        pre.preprocess(&large, 256, 256, false)
+            .expect("large frame after buffer growth");
+    }
+}

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -219,7 +219,7 @@ pub fn postprocess(
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end detect layout `[1, max_det, 6]`.
-fn is_end2end_detect_shape(shape: &[usize]) -> bool {
+const fn is_end2end_detect_shape(shape: &[usize]) -> bool {
     shape.len() == 3 && shape[2] == 6 && shape[1] <= 4096
 }
 
@@ -233,7 +233,7 @@ fn is_end2end_segment_shape(shape: &[usize], proto_channels: Option<usize>) -> b
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end pose layout `[1, max_det, 6 + nk*dim]`.
-fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
+const fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
     shape.len() == 3 && shape[2] == 6 + nk * kpt_dim && shape[1] <= 4096
 }
 
@@ -245,7 +245,7 @@ fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
 /// the layout is ambiguous: `(12, 3)` and `(18, 2)` both decode the same
 /// tensor. Ambiguous cases fall through to the legacy pose path rather than
 /// silently guessing the wrong dimension.
-fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
+const fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
     if shape.len() != 3 || shape[1] == 0 || shape[1] > 4096 || shape[2] <= 6 {
         return None;
     }
@@ -260,7 +260,7 @@ fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end OBB layout `[1, max_det, 7]`.
-fn is_end2end_obb_shape(shape: &[usize]) -> bool {
+const fn is_end2end_obb_shape(shape: &[usize]) -> bool {
     shape.len() == 3 && shape[2] == 7 && shape[1] <= 4096
 }
 

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -522,7 +522,7 @@ fn image_to_tensor_generic<T: Clone>(
     let (r_slice, rest) = tensor.as_slice_mut().unwrap().split_at_mut(h * w);
     let (g_slice, b_slice) = rest.split_at_mut(h * w);
 
-    for (i, chunk) in pixels.chunks_exact(3).enumerate() {
+    for (i, chunk) in pixels.as_chunks::<3>().0.iter().enumerate() {
         r_slice[i] = convert(chunk[0]);
         g_slice[i] = convert(chunk[1]);
         b_slice[i] = convert(chunk[2]);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,7 +12,7 @@ use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
 use ultralytics_inference::task::Task;
 use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
-#[cfg(feature = "coreml")]
+#[cfg(any(feature = "coreml", feature = "cuda"))]
 use ultralytics_inference::{Device, YOLOModel};
 
 /// End-to-end `CoreML` test covering two known regressions:
@@ -277,4 +277,151 @@ fn test_speed_timing() {
     assert_eq!(speed.preprocess, Some(10.0));
     assert_eq!(speed.inference, Some(20.0));
     assert_eq!(speed.postprocess, Some(5.0));
+}
+
+// GPU inference tests. Gated on the `cuda` feature and `#[ignore]`d so they run
+// only on the self-hosted GPU CI (via `--include-ignored`), never on hosted
+// runners. They auto-download `yolo26n.onnx` and the bus.jpg sample.
+
+#[cfg(feature = "cuda")]
+fn load_bus_image() -> String {
+    ultralytics_inference::download::download_image("https://ultralytics.com/images/bus.jpg")
+        .expect("bus.jpg should download")
+}
+
+/// Loading on `Device::Cuda(0)` registers the CUDA execution provider and warms
+/// up without error (warmup runs inside `load_with_config`).
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_model_loads_and_warms_up() {
+    let config = InferenceConfig::new().with_device(Device::Cuda(0));
+    let model = YOLOModel::load_with_config("yolo26n.onnx", config)
+        .expect("CUDA model should load and warm up");
+
+    let ep = model.execution_provider();
+    assert!(
+        ep.to_lowercase().contains("cuda"),
+        "expected the CUDA execution provider, got '{ep}'"
+    );
+}
+
+/// End-to-end CUDA inference on bus.jpg yields at least one detection.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_predict_bus_has_detections() {
+    let config = InferenceConfig::new().with_device(Device::Cuda(0));
+    let mut model =
+        YOLOModel::load_with_config("yolo26n.onnx", config).expect("CUDA model should load");
+    let image = load_bus_image();
+
+    let results = model
+        .predict(&image)
+        .expect("CUDA prediction should succeed");
+    let boxes = results
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("bus.jpg should produce boxes on CUDA");
+    assert!(
+        !boxes.is_empty(),
+        "expected at least one detection on bus.jpg"
+    );
+}
+
+/// CUDA and CPU produce equivalent detections on the same image. The CPU
+/// baseline pins `Device::Cpu`: with the `cuda-preprocess` feature enabled a
+/// default (`None`) device would silently route through the CUDA fast path.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_cpu_detection_parity() {
+    let image = load_bus_image();
+
+    let mut cuda_model = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new().with_device(Device::Cuda(0)),
+    )
+    .expect("CUDA model should load");
+    let cuda = cuda_model.predict(&image).expect("CUDA prediction");
+    let cuda_boxes = cuda
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("CUDA boxes");
+
+    let mut cpu_model = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new().with_device(Device::Cpu),
+    )
+    .expect("CPU model should load");
+    let cpu = cpu_model.predict(&image).expect("CPU prediction");
+    let cpu_boxes = cpu
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("CPU boxes");
+
+    // Counts match within one box: NMS can keep/drop a borderline candidate
+    // differently under GPU vs CPU rounding.
+    let diff = cuda_boxes.len().abs_diff(cpu_boxes.len());
+    assert!(
+        diff <= 1,
+        "detection count mismatch: cuda={}, cpu={}",
+        cuda_boxes.len(),
+        cpu_boxes.len()
+    );
+
+    // Matched leading boxes (sorted by confidence) agree to a couple of pixels.
+    for (cb, pb) in cuda_boxes
+        .xyxy()
+        .outer_iter()
+        .zip(cpu_boxes.xyxy().outer_iter())
+    {
+        for (x, y) in cb.iter().zip(pb.iter()) {
+            let d = (x - y).abs();
+            assert!(d < 2.0, "box corner differs by {d}px between cuda and cpu");
+        }
+    }
+}
+
+/// The fused GPU preprocess (`cuda-preprocess`) and the CPU preprocess produce
+/// equivalent detections through the same CUDA execution provider.
+#[cfg(feature = "cuda-preprocess")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_preprocess_on_off_parity() {
+    let image = load_bus_image();
+
+    let mut fused = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new()
+            .with_device(Device::Cuda(0))
+            .with_cuda_preprocess(true),
+    )
+    .expect("model with fused GPU preprocess should load");
+    let fused_res = fused.predict(&image).expect("fused prediction");
+    let fused_boxes = fused_res
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("fused boxes");
+
+    let mut cpu_pre = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new()
+            .with_device(Device::Cuda(0))
+            .with_cuda_preprocess(false),
+    )
+    .expect("model with CPU preprocess should load");
+    let cpu_pre_res = cpu_pre.predict(&image).expect("cpu-preprocess prediction");
+    let cpu_pre_boxes = cpu_pre_res
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("cpu-preprocess boxes");
+
+    let diff = fused_boxes.len().abs_diff(cpu_pre_boxes.len());
+    assert!(
+        diff <= 1,
+        "detection count mismatch: fused={}, cpu-preprocess={}",
+        fused_boxes.len(),
+        cpu_pre_boxes.len()
+    );
 }


### PR DESCRIPTION
## What this does

Adds a self-hosted GPU workflow and CUDA tests so the GPU code paths that hosted CI cannot reach are exercised and counted toward coverage.

## Changes

**`.github/workflows/gpu.yml`** (new)
- Runs on `[self-hosted, Linux, X64, gpu-latest]` on every PR, push to main, and manual dispatch, with a concurrency group that cancels superseded runs.
- Builds `--no-default-features --features annotate,cuda-preprocess` (pulls in cuda, tensorrt, cudarc).
- `nvidia-smi` / `nvcc` sanity gate, stable clippy with `-D warnings`, then a single `cargo llvm-cov ... --include-ignored --test-threads=1` run that doubles as the test suite and the coverage report.
- Uploads to Codecov under a `gpu` flag that includes `src/cuda_inference.rs` (dropped from the host coverage exclusions), so the fused kernel is finally measured.

**Tests (13)**
- `src/cuda_inference.rs`: 9 inline unit tests for `CudaStreamHandle::open`, `CudaPreprocessor::finalize`, and the fused kernel (letterbox geometry for square and non-square targets, normalize, CHW packing, BGR to RGB swap, padding value, wrong-length error, buffer growth), asserting on the device buffer copied back with `clone_dtoh`.
- `tests/integration_test.rs`: 4 `#[cfg(feature = "cuda")]` ignored tests covering CUDA load and warmup with an execution provider check, end to end detection on bus.jpg, CUDA versus CPU parity, and fused versus CPU preprocess parity.

**Clippy**
- Fixes 5 pre-existing nursery and pedantic warnings in `postprocessing.rs` and `preprocessing.rs` so the strict clippy step stays green.

## Notes

- The CUDA features need `nvcc`, so none of this builds on macOS. The runner is the verification path.
- `ORT_CUDA_VERSION` defaults to 12. If the runner reports CUDA 13 in `nvidia-smi`, bump it, and add `LD_LIBRARY_PATH` if the EP cannot load cuDNN or TensorRT.
- Starts on every PR to gauge runner throughput. If the pool queues, switch to a global serial concurrency group or a `gpu` label gate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds dedicated GPU CI and expanded CUDA preprocessing/inference tests to improve reliability for YOLO26 GPU workflows 🚀

### 📊 Key Changes
- Added a new **GPU CI workflow** for self-hosted NVIDIA runners with CUDA sanity checks, Rust setup, Clippy, test coverage, and Codecov upload 🧪
- Runs CUDA-specific tests with `cuda-preprocess` enabled, including coverage for GPU preprocessing code that standard hosted CI cannot exercise 🎯
- Added unit tests for `CudaPreprocessor`, covering:
  - CUDA stream creation
  - Device buffer allocation
  - Letterbox geometry and padding
  - RGB/BGR channel handling
  - Normalization
  - Invalid input length handling
  - Device buffer growth ⚙️
- Added ignored GPU integration tests that run only in GPU CI, validating:
  - CUDA model loading and warmup
  - YOLO26 inference on `bus.jpg`
  - CUDA vs CPU detection parity
  - Fused CUDA preprocessing vs CPU preprocessing parity 🚌
- Made several YOLO26 postprocessing shape helper functions `const fn` for compile-time compatibility and minor optimization ✨
- Updated preprocessing pixel iteration to use fixed-size chunking with `as_chunks::<3>()` for cleaner RGB handling 🔧

### 🎯 Purpose & Impact
- Improves confidence that CUDA inference and fused GPU preprocessing work correctly before changes reach users ✅
- Helps catch GPU-only regressions that normal CPU-based CI would miss 🛡️
- Ensures YOLO26 CUDA outputs stay consistent with CPU results, reducing surprises across deployment environments 📊
- Increases test coverage for performance-critical GPU preprocessing paths, supporting more stable and faster inference pipelines ⚡
- Provides a stronger foundation for maintaining reliable NVIDIA GPU support in `ultralytics/inference` 🤝