### PR TITLE
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,7 +166,7 @@ jobs:
     steps:
       - name: Notify Success
         if: needs.build.result == 'success' && needs.publish.result == 'success' && needs.sbom.result == 'success'
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -174,7 +174,7 @@ jobs:
             text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.build.result != 'success' || needs.publish.result != 'success' || needs.sbom.result != 'success'
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded the GitHub Actions Slack notification integration from v3.0.5 to v4.0.0. 🔔

### 📊 Key Changes

- Updated the pinned `slackapi/slack-github-action` version in `.github/workflows/publish.yml`.
- Applied the upgrade to both release success and failure notifications.
- Kept the existing webhook configuration and notification messages unchanged.

### 🎯 Purpose & Impact

- Ensures Slack notifications use the latest supported action implementation. ✅
- Improves workflow maintenance and may provide upstream fixes or enhancements from the v4 release.
- Release teams should continue receiving success and failure alerts without changes to their Slack setup.