### PR TITLE
Add CUDA inference tests

### DIFF
--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -303,3 +303,199 @@ impl CudaPreprocessor {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Runs only on an NVIDIA GPU: the whole module is `cuda-preprocess`-gated,
+    // so these compile and execute exclusively on the GPU CI runner. Inline
+    // tests reach the preprocessor's private `stream`/`input_dev` fields to copy
+    // the kernel output back to the host and assert on it.
+    use super::*;
+
+    /// Padded background emitted by the kernel (`114/255`).
+    const PAD: f32 = 114.0 / 255.0;
+    /// Tolerance for GPU-computed float comparisons.
+    const EPS: f32 = 1e-4;
+
+    /// Open device 0 and build a preprocessor targeting `dst_h` x `dst_w`.
+    fn preprocessor(dst_h: usize, dst_w: usize) -> CudaPreprocessor {
+        let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
+        CudaPreprocessor::finalize(handle, dst_h, dst_w).expect("finalize preprocessor")
+    }
+
+    /// Build an HWC RGB buffer filled with a single solid color.
+    fn solid(height: usize, width: usize, red: u8, green: u8, blue: u8) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(height * width * 3);
+        for _ in 0..height * width {
+            buf.extend_from_slice(&[red, green, blue]);
+        }
+        buf
+    }
+
+    /// Copy the device input buffer back to the host as flat CHW f32 planes.
+    fn readback(pre: &CudaPreprocessor) -> Vec<f32> {
+        pre.stream
+            .clone_dtoh(&pre.input_dev)
+            .expect("device to host copy")
+    }
+
+    #[test]
+    fn stream_handle_open() {
+        let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
+        // cudarc hands back CUDA's default stream, whose raw pointer is null by
+        // design, so only assert that the accessor is callable (it feeds ort's
+        // with_compute_stream) rather than that it is non-null.
+        let _ = handle.raw_stream_ptr();
+    }
+
+    #[test]
+    fn preprocessor_finalize_allocates() {
+        let pre = preprocessor(640, 640);
+        assert_eq!(pre.dst_hw(), (640, 640));
+        assert_ne!(
+            pre.input_dev_ptr(),
+            0,
+            "device input buffer must be allocated"
+        );
+    }
+
+    #[test]
+    fn preprocess_square_geometry() {
+        let mut pre = preprocessor(640, 640);
+        let (src_h, src_w) = (480u32, 640u32);
+        let frame = solid(src_h as usize, src_w as usize, 200, 100, 50);
+
+        let geom = pre
+            .preprocess(&frame, src_h, src_w, false)
+            .expect("preprocess");
+
+        // 640/640 = 1.0 is the binding axis; the 480-tall image is centered.
+        assert!((geom.scale - 1.0).abs() < EPS, "scale = {}", geom.scale);
+        assert_eq!(geom.pad_x, 0);
+        assert_eq!(geom.pad_y, 80);
+
+        let host = readback(&pre);
+        assert!(
+            host.iter().all(|&v| (0.0..=1.0).contains(&v)),
+            "every output value must be normalized into [0, 1]"
+        );
+    }
+
+    #[test]
+    fn preprocess_non_square_target() {
+        let mut pre = preprocessor(384, 640);
+        assert_eq!(pre.dst_hw(), (384, 640));
+
+        // 640x640 into 384x640: scale 0.6 fills the width, pads the height to 0.
+        let frame = solid(640, 640, 10, 20, 30);
+        let geom = pre.preprocess(&frame, 640, 640, false).expect("preprocess");
+
+        assert_eq!(geom.pad_y, 0);
+        assert!(
+            geom.pad_x > 0,
+            "expected horizontal padding, got {}",
+            geom.pad_x
+        );
+    }
+
+    #[test]
+    fn preprocess_padding_value() {
+        let (dst, src_h, src_w) = (128usize, 64u32, 32u32);
+        let mut pre = preprocessor(dst, dst);
+        let frame = solid(src_h as usize, src_w as usize, 255, 255, 255);
+
+        let geom = pre
+            .preprocess(&frame, src_h, src_w, false)
+            .expect("preprocess");
+        assert!(
+            geom.pad_x > 0,
+            "expected horizontal padding, got {}",
+            geom.pad_x
+        );
+
+        // The top-left pixel is outside the resized image, so it is background.
+        let host = readback(&pre);
+        let hw = dst * dst;
+        for plane in 0..3 {
+            let v = host[plane * hw];
+            assert!(
+                (v - PAD).abs() < EPS,
+                "padding plane {plane} = {v}, want {PAD}"
+            );
+        }
+    }
+
+    #[test]
+    fn preprocess_center_normalize() {
+        let dst = 64usize;
+        let mut pre = preprocessor(dst, dst);
+        // Square input, no letterbox: every pixel is R=255, G=0, B=0.
+        let frame = solid(dst, dst, 255, 0, 0);
+        pre.preprocess(&frame, dst as u32, dst as u32, false)
+            .expect("preprocess");
+
+        let host = readback(&pre);
+        let hw = dst * dst;
+        let idx = (dst / 2) * dst + dst / 2;
+        assert!((host[idx] - 1.0).abs() < EPS, "R plane = {}", host[idx]);
+        assert!(host[hw + idx].abs() < EPS, "G plane = {}", host[hw + idx]);
+        assert!(
+            host[2 * hw + idx].abs() < EPS,
+            "B plane = {}",
+            host[2 * hw + idx]
+        );
+    }
+
+    #[test]
+    fn preprocess_bgr_swap() {
+        let dst = 64usize;
+        let frame = solid(dst, dst, 255, 0, 0); // byte order [255, 0, 0]
+        let hw = dst * dst;
+        let idx = (dst / 2) * dst + dst / 2;
+
+        let mut rgb = preprocessor(dst, dst);
+        rgb.preprocess(&frame, dst as u32, dst as u32, false)
+            .expect("rgb preprocess");
+        let rgb_host = readback(&rgb);
+
+        let mut bgr = preprocessor(dst, dst);
+        bgr.preprocess(&frame, dst as u32, dst as u32, true)
+            .expect("bgr preprocess");
+        let bgr_host = readback(&bgr);
+
+        // RGB reads byte[0]=255 into R; BGR reads the same byte into B.
+        assert!(
+            (rgb_host[idx] - 1.0).abs() < EPS,
+            "rgb R = {}",
+            rgb_host[idx]
+        );
+        assert!(bgr_host[idx].abs() < EPS, "bgr R = {}", bgr_host[idx]);
+        assert!(
+            (bgr_host[2 * hw + idx] - 1.0).abs() < EPS,
+            "bgr B = {}",
+            bgr_host[2 * hw + idx]
+        );
+    }
+
+    #[test]
+    fn preprocess_rejects_wrong_len() {
+        let mut pre = preprocessor(64, 64);
+        let bad = vec![0u8; 10]; // != 64 * 64 * 3
+        let result = pre.preprocess(&bad, 64, 64, false);
+        assert!(
+            matches!(result, Err(InferenceError::InferenceError(_))),
+            "wrong-length frame must be rejected"
+        );
+    }
+
+    #[test]
+    fn preprocess_frame_buffer_growth() {
+        let mut pre = preprocessor(128, 128);
+        // First a small frame, then a larger one to force `frame_dev` to grow.
+        let small = solid(32, 32, 1, 2, 3);
+        pre.preprocess(&small, 32, 32, false).expect("small frame");
+        let large = solid(256, 256, 4, 5, 6);
+        pre.preprocess(&large, 256, 256, false)
+            .expect("large frame after buffer growth");
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,7 +12,7 @@ use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
 use ultralytics_inference::task::Task;
 use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
-#[cfg(feature = "coreml")]
+#[cfg(any(feature = "coreml", feature = "cuda"))]
 use ultralytics_inference::{Device, YOLOModel};
 
 /// End-to-end `CoreML` test covering two known regressions:
@@ -277,4 +277,156 @@ fn test_speed_timing() {
     assert_eq!(speed.preprocess, Some(10.0));
     assert_eq!(speed.inference, Some(20.0));
     assert_eq!(speed.postprocess, Some(5.0));
+}
+
+// GPU inference tests. Gated on the `cuda` feature and `#[ignore]`d so they run
+// only on the self-hosted GPU CI (via `--include-ignored`), never on hosted
+// runners. They auto-download `yolo26n.onnx` and the bus.jpg sample.
+
+#[cfg(feature = "cuda")]
+fn load_bus_image() -> String {
+    ultralytics_inference::download::download_image("https://ultralytics.com/images/bus.jpg")
+        .expect("bus.jpg should download")
+}
+
+/// Loading on `Device::Cuda(0)` registers the CUDA execution provider and warms
+/// up without error (warmup runs inside `load_with_config`).
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_model_loads_and_warms_up() {
+    let config = InferenceConfig::new().with_device(Device::Cuda(0));
+    let model = YOLOModel::load_with_config("yolo26n.onnx", config)
+        .expect("CUDA model should load and warm up");
+
+    let ep = model.execution_provider();
+    assert!(
+        ep.to_lowercase().contains("cuda"),
+        "expected the CUDA execution provider, got '{ep}'"
+    );
+}
+
+/// End-to-end CUDA inference on bus.jpg yields at least one detection.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_predict_bus_has_detections() {
+    let config = InferenceConfig::new().with_device(Device::Cuda(0));
+    let mut model =
+        YOLOModel::load_with_config("yolo26n.onnx", config).expect("CUDA model should load");
+    let image = load_bus_image();
+
+    let results = model
+        .predict(&image)
+        .expect("CUDA prediction should succeed");
+    let boxes = results
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("bus.jpg should produce boxes on CUDA");
+    assert!(
+        !boxes.is_empty(),
+        "expected at least one detection on bus.jpg"
+    );
+}
+
+/// CUDA and CPU inference produce equivalent detections on the same image.
+/// Both sides use the CPU letterbox preprocess (the CUDA model pins
+/// `with_cuda_preprocess(false)`, which the `cuda-preprocess` feature otherwise
+/// defaults on) so the comparison isolates the inference engines rather than the
+/// resize path; the fused GPU preprocess is covered by
+/// `test_cuda_preprocess_on_off_parity`.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_cpu_detection_parity() {
+    let image = load_bus_image();
+
+    let mut cuda_model = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new()
+            .with_device(Device::Cuda(0))
+            .with_cuda_preprocess(false),
+    )
+    .expect("CUDA model should load");
+    let cuda = cuda_model.predict(&image).expect("CUDA prediction");
+    let cuda_boxes = cuda
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("CUDA boxes");
+
+    let mut cpu_model = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new().with_device(Device::Cpu),
+    )
+    .expect("CPU model should load");
+    let cpu = cpu_model.predict(&image).expect("CPU prediction");
+    let cpu_boxes = cpu
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("CPU boxes");
+
+    // Counts match within one box: NMS can keep/drop a borderline candidate
+    // differently under GPU vs CPU rounding.
+    let diff = cuda_boxes.len().abs_diff(cpu_boxes.len());
+    assert!(
+        diff <= 1,
+        "detection count mismatch: cuda={}, cpu={}",
+        cuda_boxes.len(),
+        cpu_boxes.len()
+    );
+
+    // Matched leading boxes (sorted by confidence) agree to a couple of pixels.
+    for (cb, pb) in cuda_boxes
+        .xyxy()
+        .outer_iter()
+        .zip(cpu_boxes.xyxy().outer_iter())
+    {
+        for (x, y) in cb.iter().zip(pb.iter()) {
+            let d = (x - y).abs();
+            assert!(d < 2.0, "box corner differs by {d}px between cuda and cpu");
+        }
+    }
+}
+
+/// The fused GPU preprocess (`cuda-preprocess`) and the CPU preprocess produce
+/// equivalent detections through the same CUDA execution provider.
+#[cfg(feature = "cuda-preprocess")]
+#[test]
+#[ignore = "requires NVIDIA GPU; run on GPU CI"]
+fn test_cuda_preprocess_on_off_parity() {
+    let image = load_bus_image();
+
+    let mut fused = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new()
+            .with_device(Device::Cuda(0))
+            .with_cuda_preprocess(true),
+    )
+    .expect("model with fused GPU preprocess should load");
+    let fused_res = fused.predict(&image).expect("fused prediction");
+    let fused_boxes = fused_res
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("fused boxes");
+
+    let mut cpu_pre = YOLOModel::load_with_config(
+        "yolo26n.onnx",
+        InferenceConfig::new()
+            .with_device(Device::Cuda(0))
+            .with_cuda_preprocess(false),
+    )
+    .expect("model with CPU preprocess should load");
+    let cpu_pre_res = cpu_pre.predict(&image).expect("cpu-preprocess prediction");
+    let cpu_pre_boxes = cpu_pre_res
+        .first()
+        .and_then(|r| r.boxes.as_ref())
+        .expect("cpu-preprocess boxes");
+
+    let diff = fused_boxes.len().abs_diff(cpu_pre_boxes.len());
+    assert!(
+        diff <= 1,
+        "detection count mismatch: fused={}, cpu-preprocess={}",
+        fused_boxes.len(),
+        cpu_pre_boxes.len()
+    );
 }


### PR DESCRIPTION
On-device unit tests for the fused preprocess kernel (`cuda_inference.rs`) and `#[ignore]`d e2e tests for CUDA load/predict/parity (`integration_test.rs`), gated on `cuda`/`cuda-preprocess` for the GPU CI runner.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds CUDA-focused tests to validate GPU preprocessing, model loading, and inference parity for YOLO26 ONNX workflows 🚀

### 📊 Key Changes
- Added comprehensive unit tests for `CudaPreprocessor` covering allocation, stream handling, geometry, padding, normalization, RGB/BGR channel handling, invalid input rejection, and GPU buffer growth 🧪
- Added ignored CUDA integration tests that run only when the `cuda` feature is enabled and a GPU runner includes ignored tests ⚙️
- Added end-to-end CUDA checks for loading and warming up `yolo26n.onnx` on `Device::Cuda(0)` 🔥
- Added CUDA prediction test using the Ultralytics bus image to confirm GPU inference returns detections 🚌
- Added CPU vs CUDA detection parity checks to ensure similar inference results across execution providers ✅
- Added fused CUDA preprocessing vs CPU preprocessing parity checks under the `cuda-preprocess` feature 🔁
- Updated test imports so `Device` and `YOLOModel` are available for both CoreML and CUDA test builds 🛠️

### 🎯 Purpose & Impact
- Improves confidence that CUDA inference and preprocessing work correctly on NVIDIA GPU environments 💪
- Helps catch regressions in GPU letterboxing, padding, normalization, color channel ordering, and memory handling before release 🧯
- Verifies CUDA execution provider setup and warmup behavior for smoother user deployment experiences 🚀
- Ensures CUDA results stay closely aligned with CPU results, reducing surprises when users switch devices ⚖️
- Strengthens CI coverage for YOLO26 ONNX GPU inference while keeping GPU-only tests safely disabled on standard hosted runners 🧠