### PR TITLE
Reuse scale_keypoint for the OBB center point

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1283,21 +1283,12 @@ fn postprocess_obb(
         let h = output_2d[[i, 3]];
         let angle = output_2d[[i, 4 + num_classes]]; // Last value is rotation angle (radians)
 
-        // Scale center coordinates to original image space
-        let scaled = scale_coords(&[cx, cy, cx, cy], preprocess.scale, preprocess.padding);
-        let scaled_cx = scaled[0];
-        let scaled_cy = scaled[1];
+        // Scale center to original image space and clip to bounds.
+        let (clipped_cx, clipped_cy) = scale_keypoint(cx, cy, preprocess);
 
         // Scale width and height (note: don't apply padding, just scale)
         let scaled_w = w / preprocess.scale.1;
         let scaled_h = h / preprocess.scale.0;
-
-        // Clip center to image bounds
-        let (oh, ow) = preprocess.orig_shape;
-        #[allow(clippy::cast_precision_loss)]
-        let clipped_cx = scaled_cx.max(0.0).min(ow as f32);
-        #[allow(clippy::cast_precision_loss)]
-        let clipped_cy = scaled_cy.max(0.0).min(oh as f32);
 
         // Filter by class if specified
         if !config.keep_class(best_class) {


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Simplified oriented bounding box postprocessing by using the shared keypoint scaling and clipping helper.

### 📊 Key Changes

- Replaced manual center-coordinate scaling with `scale_keypoint`.
- Centralized clipping of OBB centers to image boundaries.
- Removed duplicated image-dimension handling and precision-warning suppressions.
- Kept width and height scaling behavior unchanged.

### 🎯 Purpose & Impact

- ✅ Makes OBB postprocessing more concise and consistent with other coordinate transformations.
- 🧩 Reduces duplicated logic, improving maintainability and lowering the risk of inconsistent boundary handling.
- 📦 Preserves existing output behavior while ensuring OBB centers are scaled and clipped correctly.