### PR TITLE
Consolidate the inference input-tensor preludes

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1576,6 +1576,32 @@ impl YOLOModel {
     ///
     /// Associated fn (not method) so callers can split-borrow other fields of `YOLOModel`.
     #[cfg_attr(coverage_nightly, coverage(off))]
+    /// Feed an FP32 input tensor and run timed inference, returning the ORT outputs.
+    fn run_f32_input<'s>(
+        session: &'s mut Session,
+        input_name: &str,
+        input: &ndarray::Array4<f32>,
+    ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
+        let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
+        })?;
+        Self::run_timed(session, ort::inputs![input_name => input_tensor])
+    }
+
+    /// Feed an FP16 input tensor and run timed inference, returning the ORT outputs.
+    fn run_f16_input<'s>(
+        session: &'s mut Session,
+        input_name: &str,
+        input: &ndarray::Array4<f16>,
+    ) -> Result<(ort::session::SessionOutputs<'s>, f64)> {
+        let input_contiguous = input.as_standard_layout();
+        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
+            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
+        })?;
+        Self::run_timed(session, ort::inputs![input_name => input_tensor])
+    }
+
     fn run_inference_with<R>(
         session: &mut Session,
         input_name: &str,
@@ -1583,11 +1609,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f32>,
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f32_input(session, input_name, input)?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 
@@ -1650,11 +1672,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f32>,
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(input_contiguous.view()).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f32_input(session, input_name, input)?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
@@ -1695,11 +1713,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f16>,
         cb: impl FnOnce(&[(&[u8], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f16_input(session, input_name, input)?;
         Self::extract_and_invoke_u8(&outputs, output_names, ms, cb)
     }
 
@@ -1712,11 +1726,7 @@ impl YOLOModel {
         input: &ndarray::Array4<f16>,
         cb: impl FnOnce(&[(&[f32], Vec<usize>)], f64) -> Result<R>,
     ) -> Result<R> {
-        let input_contiguous = input.as_standard_layout();
-        let input_tensor = TensorRef::from_array_view(&input_contiguous).map_err(|e| {
-            InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
-        })?;
-        let (outputs, ms) = Self::run_timed(session, ort::inputs![input_name => input_tensor])?;
+        let (outputs, ms) = Self::run_f16_input(session, input_name, input)?;
         Self::extract_and_invoke(&outputs, output_names, ms, cb)
     }
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refactored inference input handling by centralizing FP32 and FP16 tensor execution into reusable helper functions. 🦀

### 📊 Key Changes

- Added dedicated helpers for running inference with:
  - FP32 `Array4<f32>` inputs.
  - FP16 `Array4<f16>` inputs.
- Preserved contiguous memory layout handling before creating ONNX Runtime tensor references.
- Updated existing inference paths to use the new helpers instead of duplicating tensor-conversion logic.
- Retained existing timing, output extraction, and error-reporting behavior.

### 🎯 Purpose & Impact

- Reduces duplicated Rust code and makes the inference implementation easier to maintain. 🧹
- Provides clearer separation between FP32 and FP16 input handling.
- Helps prevent inconsistencies between different inference paths.
- No expected user-facing behavior changes; inference results and timing behavior should remain the same. ✅