### PR TITLE
Bump version to 0.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 <img alt="Rust" src="https://img.shields.io/badge/Rust-1.89%2B-CE422B.svg?logo=rust&logoColor=white"> <a href="https://crates.io/crates/ultralytics-inference" target="_blank"><img alt="crates.io" src="https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B"></a> <a href="https://docs.rs/ultralytics-inference" target="_blank"><img alt="docs.rs" src="https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs&color=CE422B"></a> <a href="https://docs.ultralytics.com/" target="_blank"><img alt="Ultralytics Docs" src="https://img.shields.io/badge/Ultralytics-Docs-042AFF.svg?logo=ultralytics&logoColor=white"></a>
 
-Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ultralytics-inference) library. Each example is a single file you run with `cargo run --example`. They show how to load and run [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26/), [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11/), and [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8/) models from Rust.
+Runnable examples for the [`ultralytics-inference`](https://crates.io/crates/ultralytics-inference) library. Each example is a single file you run with `cargo run --example`. They show how to load and run [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26), [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11), and [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8) models from Rust.
 
 > [!NOTE]
 > Model metadata (classes, task, image size) is read from the ONNX file, so Ultralytics YOLOv8, Ultralytics YOLO11, and Ultralytics YOLO26 models all work without extra configuration. Each example takes an optional image path and downloads a sample image when none is given.
@@ -72,4 +72,4 @@ To run a different model, change the model path in the example.
 
 ## 🤝 Contributing
 
-Contributions are welcome. See the [Ultralytics Contributing Guide](https://docs.ultralytics.com/help/contributing/) for details. If you find an issue with an example or want to add one, open an issue or pull request on the [Ultralytics inference repository](https://github.com/ultralytics/inference).
+Contributions are welcome. See the [Ultralytics Contributing Guide](https://docs.ultralytics.com/help/contributing) for details. If you find an issue with an example or want to add one, open an issue or pull request on the [Ultralytics inference repository](https://github.com/ultralytics/inference).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Bumps the Ultralytics inference packages from version `0.0.29` to `0.0.30` and refreshes documentation links.

### 📊 Key Changes

- Updated the Rust workspace package version to `0.0.30`.
- Updated the Rust WebAssembly/WebGPU package to `0.0.30`.
- Updated the browser package `@ultralytics/yolo` to `0.0.30`.
- Regenerated dependency lockfiles: `Cargo.lock` and `web/package-lock.json`.
- Simplified documentation URLs in the examples README.
- Retained examples covering YOLO26, YOLO11, and YOLOv8 models.

### 🎯 Purpose & Impact

- 📦 Publishes a synchronized patch release across Rust, WebAssembly, and browser packages.
- 🔄 Keeps package metadata and lockfiles aligned for reliable builds and distribution.
- 🔗 Improves documentation link consistency without changing inference behavior.
- ✅ Existing users should experience no functional changes; upgrading mainly provides the latest packaged release.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
