### PR TITLE
Queue publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ on:
         description: Publish to crates.io
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/inference' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`.
- Preserve up to 100 pending release runs instead of replacing older pending releases.
- Align release robustness with [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) without changing the repository-specific publisher.

Deleted: nothing — GitHub owns workflow scheduling, so preserving pending release runs requires workflow-level concurrency configuration.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds queued concurrency control to the publishing workflow to prevent overlapping release runs. 🚦

### 📊 Key Changes

- Configures GitHub Actions concurrency for the `publish.yml` workflow.
- Groups runs by workflow name using `${{ github.workflow }}`.
- Queues new publishing runs instead of allowing them to run simultaneously.
- Applies to the existing publishing checks and crates.io release process.

### 🎯 Purpose & Impact

- Prevents multiple publish jobs from running at the same time. 🔒
- Reduces the risk of conflicting releases or duplicate package-publishing attempts.
- Makes the publishing process more predictable when workflows are triggered close together.
- Has no direct impact on inference functionality or end users.