### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,11 +290,12 @@ jobs:
         run: cargo llvm-cov --features annotate,video,visualize --workspace --lcov --output-path lcov.info --ignore-filename-regex '(src/cuda_inference\.rs|src/visualizer/viewer\.rs|src/main\.rs|crates/web/)'
 
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./lcov.info
           disable_search: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           plugins: noop
           flags: template_coverage
           use_oidc: true


### PR DESCRIPTION
## Summary\n- make the Codecov upload step non-blocking\n- keep existing coverage files, OIDC, flags, and plugins settings\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CI reliability by making Codecov coverage uploads non-blocking 🚀

### 📊 Key Changes
- Updated the GitHub Actions CI workflow for coverage reporting.
- Added `continue-on-error: true` to the Codecov upload step.
- Changed Codecov behavior from `fail_ci_if_error: true` to `fail_ci_if_error: false`.
- Coverage is still uploaded using the existing `lcov.info` report and Codecov action.

### 🎯 Purpose & Impact
- Prevents external Codecov upload issues from failing otherwise successful CI runs ✅
- Keeps coverage reporting active while reducing flaky pipeline failures.
- Improves developer productivity by avoiding unnecessary PR blocks caused by third-party service interruptions.
- Makes the CI process more resilient and smoother for contributors 🤝