### PR TITLE
Bump astral-sh/setup-uv from v8.3.1 to v8.3.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
       - name: Install ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.3.1 to v8.3.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions `uv` setup action to a newer pinned version for the Ultralytics Inference publish workflow 🔄

### 📊 Key Changes
- Upgraded `astral-sh/setup-uv` from `v8.3.1` to `v8.3.2` in `.github/workflows/publish.yml` ⚙️
- Kept the action pinned to a specific commit hash for improved supply-chain security 🔐
- No changes to inference code, APIs, models, or user-facing behavior ✅

### 🎯 Purpose & Impact
- Improves CI/CD reliability by using the latest patch release of the `setup-uv` GitHub Action 🚀
- Helps keep the package publishing workflow maintained and secure 🛡️
- Expected impact is limited to internal release automation, with no direct changes required from users or developers 🙌