### PR TITLE
Bump astral-sh/setup-uv from v8.3.0 to v8.3.1 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
         with:
           enable-cache: false
       - name: Install ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.3.0 to v8.3.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions `uv` setup step to a newer pinned version for the publish workflow 🔧

### 📊 Key Changes
- Bumped `astral-sh/setup-uv` from `v8.3.0` to `v8.3.1` in `.github/workflows/publish.yml` 📦
- Updated the pinned commit SHA to match the newer action version for secure and reproducible CI runs 🔐

### 🎯 Purpose & Impact
- Improves workflow reliability by using the latest patch release of the `setup-uv` action ✅
- Maintains secure dependency pinning in CI/CD while benefiting from upstream fixes 🛡️
- No expected impact on end users or inference functionality; this is a maintenance-only CI update 🚀