### PR TITLE
Bump actions/setup-python from v6.3.0 to v7.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6.3.0 to v7.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the publishing workflow to use the latest `actions/setup-python` release. ⚙️

### 📊 Key Changes

- Upgraded `actions/setup-python` from **v6.3.0** to **v7.0.0**.
- Kept Python configured to use the latest available **3.x** version.
- Updated the pinned action commit for reproducible CI runs.

### 🎯 Purpose & Impact

- ✅ Keeps the release workflow aligned with the latest GitHub Actions tooling.
- 🔒 Maintains secure, deterministic dependency execution through commit pinning.
- 🚀 May improve Python setup reliability and compatibility during package publishing, with no expected changes to end-user functionality.