### PR TITLE
LiteRT wasm multithreading for up to 2x faster CPU inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,7 +2622,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.26"
+version = "0.0.27"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.27 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -215,7 +215,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.27 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -311,7 +311,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.26"
+ultralytics-inference = "0.0.27"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,7 +194,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.27 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -214,7 +214,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.26 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.27 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -310,7 +310,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.26"
+ultralytics-inference = "0.0.27"
 ```
 
 ```toml

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.26"
+version = "0.0.27"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -27,9 +27,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.26", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.27", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.26", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.27", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -59,7 +59,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.26", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.27", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -343,7 +343,7 @@ interface LiteRtCompiledModel {
   delete?(): void;
 }
 interface LiteRtModule {
-  loadLiteRt(wasmPath: string): Promise<void>;
+  loadLiteRt(wasmPath: string, opts?: { threads?: boolean }): Promise<void>;
   loadAndCompile(model: Uint8Array | string, opts: { accelerator: string | string[] }): Promise<LiteRtCompiledModel>;
   Tensor: new (data: Float32Array, shape: number[]) => LiteRtTensor;
 }
@@ -385,7 +385,12 @@ function ensureLiteRtRuntime(litert: LiteRtModule, wasmUrl: string): Promise<voi
     return litertInit;
   }
   litertInitUrl = wasmUrl;
-  litertInit = litert.loadLiteRt(wasmUrl).catch((e) => {
+  // Enable WASM multithreading when the page is cross-origin isolated (COOP/COEP
+  // set, so SharedArrayBuffer is available); otherwise LiteRT.js runs single-
+  // threaded. SIMD is detected by LiteRT itself. Isolation is a page-global
+  // property, so this needs no per-load option.
+  const threads = typeof crossOriginIsolated !== "undefined" && crossOriginIsolated;
+  litertInit = litert.loadLiteRt(wasmUrl, { threads }).catch((e) => {
     litertInit = null; // let a later load retry if the first init failed
     litertInitUrl = null;
     throw e;


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps Ultralytics Inference to `0.0.27` and enables optional LiteRT WebAssembly multithreading in supported browsers 🚀

### 📊 Key Changes
- Updated Rust crate versions from `0.0.26` to `0.0.27` across the main package and web crate 📦
- Updated the npm package `@ultralytics/yolo` version to `0.0.27` 🌐
- Refreshed README, Chinese README, and CUDA documentation examples to reference the new release version 📚
- Extended the LiteRT web runtime loader to accept an optional `threads` setting ⚙️
- Automatically enables WASM multithreading when the browser page is `crossOriginIsolated`, allowing use of `SharedArrayBuffer` where available 🧵
- Updated generated dependency lock files: `Cargo.lock` and `web/package-lock.json` 🔒

### 🎯 Purpose & Impact
- Keeps package metadata and documentation aligned for the `0.0.27` release ✅
- Improves browser inference performance potential by allowing LiteRT.js to use multithreaded WASM when security headers support it ⚡
- Maintains compatibility by falling back to single-threaded execution when cross-origin isolation is unavailable 🛡️
- Makes setup instructions clearer and current for Rust, CUDA, TensorRT, and WebGPU users using Ultralytics YOLO models 🧰
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
