### PR TITLE
Bump actions/setup-node from v6.4.0 to v7.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
           tool: wasm-pack
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,7 @@ jobs:
       version: ${{ steps.check_version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - id: check_version
@@ -75,7 +75,7 @@ jobs:
           tool: wasm-pack
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Bump actions/setup-node from v6.4.0 to v7.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded GitHub Actions’ Node.js setup action from v6.4.0 to v7.0.0 across CI and npm publishing workflows. ⚙️

### 📊 Key Changes

- Updated `actions/setup-node` to v7.0.0 in the main CI workflow.
- Updated `actions/setup-node` to v7.0.0 in both npm publishing workflow jobs.
- Kept Node.js 20 as the runtime version.
- Preserved npm registry configuration for package publishing.

### 🎯 Purpose & Impact

- ✅ Keeps automation workflows aligned with the latest supported Node.js setup action.
- 🔒 Uses pinned action references for reproducible and secure builds.
- 🚀 Maintains existing CI testing and npm publishing behavior without changing runtime versions.
- 🛠️ May provide ongoing compatibility, maintenance, and security improvements from the newer action release.