### PR TITLE
Add runnable Rust library examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ name = "basic"
 name = "config"
 
 [[example]]
+name = "tasks"
+
+[[example]]
 name = "annotate"
 required-features = ["annotate"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ include = [
     "/README.md",
     "/src/**/*.rs",
     "/tests/**/*.rs",
+    "/examples/**/*.rs",
+    "/examples/README.md",
     "/docs/**/*.md",
 ]
 
@@ -63,6 +65,13 @@ path = "src/lib.rs"
 [[bin]]
 name = "ultralytics-inference"
 path = "src/main.rs"
+
+[[example]]
+name = "basic"
+
+[[example]]
+name = "annotate"
+required-features = ["annotate"]
 
 [dependencies]
 # Core - Image loading and processing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ path = "src/main.rs"
 name = "basic"
 
 [[example]]
+name = "config"
+
+[[example]]
 name = "annotate"
 required-features = ["annotate"]
 

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ inference/
 ├── examples/               # Runnable library examples
 │   ├── basic.rs            # Load a model, run inference, print detections
 │   ├── config.rs           # Set confidence, IoU, image size, and device
+│   ├── tasks.rs            # Summary for detect, segment, pose, obb, classify
 │   ├── annotate.rs         # Draw boxes and labels, save the annotated image
 │   └── README.md           # Examples guide
 ├── assets/                 # Test images

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ inference/
 │   └── integration_test.rs # Integration tests
 ├── examples/               # Runnable library examples
 │   ├── basic.rs            # Load a model, run inference, print detections
+│   ├── config.rs           # Set confidence, IoU, image size, and device
 │   ├── annotate.rs         # Draw boxes and labels, save the annotated image
 │   └── README.md           # Examples guide
 ├── assets/                 # Test images

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+For runnable programs you can copy and adapt, see the [examples](examples/README.md) directory.
+
 ## 🗂️ Project Structure
 
 ```text
@@ -441,6 +443,10 @@ inference/
 │   └── visualizer/         # Real-time visualization (minifb)
 ├── tests/
 │   └── integration_test.rs # Integration tests
+├── examples/               # Runnable library examples
+│   ├── basic.rs            # Load a model, run inference, print detections
+│   ├── annotate.rs         # Draw boxes and labels, save the annotated image
+│   └── README.md           # Examples guide
 ├── assets/                 # Test images
 │   ├── boats.jpg
 │   ├── bus.jpg

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -445,6 +445,7 @@ inference/
 ├── examples/               # 可运行的库示例
 │   ├── basic.rs            # 加载模型、运行推理、打印检测结果
 │   ├── config.rs           # 设置置信度、IoU、图片尺寸和设备
+│   ├── tasks.rs            # 检测、分割、姿态、旋转框、分类的结果概览
 │   ├── annotate.rs         # 绘制边界框和标签，保存标注后的图片
 │   └── README.md           # 示例说明
 ├── assets/                 # 测试图片

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -444,6 +444,7 @@ inference/
 │   └── integration_test.rs # 集成测试
 ├── examples/               # 可运行的库示例
 │   ├── basic.rs            # 加载模型、运行推理、打印检测结果
+│   ├── config.rs           # 设置置信度、IoU、图片尺寸和设备
 │   ├── annotate.rs         # 绘制边界框和标签，保存标注后的图片
 │   └── README.md           # 示例说明
 ├── assets/                 # 测试图片

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -408,6 +408,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+可复制并修改的可运行程序，请参见 [examples](examples/README.md) 目录。
+
 ## 🗂️ 项目结构
 
 ```text
@@ -440,6 +442,10 @@ inference/
 │   └── visualizer/         # 实时可视化（minifb）
 ├── tests/
 │   └── integration_test.rs # 集成测试
+├── examples/               # 可运行的库示例
+│   ├── basic.rs            # 加载模型、运行推理、打印检测结果
+│   ├── annotate.rs         # 绘制边界框和标签，保存标注后的图片
+│   └── README.md           # 示例说明
 ├── assets/                 # 测试图片
 │   ├── boats.jpg
 │   ├── bus.jpg

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,45 @@
+<a href="https://www.ultralytics.com/" target="_blank"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+
+# Ultralytics YOLO Rust Examples
+
+<img alt="Rust" src="https://img.shields.io/badge/Rust-1.89%2B-CE422B.svg?logo=rust&logoColor=white"> <a href="https://docs.rs/ultralytics-inference" target="_blank"><img alt="docs.rs" src="https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B"></a> <a href="https://docs.ultralytics.com/" target="_blank"><img alt="Ultralytics Docs" src="https://img.shields.io/badge/Ultralytics-Docs-042AFF.svg?logo=ultralytics&logoColor=white"></a>
+
+Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ultralytics-inference) library. Each example is a single file you run with `cargo run --example`. They show how to load and run [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26/), [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11/), and [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8/) models from Rust.
+
+> [!NOTE]
+> Model metadata (classes, task, image size) is read from the ONNX file, so Ultralytics YOLOv8, Ultralytics YOLO11, and Ultralytics YOLO26 models all work without extra configuration. Each example takes an optional image path and downloads a sample image when none is given.
+
+## 📂 Examples
+
+| Example                 | Feature    | Description                                     | Run                                                |
+| ----------------------- | ---------- | ----------------------------------------------- | -------------------------------------------------- |
+| [basic](basic.rs)       | none       | Load a model, run inference, print detections   | `cargo run --example basic`                        |
+| [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image | `cargo run --example annotate --features annotate` |
+
+## ✅ How to Run
+
+Run any example from the repository root. The model and a sample image are downloaded on first use, so a network connection is needed once.
+
+```bash
+# Print detections for the sample image
+cargo run --example basic
+
+# Use your own image
+cargo run --example basic -- path/to/image.jpg
+
+# Annotate and save to runs/predict/annotated_*.jpg
+cargo run --example annotate --features annotate
+```
+
+To run your own model, export one with the Ultralytics Python package and pass its path:
+
+```bash
+pip install ultralytics
+yolo export model=yolo26n.pt format=onnx
+
+cargo run --example basic -- image.jpg
+```
+
+## 🤝 Contributing
+
+Contributions are welcome. If you find an issue with an example or want to add one, open an issue or pull request on the [Ultralytics inference repository](https://github.com/ultralytics/inference).

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,8 +44,8 @@ cargo run --example tasks -- yolo26n-seg.onnx   # segment
 cargo run --example tasks -- yolo26n-pose.onnx  # pose
 cargo run --example tasks -- yolo26n-obb.onnx   # obb
 cargo run --example tasks -- yolo26n-cls.onnx   # classify
-cargo run --example tasks -- yolo26n-sem.onnx   # semantic (YOLO26)
-cargo run --example tasks -- yolo26n-depth.onnx # depth (YOLO26)
+cargo run --example tasks -- yolo26n-sem.onnx   # semantic (Ultralytics YOLO26)
+cargo run --example tasks -- yolo26n-depth.onnx # depth (Ultralytics YOLO26)
 ```
 
 The `basic` example prints one block per image:

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,4 +59,4 @@ To run a different model, change the model path in the example.
 
 ## 🤝 Contributing
 
-Contributions are welcome. If you find an issue with an example or want to add one, open an issue or pull request on the [Ultralytics inference repository](https://github.com/ultralytics/inference).
+Contributions are welcome. See the [Ultralytics Contributing Guide](https://docs.ultralytics.com/help/contributing/) for details. If you find an issue with an example or want to add one, open an issue or pull request on the [Ultralytics inference repository](https://github.com/ultralytics/inference).

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ cargo run --example basic -- path/to/image.jpg
 cargo run --example annotate --features annotate
 ```
 
-To run your own model, export one with the Ultralytics Python package and pass its path:
+The examples load `yolo26n.onnx`, downloading it on first use. To provide the model yourself, export it with the Ultralytics Python package. The command below writes `yolo26n.onnx` into the current directory, which the example then loads instead of downloading. The positional argument is still the input image:
 
 ```bash
 pip install ultralytics
@@ -39,6 +39,8 @@ yolo export model=yolo26n.pt format=onnx
 
 cargo run --example basic -- image.jpg
 ```
+
+To run a different model, change the model path in the example.
 
 ## 🤝 Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 # Ultralytics YOLO Rust Examples
 
-<img alt="Rust" src="https://img.shields.io/badge/Rust-1.89%2B-CE422B.svg?logo=rust&logoColor=white"> <a href="https://docs.rs/ultralytics-inference" target="_blank"><img alt="docs.rs" src="https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B"></a> <a href="https://docs.ultralytics.com/" target="_blank"><img alt="Ultralytics Docs" src="https://img.shields.io/badge/Ultralytics-Docs-042AFF.svg?logo=ultralytics&logoColor=white"></a>
+<img alt="Rust" src="https://img.shields.io/badge/Rust-1.89%2B-CE422B.svg?logo=rust&logoColor=white"> <a href="https://crates.io/crates/ultralytics-inference" target="_blank"><img alt="crates.io" src="https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B"></a> <a href="https://docs.rs/ultralytics-inference" target="_blank"><img alt="docs.rs" src="https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B"></a> <a href="https://docs.ultralytics.com/" target="_blank"><img alt="Ultralytics Docs" src="https://img.shields.io/badge/Ultralytics-Docs-042AFF.svg?logo=ultralytics&logoColor=white"></a>
 
 Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ultralytics-inference) library. Each example is a single file you run with `cargo run --example`. They show how to load and run [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26/), [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11/), and [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8/) models from Rust.
 
@@ -14,6 +14,7 @@ Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ult
 | Example                 | Feature    | Description                                     | Run                                                |
 | ----------------------- | ---------- | ----------------------------------------------- | -------------------------------------------------- |
 | [basic](basic.rs)       | none       | Load a model, run inference, print detections   | `cargo run --example basic`                        |
+| [config](config.rs)     | none       | Set confidence, IoU, image size, and device     | `cargo run --example config`                       |
 | [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image | `cargo run --example annotate --features annotate` |
 
 ## ✅ How to Run
@@ -27,8 +28,22 @@ cargo run --example basic
 # Use your own image
 cargo run --example basic -- path/to/image.jpg
 
+# Set thresholds, image size, and device
+cargo run --example config
+
 # Annotate and save to runs/predict/annotated_*.jpg
 cargo run --example annotate --features annotate
+```
+
+The `basic` example prints one block per image:
+
+```text
+Found 5 detections
+  bus 0.93 [5.9 228.8 807.3 748.9]
+  person 0.92 [46.7 398.6 237.0 901.8]
+  person 0.90 [223.0 405.3 345.2 863.1]
+  person 0.86 [668.6 391.2 810.0 879.7]
+  person 0.51 [0.0 553.4 65.4 874.1]
 ```
 
 The examples load `yolo26n.onnx`, downloading it on first use. To provide the model yourself, export it with the Ultralytics Python package. The command below writes `yolo26n.onnx` into the current directory, which the example then loads instead of downloading. The positional argument is still the input image:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,11 +11,12 @@ Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ult
 
 ## 📂 Examples
 
-| Example                 | Feature    | Description                                     | Run                                                |
-| ----------------------- | ---------- | ----------------------------------------------- | -------------------------------------------------- |
-| [basic](basic.rs)       | none       | Load a model, run inference, print detections   | `cargo run --example basic`                        |
-| [config](config.rs)     | none       | Set confidence, IoU, image size, and device     | `cargo run --example config`                       |
-| [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image | `cargo run --example annotate --features annotate` |
+| Example                 | Feature    | Description                                      | Run                                                |
+| ----------------------- | ---------- | ------------------------------------------------ | -------------------------------------------------- |
+| [basic](basic.rs)       | none       | Load a model, run inference, print detections    | `cargo run --example basic`                        |
+| [config](config.rs)     | none       | Set confidence, IoU, image size, and device      | `cargo run --example config`                       |
+| [tasks](tasks.rs)       | none       | Summary for detect, segment, pose, obb, classify | `cargo run --example tasks`                        |
+| [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image  | `cargo run --example annotate --features annotate` |
 
 ## ✅ How to Run
 
@@ -33,6 +34,16 @@ cargo run --example config
 
 # Annotate and save to runs/predict/annotated_*.jpg
 cargo run --example annotate --features annotate
+```
+
+The `tasks` example defaults to detection and works with the other tasks when you pass their model. The matching sample image is downloaded automatically:
+
+```bash
+cargo run --example tasks                      # detect (default)
+cargo run --example tasks -- yolo26n-seg.onnx  # segment
+cargo run --example tasks -- yolo26n-pose.onnx # pose
+cargo run --example tasks -- yolo26n-obb.onnx  # obb
+cargo run --example tasks -- yolo26n-cls.onnx  # classify
 ```
 
 The `basic` example prints one block per image:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,12 @@ Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ult
 
 ## 📂 Examples
 
-| Example                 | Feature    | Description                                      | Run                                                |
-| ----------------------- | ---------- | ------------------------------------------------ | -------------------------------------------------- |
-| [basic](basic.rs)       | none       | Load a model, run inference, print detections    | `cargo run --example basic`                        |
-| [config](config.rs)     | none       | Set confidence, IoU, image size, and device      | `cargo run --example config`                       |
-| [tasks](tasks.rs)       | none       | Summary for detect, segment, pose, obb, classify | `cargo run --example tasks`                        |
-| [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image  | `cargo run --example annotate --features annotate` |
+| Example                 | Feature    | Description                                                          | Run                                                |
+| ----------------------- | ---------- | -------------------------------------------------------------------- | -------------------------------------------------- |
+| [basic](basic.rs)       | none       | Load a model, run inference, print detections                        | `cargo run --example basic`                        |
+| [config](config.rs)     | none       | Set confidence, IoU, image size, and device                          | `cargo run --example config`                       |
+| [tasks](tasks.rs)       | none       | Summary for every task, plus raw arrays for segment, semantic, depth | `cargo run --example tasks`                        |
+| [annotate](annotate.rs) | `annotate` | Draw boxes and labels, save the annotated image                      | `cargo run --example annotate --features annotate` |
 
 ## ✅ How to Run
 
@@ -36,14 +36,16 @@ cargo run --example config
 cargo run --example annotate --features annotate
 ```
 
-The `tasks` example defaults to detection and works with the other tasks when you pass their model. The matching sample image is downloaded automatically:
+The `tasks` example defaults to detection and works with the other tasks when you pass their model. The matching sample image is downloaded automatically. The segment, semantic, and depth branches also print the raw output array, which `ndarray` truncates with `...`:
 
 ```bash
-cargo run --example tasks                      # detect (default)
-cargo run --example tasks -- yolo26n-seg.onnx  # segment
-cargo run --example tasks -- yolo26n-pose.onnx # pose
-cargo run --example tasks -- yolo26n-obb.onnx  # obb
-cargo run --example tasks -- yolo26n-cls.onnx  # classify
+cargo run --example tasks                       # detect (default)
+cargo run --example tasks -- yolo26n-seg.onnx   # segment
+cargo run --example tasks -- yolo26n-pose.onnx  # pose
+cargo run --example tasks -- yolo26n-obb.onnx   # obb
+cargo run --example tasks -- yolo26n-cls.onnx   # classify
+cargo run --example tasks -- yolo26n-sem.onnx   # semantic (YOLO26)
+cargo run --example tasks -- yolo26n-depth.onnx # depth (YOLO26)
 ```
 
 The `basic` example prints one block per image:

--- a/examples/annotate.rs
+++ b/examples/annotate.rs
@@ -1,0 +1,35 @@
+//! Annotate detections onto the image and save the result to disk.
+//!
+//! Requires the `annotate` feature (enabled by default):
+//!
+//! ```bash
+//! cargo run --example annotate --features annotate
+//! cargo run --example annotate --features annotate -- path/to/image.jpg
+//! ```
+
+use std::path::Path;
+
+use ultralytics_inference::YOLOModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load the model (auto-downloads a known Ultralytics YOLO26 model if missing).
+    let mut model = YOLOModel::load("yolo26n.onnx")?;
+
+    // Predict on the given image path, or an auto-downloaded sample when omitted.
+    let results = match std::env::args().nth(1) {
+        Some(path) => model.predict(path)?,
+        None => model.predict_default()?,
+    };
+
+    // Draw boxes/labels onto each result and write it out. `Results::save`
+    // annotates the original image and saves it in one call.
+    let out_dir = Path::new("runs/predict");
+    std::fs::create_dir_all(out_dir)?;
+    for (i, result) in results.iter().enumerate() {
+        let out = out_dir.join(format!("annotated_{i}.jpg"));
+        result.save(&out)?;
+        println!("Saved {}", out.display());
+    }
+
+    Ok(())
+}

--- a/examples/annotate.rs
+++ b/examples/annotate.rs
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 //! Annotate detections onto the image and save the result to disk.
 //!
 //! Requires the `annotate` feature (enabled by default):

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,44 @@
+//! Basic quickstart: load a model, run inference, print detections.
+//!
+//! Run it (auto-downloads `yolo26n.onnx` and a sample image on first use):
+//!
+//! ```bash
+//! cargo run --example basic
+//! cargo run --example basic -- path/to/image.jpg
+//! ```
+
+use ultralytics_inference::YOLOModel;
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load the model. A known Ultralytics YOLO26 name is auto-downloaded if the
+    // file is not already on disk; model metadata (classes, task, image size) is
+    // read automatically from the ONNX file.
+    let mut model = YOLOModel::load("yolo26n.onnx")?;
+
+    // Predict on the image path passed as the first argument, or fall back to an
+    // auto-downloaded sample image when none is given.
+    let results = match std::env::args().nth(1) {
+        Some(path) => model.predict(path)?,
+        None => model.predict_default()?,
+    };
+
+    // Print every detection as: <name> <conf> [x1 y1 x2 y2].
+    for result in &results {
+        let Some(boxes) = &result.boxes else { continue };
+        println!("Found {} detections", boxes.len());
+        let xyxy = boxes.xyxy();
+        for i in 0..boxes.len() {
+            let cls = boxes.cls()[i] as usize;
+            let conf = boxes.conf()[i];
+            let name = result.names.get(&cls).map_or("unknown", String::as_str);
+            let b = xyxy.row(i);
+            println!(
+                "  {name} {conf:.2} [{:.1} {:.1} {:.1} {:.1}]",
+                b[0], b[1], b[2], b[3]
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 //! Basic quickstart: load a model, run inference, print detections.
 //!
 //! Run it (auto-downloads `yolo26n.onnx` and a sample image on first use):

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 //! Configure inference with `InferenceConfig` before loading the model.
 //!
 //! ```bash

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -28,11 +28,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for result in &results {
         let Some(boxes) = &result.boxes else { continue };
         println!("Found {} detections", boxes.len());
+        let xyxy = boxes.xyxy();
         for i in 0..boxes.len() {
             let cls = boxes.cls()[i] as usize;
             let conf = boxes.conf()[i];
             let name = result.names.get(&cls).map_or("unknown", String::as_str);
-            println!("  {name} {conf:.2}");
+            let b = xyxy.row(i);
+            println!(
+                "  {name} {conf:.2} [{:.1} {:.1} {:.1} {:.1}]",
+                b[0], b[1], b[2], b[3]
+            );
         }
     }
 

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,0 +1,38 @@
+//! Configure inference with `InferenceConfig` before loading the model.
+//!
+//! ```bash
+//! cargo run --example config
+//! cargo run --example config -- path/to/image.jpg
+//! ```
+
+use ultralytics_inference::{Device, InferenceConfig, YOLOModel};
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Build a configuration with the builder methods, then load the model with it.
+    let config = InferenceConfig::new()
+        .with_confidence(0.5) // keep detections at or above 0.5 confidence
+        .with_iou(0.45) // NMS IoU threshold
+        .with_imgsz(640, 640) // inference image size
+        .with_device(Device::Cpu); // run on CPU
+
+    let mut model = YOLOModel::load_with_config("yolo26n.onnx", config)?;
+
+    let results = match std::env::args().nth(1) {
+        Some(path) => model.predict(path)?,
+        None => model.predict_default()?,
+    };
+
+    for result in &results {
+        let Some(boxes) = &result.boxes else { continue };
+        println!("Found {} detections", boxes.len());
+        for i in 0..boxes.len() {
+            let cls = boxes.cls()[i] as usize;
+            let conf = boxes.conf()[i];
+            let name = result.names.get(&cls).map_or("unknown", String::as_str);
+            println!("  {name} {conf:.2}");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -5,12 +5,17 @@
 //! The default model is detection. Pass another task's ONNX to try it:
 //!
 //! ```bash
-//! cargo run --example tasks                       # detect (default)
-//! cargo run --example tasks -- yolo26n-seg.onnx   # segment
-//! cargo run --example tasks -- yolo26n-pose.onnx  # pose
-//! cargo run --example tasks -- yolo26n-obb.onnx   # obb
-//! cargo run --example tasks -- yolo26n-cls.onnx   # classify
+//! cargo run --example tasks                        # detect (default)
+//! cargo run --example tasks -- yolo26n-seg.onnx    # segment
+//! cargo run --example tasks -- yolo26n-pose.onnx   # pose
+//! cargo run --example tasks -- yolo26n-obb.onnx    # obb
+//! cargo run --example tasks -- yolo26n-cls.onnx    # classify
+//! cargo run --example tasks -- yolo26n-sem.onnx    # semantic (YOLO26)
+//! cargo run --example tasks -- yolo26n-depth.onnx  # depth (YOLO26)
 //! ```
+//!
+//! The segment, semantic, and depth branches also print the raw output array.
+//! `ndarray` truncates large arrays automatically, showing the corners with `...`.
 
 use ultralytics_inference::YOLOModel;
 
@@ -30,6 +35,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for result in &results {
         if let Some(masks) = &result.masks {
             println!("segment: {} instance masks", masks.len());
+            // masks.data is Array3<f32> of shape [N, H, W] (per-pixel mask probabilities).
+            println!("  raw data shape {:?}", masks.data.shape());
+            println!("{:?}", masks.data);
         } else if let Some(keypoints) = &result.keypoints {
             println!("pose: {} sets of keypoints", keypoints.len());
         } else if let Some(obb) = &result.obb {
@@ -40,8 +48,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("classify: top1 {name} {:.2}", probs.top1conf());
         } else if let Some(sem) = &result.semantic_mask {
             println!("semantic: class map shape {:?}", sem.data.shape());
+            // sem.data is Array2<u16> of shape [H, W] (per-pixel class ids).
+            println!("{:?}", sem.data);
         } else if let Some(depth) = &result.depth {
-            println!("depth: map shape {:?}", depth.data.shape());
+            println!(
+                "depth: map shape {:?}, range {:?}..{:?}",
+                depth.data.shape(),
+                depth.min_depth(),
+                depth.max_depth()
+            );
+            // depth.data is Array2<f32> of shape [H, W] (per-pixel meters).
+            println!("{:?}", depth.data);
         } else if let Some(boxes) = &result.boxes {
             println!("detect: {} objects", boxes.len());
             for i in 0..boxes.len() {

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 //! Print a short, task-appropriate summary for any YOLO model.
 //!
 //! The default model is detection. Pass another task's ONNX to try it:

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,0 +1,54 @@
+//! Print a short, task-appropriate summary for any YOLO model.
+//!
+//! The default model is detection. Pass another task's ONNX to try it:
+//!
+//! ```bash
+//! cargo run --example tasks                       # detect (default)
+//! cargo run --example tasks -- yolo26n-seg.onnx   # segment
+//! cargo run --example tasks -- yolo26n-pose.onnx  # pose
+//! cargo run --example tasks -- yolo26n-obb.onnx   # obb
+//! cargo run --example tasks -- yolo26n-cls.onnx   # classify
+//! ```
+
+use ultralytics_inference::YOLOModel;
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // A known model name is auto-downloaded if it is not already on disk.
+    let model_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "yolo26n.onnx".to_string());
+    let mut model = YOLOModel::load(&model_path)?;
+
+    // predict_default downloads the sample image that matches the model's task.
+    let results = model.predict_default()?;
+
+    // Each task fills a different field of Results. Check the specific ones first,
+    // since segment and pose models also carry boxes.
+    for result in &results {
+        if let Some(masks) = &result.masks {
+            println!("segment: {} instance masks", masks.len());
+        } else if let Some(keypoints) = &result.keypoints {
+            println!("pose: {} sets of keypoints", keypoints.len());
+        } else if let Some(obb) = &result.obb {
+            println!("obb: {} oriented boxes", obb.len());
+        } else if let Some(probs) = &result.probs {
+            let top1 = probs.top1();
+            let name = result.names.get(&top1).map_or("unknown", String::as_str);
+            println!("classify: top1 {name} {:.2}", probs.top1conf());
+        } else if let Some(sem) = &result.semantic_mask {
+            println!("semantic: class map shape {:?}", sem.data.shape());
+        } else if let Some(depth) = &result.depth {
+            println!("depth: map shape {:?}", depth.data.shape());
+        } else if let Some(boxes) = &result.boxes {
+            println!("detect: {} objects", boxes.len());
+            for i in 0..boxes.len() {
+                let cls = boxes.cls()[i] as usize;
+                let name = result.names.get(&cls).map_or("unknown", String::as_str);
+                println!("  {name} {:.2}", boxes.conf()[i]);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@
 //! }
 //! ```
 //!
+//! For runnable programs you can copy and adapt, see the
+//! [examples](https://github.com/ultralytics/inference/tree/main/examples) directory.
+//!
 //! ## CLI Usage
 //!
 //! The `ultralytics-inference` CLI provides a command-line interface for running YOLO inference:


### PR DESCRIPTION
Adds an examples directory so people can run the library quickly.

Includes two examples:

- basic: load a model, run inference, print detections
- annotate: draw boxes and labels, save the annotated image

Both take an optional image path and download a sample when none is given. The examples directory has a README, and the English and Chinese READMEs and the crate docs now point to it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Adds runnable Rust examples and documentation to make Ultralytics inference easier to learn and use.

### 📊 Key Changes

- Added four Rust examples:
  - `basic` for loading a model and printing detections.
  - `config` for setting confidence, IoU, image size, and device options.
  - `tasks` for summarizing detection, segmentation, pose, OBB, classification, semantic, and depth results.
  - `annotate` for drawing detections and saving annotated images.
- Registered the examples in `Cargo.toml`, including the optional `annotate` feature.
- Added a dedicated [examples guide](examples/README.md) with setup, commands, supported tasks, model usage, and sample output.
- Updated the English and Chinese README files and Rust library documentation to link to the new examples.
- Examples support automatic model and sample-image downloads, including YOLO26, YOLO11, and YOLOv8 ONNX models.

### 🎯 Purpose & Impact

- 🧑‍💻 Gives new Rust users copy-ready programs instead of requiring them to build integrations from scratch.
- ⚙️ Demonstrates both basic inference and practical configuration options for different deployment scenarios.
- 🎯 Makes multi-task inference easier to understand by showing task-specific result handling.
- 🖼️ Provides a simple path to generate annotated output images.
- 📚 Improves discoverability and onboarding without changing the core inference API or behavior.