### PR TITLE
refactor workflow to use shared setup-uv action from ultralytics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚙️ Updated the publishing workflow to use Ultralytics’ shared `setup-uv` action.

### 📊 Key Changes

- Replaced the pinned `astral-sh/setup-uv` action with `ultralytics/actions/setup-uv@main`.
- Removed the explicit cache configuration from the workflow.
- Kept the existing Python setup and `ultralytics-actions` installation steps unchanged.

### 🎯 Purpose & Impact

- 🔄 Centralizes `uv` setup and maintenance through Ultralytics’ shared GitHub Action.
- 🛠️ Simplifies the publishing workflow and reduces local configuration.
- 📦 Helps keep package publishing aligned with shared Ultralytics CI practices.
- ⚠️ Because the action tracks `main`, future changes to the shared action may affect publishing behavior.