### PR TITLE
Pin coverage job to known-good nightly to avoid rustc ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libavutil-dev libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libswscale-dev libswresample-dev libpostproc-dev clang
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@nightly
+        # Pinned to a known-good nightly to dodge latest-nightly rustc ICEs; bump forward periodically.
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-13
 
       # Nightly toolchain version in rustc -V already gives this job a unique cache key
       - name: Cache Rust dependencies


### PR DESCRIPTION
The coverage job uses `dtolnay/rust-toolchain@nightly` (latest, unpinned), so a broken nightly crashed rustc with an internal compiler error and failed CI on unrelated PRs.

Pin to `nightly-2026-07-13` so the job stays on nightly and keeps the `#[coverage(off)]` exclusions working, without inheriting random latest-nightly ICEs. Bump forward periodically.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Pinned the CI workflow to a known-good Rust nightly toolchain to avoid compiler crashes in automated builds. 🦀

### 📊 Key Changes

- Replaced the moving `nightly` Rust toolchain with `nightly-2026-07-13`.
- Updated the Rust toolchain action to use `dtolnay/rust-toolchain@master`.
- Added a comment documenting why the version is pinned and that it should be updated periodically.

### 🎯 Purpose & Impact

- Prevents CI failures caused by internal compiler errors in newer Rust nightly releases. ✅
- Makes Rust dependency caching and build results more consistent and reproducible.
- Future nightly upgrades will require an intentional, periodic update rather than happening automatically. 🔧