### PR TITLE
Use const fn and as_chunks in pre/postprocessing

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -219,7 +219,7 @@ pub fn postprocess(
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end detect layout `[1, max_det, 6]`.
-fn is_end2end_detect_shape(shape: &[usize]) -> bool {
+const fn is_end2end_detect_shape(shape: &[usize]) -> bool {
     shape.len() == 3 && shape[2] == 6 && shape[1] <= 4096
 }
 
@@ -233,7 +233,7 @@ fn is_end2end_segment_shape(shape: &[usize], proto_channels: Option<usize>) -> b
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end pose layout `[1, max_det, 6 + nk*dim]`.
-fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
+const fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
     shape.len() == 3 && shape[2] == 6 + nk * kpt_dim && shape[1] <= 4096
 }
 
@@ -245,7 +245,7 @@ fn is_end2end_pose_shape(shape: &[usize], nk: usize, kpt_dim: usize) -> bool {
 /// the layout is ambiguous: `(12, 3)` and `(18, 2)` both decode the same
 /// tensor. Ambiguous cases fall through to the legacy pose path rather than
 /// silently guessing the wrong dimension.
-fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
+const fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
     if shape.len() != 3 || shape[1] == 0 || shape[1] > 4096 || shape[2] <= 6 {
         return None;
     }
@@ -260,7 +260,7 @@ fn infer_end2end_kpt_shape(shape: &[usize]) -> Option<(usize, usize)> {
 }
 
 /// Detect if a 3D shape matches YOLO26 end2end OBB layout `[1, max_det, 7]`.
-fn is_end2end_obb_shape(shape: &[usize]) -> bool {
+const fn is_end2end_obb_shape(shape: &[usize]) -> bool {
     shape.len() == 3 && shape[2] == 7 && shape[1] <= 4096
 }
 

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -522,7 +522,7 @@ fn image_to_tensor_generic<T: Clone>(
     let (r_slice, rest) = tensor.as_slice_mut().unwrap().split_at_mut(h * w);
     let (g_slice, b_slice) = rest.split_at_mut(h * w);
 
-    for (i, chunk) in pixels.chunks_exact(3).enumerate() {
+    for (i, chunk) in pixels.as_chunks::<3>().0.iter().enumerate() {
         r_slice[i] = convert(chunk[0]);
         g_slice[i] = convert(chunk[1]);
         b_slice[i] = convert(chunk[2]);


### PR DESCRIPTION
Mark the YOLO26 end2end shape helpers `const fn` and replace `chunks_exact(3)` with `as_chunks::<3>()` in the tensor pack loop.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Rust inference preprocessing and postprocessing with small compile-time and iteration optimizations for YOLO26 outputs 🚀

### 📊 Key Changes
- Marked several YOLO26 end-to-end output shape detection helpers as `const fn` ⚙️
  - Detection shape checks
  - Pose shape checks
  - Keypoint shape inference
  - Oriented bounding box (OBB) shape checks
- Updated image preprocessing pixel iteration from `chunks_exact(3)` to `as_chunks::<3>()` 🖼️
- No functional behavior changes are introduced.

### 🎯 Purpose & Impact
- Enables certain shape checks to be evaluated at compile time where applicable, improving Rust code flexibility and potential optimization 🦀
- Makes RGB pixel processing more type-safe and explicit by iterating over fixed-size 3-channel chunks ✅
- Maintains existing inference behavior while improving code quality and performance readiness for YOLO26 workflows 🔍