### PR TITLE
Bump taiki-e/install-action from v2.82.9 to v2.82.10 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: wasm-pack
 
@@ -279,7 +279,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.9 to v2.82.10 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates GitHub Actions tooling for Rust/WASM workflows to a newer pinned `taiki-e/install-action` version 🚀

### 📊 Key Changes
- Bumped `taiki-e/install-action` from `v2.82.9` to `v2.82.10` in CI workflows 🔧
- Updated installs for:
  - `wasm-pack` in CI and npm publish workflows 📦
  - `cargo-llvm-cov` in CI coverage workflow ✅
- Kept actions pinned by commit hash for reproducible and secure workflow runs 🔒

### 🎯 Purpose & Impact
- Improves CI and npm publishing reliability by using the latest patch version of the install action ⚙️
- Maintains secure, deterministic builds through commit-pinned GitHub Actions 🛡️
- No expected user-facing behavior changes; this is a maintenance update for developer infrastructure ✨