### PR TITLE
Consolidate the inference input-tensor preludes

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1576,6 +1576,32 @@ impl YOLOModel {
     ///
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
     #[cfg_attr(coverage_nightly, coverage(off))]
+    /// Feed an FP32 input tensor and run timed inference, returning the ORT outputs.
+    fn run_f32_input<'s>(
+        session: &'s mut Session,
+        input_name: &str,
+        input: &ndarray::Array4<f32>,
+    ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
+        let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+        })?;
+        Self::run_timed(session, ort::inputs![input_name => input_tensor])
+    }
+
+    /// Feed an FP16 input tensor and run timed inference, returning the ORT outputs.
+    fn run_f16_input<'s>(
+        session: &'s mut Session,
+        input_name: &str,
+        input: &ndarray::Array4<f16>,
+    ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
+        let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
+        })?;
+        Self::run_timed(session, ort::inputs![input_name => input_tensor])
+    }
+
     fn run_inference_with<R>(
         session: &mut Session,
         input_name: &str,
@@ -1583,11 +1609,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f32>,
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f32_input(session, input_name, input)?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 
@@ -1650,11 +1672,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f32>,
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f32_input(session, input_name, input)?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
@@ -1695,11 +1713,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f16>,
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f16_input(session, input_name, input)?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
@@ -1712,11 +1726,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f16>,
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f16_input(session, input_name, input)?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactored Rust inference input handling by centralizing FP32 and FP16 tensor execution into reusable helper functions. 🦀

### 📊 Key Changes
- Added dedicated helpers for running inference with:
  - FP32 `ndarray::Array4<f32>` inputs.
  - FP16 `ndarray::Array4<f16>` inputs.
- Preserved contiguous memory layout conversion and timed ONNX Runtime execution.
- Updated existing inference paths to use the new helpers.
- Kept input tensor creation errors explicit, including FP16-specific error messages.

### 🎯 Purpose & Impact
- Reduces duplicated tensor-conversion and inference code, improving maintainability. 🧹
- Ensures FP32 and FP16 inference paths follow consistent execution behavior.
- Keeps existing inference outputs and timing behavior unchanged.
- Makes future input-type extensions or inference updates easier to implement. 🚀