### PR TITLE
Bump taiki-e/install-action from v2.82.10 to v2.82.11 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        uses: taiki-e/install-action@5ebac0d9522d786674368e47e92963ba13f2c376 # v2.82.11
         with:
           tool: wasm-pack
 
@@ -279,7 +279,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        uses: taiki-e/install-action@5ebac0d9522d786674368e47e92963ba13f2c376 # v2.82.11
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        uses: taiki-e/install-action@5ebac0d9522d786674368e47e92963ba13f2c376 # v2.82.11
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.10 to v2.82.11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates GitHub workflow tooling to use the latest pinned `taiki-e/install-action` version for WebAssembly and coverage-related CI tasks 🔧

### 📊 Key Changes
- Bumped `taiki-e/install-action` from `v2.82.10` to `v2.82.11` in CI workflows.
- Updated the action hash in `.github/workflows/ci.yml` for:
  - `wasm-pack` installation 🧩
  - `cargo-llvm-cov` installation 📈
- Updated the action hash in `.github/workflows/npm-publish.yml` for `wasm-pack` installation 📦
- No application, model, or inference logic was changed.

### 🎯 Purpose & Impact
- Improves workflow reliability by keeping GitHub Actions dependencies current ✅
- Maintains pinned action versions for better security and reproducibility 🔒
- Supports stable WebAssembly build, test coverage, and npm publishing pipelines 🚀
- Users should see no direct behavior changes, but maintainers benefit from healthier CI/CD automation.