### PR TITLE
Make the CUDA preprocess kernel match the CPU letterbox

### DIFF
--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -104,9 +104,11 @@ What to expect and how to avoid surprises:
   to `.gitignore`, not to clean builds) to avoid paying the cost again.
 - **Cache is keyed to the build context.** A new engine is built whenever the
   model file, GPU/driver/TensorRT version, precision (`--half`), or **input
-  shape** changes. **Dynamic-shape models rebuild per new input size** - feed a
-  consistent size (the fast path uses the model's resolved `imgsz`) to keep it
-  to a single cached engine.
+  shape** changes. **Dynamic-shape models rebuild per new input size** - feed
+  consistently-sized inputs to keep it to a single cached engine. Note that rectangular
+  inference (`rect`, on by default) letterboxes each image to its own aspect ratio, so a
+  source with mixed aspect ratios produces one engine build per distinct shape; pass
+  `--rect false` to pin every input to the square model size.
 - **Warm up before timing.** The first `predict*` call also triggers an
   inference-time warm-up. Always discard the first few iterations when
   benchmarking (the examples do this).
@@ -124,10 +126,11 @@ What to expect and how to avoid surprises:
 No separate type or API. With the feature compiled in and a CUDA/TensorRT
 device, [`YOLOModel::predict_image`] automatically runs the fused GPU
 preprocess kernel (bilinear letterbox + `/255` normalize + HWC→CHW) and hands
-the result to ORT as a zero-copy device tensor. The kernel reproduces the CPU
-letterbox exactly - same half-pixel bilinear sampling, and the same
-stride-aligned rectangular target under `rect` - so `--device cuda` and
-`--device cpu` infer on identical pixels:
+the result to ORT as a zero-copy device tensor. The kernel mirrors the CPU letterbox -
+same half-pixel bilinear sampling, same per-axis resampling ratios, and the same
+stride-aligned rectangular target under `rect` - so `--device cuda` and `--device cpu`
+agree to within one 8-bit quantization step (the CPU uses OpenCV's fixed-point weights,
+the kernel f32):
 
 ```rust,no_run
 use ultralytics_inference::{Device, InferenceConfig, YOLOModel};

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -124,7 +124,10 @@ What to expect and how to avoid surprises:
 No separate type or API. With the feature compiled in and a CUDA/TensorRT
 device, [`YOLOModel::predict_image`] automatically runs the fused GPU
 preprocess kernel (bilinear letterbox + `/255` normalize + HWC→CHW) and hands
-the result to ORT as a zero-copy device tensor:
+the result to ORT as a zero-copy device tensor. The kernel reproduces the CPU
+letterbox exactly - same half-pixel bilinear sampling, and the same
+stride-aligned rectangular target under `rect` - so `--device cuda` and
+`--device cpu` infer on identical pixels:
 
 ```rust,no_run
 use ultralytics_inference::{Device, InferenceConfig, YOLOModel};

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -60,8 +60,10 @@ extern "C" __global__ void preprocess(
     if (rx < 0 || ry < 0 || rx >= valid_w || ry >= valid_h) {
         r = g = b = 114.0f / 255.0f;
     } else {
-        float fx = (float)rx / scale;
-        float fy = (float)ry / scale;
+        // Half-pixel convention: src = (dst + 0.5) / scale - 0.5, matching the CPU
+        // letterbox in preprocessing.rs and cv2/torch `align_corners=False`.
+        float fx = ((float)rx + 0.5f) / scale - 0.5f;
+        float fy = ((float)ry + 0.5f) / scale - 0.5f;
         if (fx < 0.f) fx = 0.f;
         if (fy < 0.f) fy = 0.f;
         if (fx > (float)(src_w - 1)) fx = (float)(src_w - 1);
@@ -111,6 +113,10 @@ pub(crate) struct PreGeom {
     pub scale: f32,
     pub pad_x: i32,
     pub pad_y: i32,
+    /// Target the frame was letterboxed into, `(height, width)`. Equals the caller's
+    /// requested size, which is the model input for square inference and the
+    /// stride-aligned rectangle for `rect`.
+    pub dst_hw: (usize, usize),
 }
 
 /// Phase-1 of the fast-path init: a cudarc context + stream created before
@@ -227,6 +233,11 @@ impl CudaPreprocessor {
     /// into the input buffer, and return the letterbox geometry needed by
     /// post-processing.
     ///
+    /// `dst` is the letterbox target `(height, width)`: the model input for square
+    /// inference, or the smaller stride-aligned rectangle for `rect`. It must fit the
+    /// buffer sized at [`Self::finalize`], which every rect target does since
+    /// `calculate_rect_size` only shrinks axes.
+    ///
     /// The output of this call is enqueued on the same stream that the ORT
     /// session was bound to via [`CudaStreamHandle::raw_stream_ptr`], so the
     /// subsequent `session.run_binding(...)` sees the writes without an
@@ -237,7 +248,15 @@ impl CudaPreprocessor {
         src_h: u32,
         src_w: u32,
         bgr_in: bool,
+        dst: (usize, usize),
     ) -> Result<PreGeom> {
+        let (dst_h, dst_w) = dst;
+        if dst_h * dst_w > self.dst_h * self.dst_w {
+            return Err(InferenceError::InferenceError(format!(
+                "letterbox target {dst_h}x{dst_w} exceeds the input buffer sized for {}x{}",
+                self.dst_h, self.dst_w
+            )));
+        }
         let needed = (src_h as usize) * (src_w as usize) * 3;
         if frame_hwc.len() != needed {
             return Err(InferenceError::InferenceError(format!(
@@ -260,17 +279,17 @@ impl CudaPreprocessor {
 
         // Letterbox into the (possibly non-square) dst_h × dst_w target:
         // single uniform scale = min over both axes, centered padding.
-        let scale = (self.dst_h as f32 / src_h as f32).min(self.dst_w as f32 / src_w as f32);
+        let scale = (dst_h as f32 / src_h as f32).min(dst_w as f32 / src_w as f32);
         let resized_w = (src_w as f32 * scale).round() as i32;
         let resized_h = (src_h as f32 * scale).round() as i32;
-        let pad_x = (self.dst_w as i32 - resized_w) / 2;
-        let pad_y = (self.dst_h as i32 - resized_h) / 2;
+        let pad_x = (dst_w as i32 - resized_w) / 2;
+        let pad_y = (dst_h as i32 - resized_h) / 2;
         let bgr_in_i = i32::from(bgr_in);
 
         let block_dim = (16u32, 16u32, 1u32);
         let grid_dim = (
-            (self.dst_w as u32).div_ceil(block_dim.0),
-            (self.dst_h as u32).div_ceil(block_dim.1),
+            (dst_w as u32).div_ceil(block_dim.0),
+            (dst_h as u32).div_ceil(block_dim.1),
             1u32,
         );
         let launch_cfg = LaunchConfig {
@@ -286,8 +305,8 @@ impl CudaPreprocessor {
                 .arg(&(src_h as i32))
                 .arg(&(src_w as i32))
                 .arg(&mut self.input_dev)
-                .arg(&(self.dst_h as i32))
-                .arg(&(self.dst_w as i32))
+                .arg(&(dst_h as i32))
+                .arg(&(dst_w as i32))
                 .arg(&scale)
                 .arg(&pad_x)
                 .arg(&pad_y)
@@ -300,6 +319,7 @@ impl CudaPreprocessor {
             scale,
             pad_x,
             pad_y,
+            dst_hw: (dst_h, dst_w),
         })
     }
 }
@@ -366,7 +386,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 200, 100, 50);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false)
+            .preprocess(&frame, src_h, src_w, false, pre.dst_hw())
             .expect("preprocess");
 
         // 640/640 = 1.0 is the binding axis; the 480-tall image is centered.
@@ -388,7 +408,9 @@ mod tests {
 
         // 640x640 into 384x640: scale 0.6 fills the width, pads the height to 0.
         let frame = solid(640, 640, 10, 20, 30);
-        let geom = pre.preprocess(&frame, 640, 640, false).expect("preprocess");
+        let geom = pre
+            .preprocess(&frame, 640, 640, false, pre.dst_hw())
+            .expect("preprocess");
 
         assert_eq!(geom.pad_y, 0);
         assert!(
@@ -405,7 +427,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 255, 255, 255);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false)
+            .preprocess(&frame, src_h, src_w, false, pre.dst_hw())
             .expect("preprocess");
         assert!(
             geom.pad_x > 0,
@@ -431,7 +453,7 @@ mod tests {
         let mut pre = preprocessor(dst, dst);
         // Square input, no letterbox: every pixel is R=255, G=0, B=0.
         let frame = solid(dst, dst, 255, 0, 0);
-        pre.preprocess(&frame, dst as u32, dst as u32, false)
+        pre.preprocess(&frame, dst as u32, dst as u32, false, pre.dst_hw())
             .expect("preprocess");
 
         let host = readback(&pre);
@@ -454,12 +476,12 @@ mod tests {
         let idx = (dst / 2) * dst + dst / 2;
 
         let mut rgb = preprocessor(dst, dst);
-        rgb.preprocess(&frame, dst as u32, dst as u32, false)
+        rgb.preprocess(&frame, dst as u32, dst as u32, false, rgb.dst_hw())
             .expect("rgb preprocess");
         let rgb_host = readback(&rgb);
 
         let mut bgr = preprocessor(dst, dst);
-        bgr.preprocess(&frame, dst as u32, dst as u32, true)
+        bgr.preprocess(&frame, dst as u32, dst as u32, true, bgr.dst_hw())
             .expect("bgr preprocess");
         let bgr_host = readback(&bgr);
 
@@ -481,7 +503,7 @@ mod tests {
     fn preprocess_rejects_wrong_len() {
         let mut pre = preprocessor(64, 64);
         let bad = vec![0u8; 10]; // != 64 * 64 * 3
-        let result = pre.preprocess(&bad, 64, 64, false);
+        let result = pre.preprocess(&bad, 64, 64, false, pre.dst_hw());
         assert!(
             matches!(result, Err(InferenceError::InferenceError(_))),
             "wrong-length frame must be rejected"
@@ -493,9 +515,47 @@ mod tests {
         let mut pre = preprocessor(128, 128);
         // First a small frame, then a larger one to force `frame_dev` to grow.
         let small = solid(32, 32, 1, 2, 3);
-        pre.preprocess(&small, 32, 32, false).expect("small frame");
+        pre.preprocess(&small, 32, 32, false, pre.dst_hw())
+            .expect("small frame");
         let large = solid(256, 256, 4, 5, 6);
-        pre.preprocess(&large, 256, 256, false)
+        pre.preprocess(&large, 256, 256, false, pre.dst_hw())
             .expect("large frame after buffer growth");
+    }
+
+    #[test]
+    fn preprocess_matches_cpu_letterbox() {
+        // The GPU kernel and the CPU letterbox must produce the same tensor, otherwise
+        // `--device cuda` silently infers on different pixels than `--device cpu`. A
+        // gradient (not a solid color) is required: it is the only input that exposes a
+        // half-pixel offset in the bilinear sampling.
+        let (src_h, src_w) = (270usize, 480usize);
+        let mut frame = Vec::with_capacity(src_h * src_w * 3);
+        for y in 0..src_h {
+            for x in 0..src_w {
+                frame.extend_from_slice(&[(x % 256) as u8, (y % 256) as u8, ((x + y) % 256) as u8]);
+            }
+        }
+
+        // A rect target, so this also covers the non-square letterbox the `rect` path uses.
+        let dst = (192usize, 320usize);
+        let mut pre = preprocessor(dst.0, dst.1);
+        pre.preprocess(&frame, src_h as u32, src_w as u32, false, dst)
+            .expect("gpu preprocess");
+        let gpu = readback(&pre);
+
+        let img = image::DynamicImage::ImageRgb8(
+            image::RgbImage::from_raw(src_w as u32, src_h as u32, frame).expect("rgb image"),
+        );
+        let cpu = crate::preprocessing::preprocess_image_with_precision(&img, dst, 32, false);
+        let cpu = cpu.tensor.as_slice().expect("contiguous cpu tensor");
+
+        let n = 3 * dst.0 * dst.1;
+        let max_diff = (0..n).fold(0.0f32, |m, i| m.max((gpu[i] - cpu[i]).abs()));
+        // 1/255 == 0.0039: anything above one input quantization step is a real
+        // resampling mismatch, not float noise.
+        assert!(
+            max_diff < 1.0 / 255.0,
+            "gpu letterbox deviates from cpu by {max_diff}"
+        );
     }
 }

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -43,7 +43,8 @@ extern "C" __global__ void preprocess(
     int src_h, int src_w,
     float* __restrict__ dst,
     int dst_h, int dst_w,
-    float scale,
+    float scale_x, float scale_y,
+    int valid_w, int valid_h,
     int pad_x, int pad_y,
     int bgr_in)
 {
@@ -53,17 +54,17 @@ extern "C" __global__ void preprocess(
 
     int rx = x - pad_x;
     int ry = y - pad_y;
-    int valid_w = (int)(src_w * scale + 0.5f);
-    int valid_h = (int)(src_h * scale + 0.5f);
 
     float r, g, b;
     if (rx < 0 || ry < 0 || rx >= valid_w || ry >= valid_h) {
         r = g = b = 114.0f / 255.0f;
     } else {
-        // Half-pixel convention: src = (dst + 0.5) / scale - 0.5, matching the CPU
-        // letterbox in preprocessing.rs and cv2/torch `align_corners=False`.
-        float fx = ((float)rx + 0.5f) / scale - 0.5f;
-        float fy = ((float)ry + 0.5f) / scale - 0.5f;
+        // Half-pixel convention: src = (dst + 0.5) * (src / resized) - 0.5, matching the
+        // CPU letterbox in preprocessing.rs and cv2's `INTER_LINEAR`. The ratios are
+        // per-axis and derived from the *rounded* resized extents, so a uniform
+        // 1 / letterbox-scale is not equivalent on the padded axis.
+        float fx = ((float)rx + 0.5f) * scale_x - 0.5f;
+        float fy = ((float)ry + 0.5f) * scale_y - 0.5f;
         if (fx < 0.f) fx = 0.f;
         if (fy < 0.f) fy = 0.f;
         if (fx > (float)(src_w - 1)) fx = (float)(src_w - 1);
@@ -224,19 +225,13 @@ impl CudaPreprocessor {
         self.input_dev_ptr
     }
 
-    /// Model input dimensions `(height, width)` - may be non-square.
-    pub(crate) const fn dst_hw(&self) -> (usize, usize) {
-        (self.dst_h, self.dst_w)
-    }
-
     /// H2D-copy the source frame, launch the fused preprocess kernel writing
     /// into the input buffer, and return the letterbox geometry needed by
     /// post-processing.
     ///
     /// `dst` is the letterbox target `(height, width)`: the model input for square
-    /// inference, or the smaller stride-aligned rectangle for `rect`. It must fit the
-    /// buffer sized at [`Self::finalize`], which every rect target does since
-    /// `calculate_rect_size` only shrinks axes.
+    /// inference, or the stride-aligned rectangle for `rect`. The caller sizes the buffer
+    /// at [`Self::finalize`] to the largest target `rect` can produce.
     ///
     /// The output of this call is enqueued on the same stream that the ORT
     /// session was bound to via [`CudaStreamHandle::raw_stream_ptr`], so the
@@ -251,12 +246,14 @@ impl CudaPreprocessor {
         dst: (usize, usize),
     ) -> Result<PreGeom> {
         let (dst_h, dst_w) = dst;
-        if dst_h * dst_w > self.dst_h * self.dst_w {
-            return Err(InferenceError::InferenceError(format!(
-                "letterbox target {dst_h}x{dst_w} exceeds the input buffer sized for {}x{}",
-                self.dst_h, self.dst_w
-            )));
-        }
+        // Writes are linear (`idx = y * dst_w + x`, plane stride `dst_h * dst_w`), so the
+        // product is what has to fit; the caller sizes the buffer to the largest target.
+        debug_assert!(
+            dst_h * dst_w <= self.dst_h * self.dst_w,
+            "letterbox target {dst_h}x{dst_w} exceeds the input buffer sized for {}x{}",
+            self.dst_h,
+            self.dst_w
+        );
         let needed = (src_h as usize) * (src_w as usize) * 3;
         if frame_hwc.len() != needed {
             return Err(InferenceError::InferenceError(format!(
@@ -284,6 +281,11 @@ impl CudaPreprocessor {
         let resized_h = (src_h as f32 * scale).round() as i32;
         let pad_x = (dst_w as i32 - resized_w) / 2;
         let pad_y = (dst_h as i32 - resized_h) / 2;
+        // Resampling ratios are src-per-dst on each axis, matching the CPU letterbox
+        // (`get_or_compute_x_lut(src_w, new_w)` / `scale_y = src_h / new_h`). `scale`
+        // itself stays the uniform gain, which is what post-processing back-projects with.
+        let scale_x = src_w as f32 / resized_w as f32;
+        let scale_y = src_h as f32 / resized_h as f32;
         let bgr_in_i = i32::from(bgr_in);
 
         let block_dim = (16u32, 16u32, 1u32);
@@ -307,7 +309,10 @@ impl CudaPreprocessor {
                 .arg(&mut self.input_dev)
                 .arg(&(dst_h as i32))
                 .arg(&(dst_w as i32))
-                .arg(&scale)
+                .arg(&scale_x)
+                .arg(&scale_y)
+                .arg(&resized_w)
+                .arg(&resized_h)
                 .arg(&pad_x)
                 .arg(&pad_y)
                 .arg(&bgr_in_i)
@@ -371,7 +376,7 @@ mod tests {
     #[test]
     fn preprocessor_finalize_allocates() {
         let pre = preprocessor(640, 640);
-        assert_eq!(pre.dst_hw(), (640, 640));
+        assert_eq!((pre.dst_h, pre.dst_w), (640, 640));
         assert_ne!(
             pre.input_dev_ptr(),
             0,
@@ -386,7 +391,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 200, 100, 50);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false, pre.dst_hw())
+            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w))
             .expect("preprocess");
 
         // 640/640 = 1.0 is the binding axis; the 480-tall image is centered.
@@ -404,12 +409,12 @@ mod tests {
     #[test]
     fn preprocess_non_square_target() {
         let mut pre = preprocessor(384, 640);
-        assert_eq!(pre.dst_hw(), (384, 640));
+        assert_eq!((pre.dst_h, pre.dst_w), (384, 640));
 
         // 640x640 into 384x640: scale 0.6 fills the width, pads the height to 0.
         let frame = solid(640, 640, 10, 20, 30);
         let geom = pre
-            .preprocess(&frame, 640, 640, false, pre.dst_hw())
+            .preprocess(&frame, 640, 640, false, (pre.dst_h, pre.dst_w))
             .expect("preprocess");
 
         assert_eq!(geom.pad_y, 0);
@@ -427,7 +432,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 255, 255, 255);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false, pre.dst_hw())
+            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w))
             .expect("preprocess");
         assert!(
             geom.pad_x > 0,
@@ -453,8 +458,14 @@ mod tests {
         let mut pre = preprocessor(dst, dst);
         // Square input, no letterbox: every pixel is R=255, G=0, B=0.
         let frame = solid(dst, dst, 255, 0, 0);
-        pre.preprocess(&frame, dst as u32, dst as u32, false, pre.dst_hw())
-            .expect("preprocess");
+        pre.preprocess(
+            &frame,
+            dst as u32,
+            dst as u32,
+            false,
+            (pre.dst_h, pre.dst_w),
+        )
+        .expect("preprocess");
 
         let host = readback(&pre);
         let hw = dst * dst;
@@ -476,12 +487,18 @@ mod tests {
         let idx = (dst / 2) * dst + dst / 2;
 
         let mut rgb = preprocessor(dst, dst);
-        rgb.preprocess(&frame, dst as u32, dst as u32, false, rgb.dst_hw())
-            .expect("rgb preprocess");
+        rgb.preprocess(
+            &frame,
+            dst as u32,
+            dst as u32,
+            false,
+            (rgb.dst_h, rgb.dst_w),
+        )
+        .expect("rgb preprocess");
         let rgb_host = readback(&rgb);
 
         let mut bgr = preprocessor(dst, dst);
-        bgr.preprocess(&frame, dst as u32, dst as u32, true, bgr.dst_hw())
+        bgr.preprocess(&frame, dst as u32, dst as u32, true, (bgr.dst_h, bgr.dst_w))
             .expect("bgr preprocess");
         let bgr_host = readback(&bgr);
 
@@ -503,7 +520,7 @@ mod tests {
     fn preprocess_rejects_wrong_len() {
         let mut pre = preprocessor(64, 64);
         let bad = vec![0u8; 10]; // != 64 * 64 * 3
-        let result = pre.preprocess(&bad, 64, 64, false, pre.dst_hw());
+        let result = pre.preprocess(&bad, 64, 64, false, (pre.dst_h, pre.dst_w));
         assert!(
             matches!(result, Err(InferenceError::InferenceError(_))),
             "wrong-length frame must be rejected"
@@ -515,10 +532,10 @@ mod tests {
         let mut pre = preprocessor(128, 128);
         // First a small frame, then a larger one to force `frame_dev` to grow.
         let small = solid(32, 32, 1, 2, 3);
-        pre.preprocess(&small, 32, 32, false, pre.dst_hw())
+        pre.preprocess(&small, 32, 32, false, (pre.dst_h, pre.dst_w))
             .expect("small frame");
         let large = solid(256, 256, 4, 5, 6);
-        pre.preprocess(&large, 256, 256, false, pre.dst_hw())
+        pre.preprocess(&large, 256, 256, false, (pre.dst_h, pre.dst_w))
             .expect("large frame after buffer growth");
     }
 
@@ -526,36 +543,47 @@ mod tests {
     fn preprocess_matches_cpu_letterbox() {
         // The GPU kernel and the CPU letterbox must produce the same tensor, otherwise
         // `--device cuda` silently infers on different pixels than `--device cpu`. A
-        // gradient (not a solid color) is required: it is the only input that exposes a
-        // half-pixel offset in the bilinear sampling.
-        let (src_h, src_w) = (270usize, 480usize);
-        let mut frame = Vec::with_capacity(src_h * src_w * 3);
-        for y in 0..src_h {
-            for x in 0..src_w {
-                frame.extend_from_slice(&[(x % 256) as u8, (y % 256) as u8, ((x + y) % 256) as u8]);
+        // gradient (not a solid color) is required: a flat image hides both the
+        // half-pixel offset and the per-axis resampling ratio.
+        //
+        // Both source shapes letterbox into the same rect target, but 271x481 rounds the
+        // padded axis (`round(271 * scale) != 271 * scale`) while 270x480 divides exactly.
+        // Only the rounding case distinguishes the CPU's `src / resized` ratio from a
+        // uniform `1 / letterbox-scale`, so it must stay in the list.
+        for (src_h, src_w) in [(271usize, 481usize), (270, 480), (481, 271)] {
+            let mut frame = Vec::with_capacity(src_h * src_w * 3);
+            for y in 0..src_h {
+                for x in 0..src_w {
+                    frame.extend_from_slice(&[
+                        (x % 256) as u8,
+                        (y % 256) as u8,
+                        ((x + y) % 256) as u8,
+                    ]);
+                }
             }
+
+            // A rect target, so this also covers the non-square letterbox `rect` produces.
+            let dst = (192usize, 320usize);
+            let mut pre = preprocessor(dst.0, dst.1);
+            pre.preprocess(&frame, src_h as u32, src_w as u32, false, dst)
+                .expect("gpu preprocess");
+            let gpu = readback(&pre);
+
+            let img = image::DynamicImage::ImageRgb8(
+                image::RgbImage::from_raw(src_w as u32, src_h as u32, frame).expect("rgb image"),
+            );
+            let cpu = crate::preprocessing::preprocess_image_with_precision(&img, dst, 32, false);
+            let cpu = cpu.tensor.as_slice().expect("contiguous cpu tensor");
+
+            let n = 3 * dst.0 * dst.1;
+            let max_diff = (0..n).fold(0.0f32, |m, i| m.max((gpu[i] - cpu[i]).abs()));
+            // 1/255 == 0.0039: anything above one input quantization step is a real
+            // resampling mismatch, not float noise (the CPU uses OpenCV's 11-bit
+            // fixed-point weights, the kernel f32).
+            assert!(
+                max_diff < 1.0 / 255.0,
+                "gpu letterbox deviates from cpu by {max_diff} at {src_h}x{src_w}"
+            );
         }
-
-        // A rect target, so this also covers the non-square letterbox the `rect` path uses.
-        let dst = (192usize, 320usize);
-        let mut pre = preprocessor(dst.0, dst.1);
-        pre.preprocess(&frame, src_h as u32, src_w as u32, false, dst)
-            .expect("gpu preprocess");
-        let gpu = readback(&pre);
-
-        let img = image::DynamicImage::ImageRgb8(
-            image::RgbImage::from_raw(src_w as u32, src_h as u32, frame).expect("rgb image"),
-        );
-        let cpu = crate::preprocessing::preprocess_image_with_precision(&img, dst, 32, false);
-        let cpu = cpu.tensor.as_slice().expect("contiguous cpu tensor");
-
-        let n = 3 * dst.0 * dst.1;
-        let max_diff = (0..n).fold(0.0f32, |m, i| m.max((gpu[i] - cpu[i]).abs()));
-        // 1/255 == 0.0039: anything above one input quantization step is a real
-        // resampling mismatch, not float noise.
-        assert!(
-            max_diff < 1.0 / 255.0,
-            "gpu letterbox deviates from cpu by {max_diff}"
-        );
     }
 }

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -114,10 +114,6 @@ pub(crate) struct PreGeom {
     pub scale: f32,
     pub pad_x: i32,
     pub pad_y: i32,
-    /// Target the frame was letterboxed into, `(height, width)`. Equals the caller's
-    /// requested size, which is the model input for square inference and the
-    /// stride-aligned rectangle for `rect`.
-    pub dst_hw: (usize, usize),
 }
 
 /// Phase-1 of the fast-path init: a cudarc context + stream created before
@@ -324,7 +320,6 @@ impl CudaPreprocessor {
             scale,
             pad_x,
             pad_y,
-            dst_hw: (dst_h, dst_w),
         })
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1061,7 +1061,7 @@ impl YOLOModel {
             .as_mut()
             .expect("predict_image_cuda_pre invariant: cuda_preprocessor.is_some()");
         let geom = pre.preprocess(&rgb_bytes, h, w, false, target)?;
-        let (dst_h, dst_w) = geom.dst_hw;
+        let (dst_h, dst_w) = target;
         let dev_ptr = pre.input_dev_ptr();
         #[allow(clippy::cast_precision_loss)]
         let preprocess_time = start_preprocess.elapsed().as_secs_f64() * 1000.0;

--- a/src/model.rs
+++ b/src/model.rs
@@ -992,6 +992,29 @@ impl YOLOModel {
         Ok(results)
     }
 
+    /// Whether rectangular inference applies: requested in the config and supported by
+    /// the model. Fixed-shape models must letterbox to their own input size.
+    const fn rect_enabled(&self) -> bool {
+        self.config.rect && self.is_dynamic
+    }
+
+    /// Letterbox target for one image: the stride-aligned rectangle when `rect` is in
+    /// effect, else `target` unchanged. Shared by the CPU and cuda-preprocess paths so
+    /// both feed the model the same pixels.
+    fn letterbox_target(
+        rect: bool,
+        width: u32,
+        height: u32,
+        target: (usize, usize),
+        stride: u32,
+    ) -> (usize, usize) {
+        if rect {
+            calculate_rect_size(width, height, target, stride)
+        } else {
+            target
+        }
+    }
+
     /// Log the standard `image 1/1 ...` verbose line for the first result (no-op when
     /// empty), shared by both the CPU and cuda-preprocess arms of [`Self::predict_image`].
     fn log_first_result(results: &[Results]) {
@@ -1032,12 +1055,16 @@ impl YOLOModel {
         let (w, h) = (rgb_img.width(), rgb_img.height());
         let rgb_bytes = rgb_img.into_raw();
 
+        // Same letterbox target the CPU path would pick, so both paths feed the model
+        // identical pixels.
+        let (rect, stride) = (self.rect_enabled(), self.metadata.stride);
         let pre = self
             .cuda_preprocessor
             .as_mut()
             .expect("predict_image_cuda_pre invariant: cuda_preprocessor.is_some()");
-        let geom = pre.preprocess(&rgb_bytes, h, w, false)?;
-        let (dst_h, dst_w) = pre.dst_hw();
+        let target = Self::letterbox_target(rect, w, h, pre.dst_hw(), stride);
+        let geom = pre.preprocess(&rgb_bytes, h, w, false, target)?;
+        let (dst_h, dst_w) = geom.dst_hw;
         let dev_ptr = pre.input_dev_ptr();
         #[allow(clippy::cast_precision_loss)]
         let preprocess_time = start_preprocess.elapsed().as_secs_f64() * 1000.0;
@@ -1257,7 +1284,7 @@ impl YOLOModel {
         // 1. Enabled in config
         // 2. Model supports dynamic shapes
         // 3. Batch is homogeneous (all images have same dimensions) or batch size is 1
-        let use_rect = self.config.rect && self.is_dynamic;
+        let use_rect = self.rect_enabled();
         let uniform_shape = if images.len() > 1 {
             let first_dims = images[0].dimensions();
             images.iter().all(|img| img.dimensions() == first_dims)
@@ -1276,12 +1303,9 @@ impl YOLOModel {
         // We will stack tensors later
         for image in images {
             // Determine target size for this image
-            let current_target_size = if actual_rect {
-                let (w, h) = image.dimensions();
-                calculate_rect_size(w, h, target_size, self.metadata.stride)
-            } else {
-                target_size
-            };
+            let (w, h) = image.dimensions();
+            let current_target_size =
+                Self::letterbox_target(actual_rect, w, h, target_size, self.metadata.stride);
 
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)

--- a/src/model.rs
+++ b/src/model.rs
@@ -1277,10 +1277,8 @@ impl YOLOModel {
         let start_preprocess = Instant::now();
         let mut preprocessed_results = Vec::with_capacity(images.len());
 
-        // Check if we can use rect inference
-        // 1. Enabled in config
-        // 2. Model supports dynamic shapes
-        // 3. Batch is homogeneous (all images have same dimensions) or batch size is 1
+        // Rect inference additionally needs a homogeneous batch: mixed sizes can't share
+        // one padded shape, so they fall back to square below.
         let use_rect = self.rect_enabled();
         let uniform_shape = if images.len() > 1 {
             let first_dims = images[0].dimensions();

--- a/src/model.rs
+++ b/src/model.rs
@@ -490,12 +490,19 @@ impl YOLOModel {
         // The handle MUST be consumed (not dropped) once `with_compute_stream`
         // has been wired into the EPs above - dropping the last `Arc<CudaStream>`
         // would invalidate the raw pointer held by ORT. So if the stream was
-        // opened we always finalize the preprocessor, sizing the input buffer to
-        // the resolved (possibly non-square) model input; `predict_image`'s
-        // runtime gate keeps it unused for Classify / fp16-input models.
+        // opened we always finalize the preprocessor; `predict_image`'s runtime gate
+        // keeps it unused for Classify / fp16-input models.
+        //
+        // The buffer is sized to the resolved (possibly non-square) model input rounded
+        // up to the stride, which is the largest target `rect` can ask for:
+        // `calculate_rect_size` shrinks the short axis but rounds each axis *up* to the
+        // stride, so a non-stride-aligned `imgsz` (e.g. 1000 -> 1024) exceeds the model
+        // input itself.
         #[cfg(feature = "cuda-preprocess")]
         let cuda_preprocessor = if let Some(handle) = cuda_pre_stream {
-            let (dst_h, dst_w) = resolved_imgsz;
+            let stride = metadata.stride as usize;
+            let round_up = |v: usize| v.div_ceil(stride) * stride;
+            let (dst_h, dst_w) = (round_up(resolved_imgsz.0), round_up(resolved_imgsz.1));
             match crate::cuda_inference::CudaPreprocessor::finalize(handle, dst_h, dst_w) {
                 Ok(p) => Some(p),
                 Err(e) => {
@@ -964,8 +971,7 @@ impl YOLOModel {
         // both its f32-logits and baked-in ArgMax (u8) output forms. Depth is
         // included too: it is a plain letterbox + f32 input with a single f32
         // output, post-processed through the shared pipeline like every other
-        // task. The kernel emits the model's fixed dst_h × dst_w; the only
-        // requirement is f32 input (the kernel writes f32, not f16).
+        // task. The only requirement is f32 input (the kernel writes f32, not f16).
         #[cfg(feature = "cuda-preprocess")]
         if self.cuda_preprocessor.is_some()
             && !self.fp16_input
@@ -996,23 +1002,6 @@ impl YOLOModel {
     /// the model. Fixed-shape models must letterbox to their own input size.
     const fn rect_enabled(&self) -> bool {
         self.config.rect && self.is_dynamic
-    }
-
-    /// Letterbox target for one image: the stride-aligned rectangle when `rect` is in
-    /// effect, else `target` unchanged. Shared by the CPU and cuda-preprocess paths so
-    /// both feed the model the same pixels.
-    fn letterbox_target(
-        rect: bool,
-        width: u32,
-        height: u32,
-        target: (usize, usize),
-        stride: u32,
-    ) -> (usize, usize) {
-        if rect {
-            calculate_rect_size(width, height, target, stride)
-        } else {
-            target
-        }
     }
 
     /// Log the standard `image 1/1 ...` verbose line for the first result (no-op when
@@ -1056,13 +1045,21 @@ impl YOLOModel {
         let rgb_bytes = rgb_img.into_raw();
 
         // Same letterbox target the CPU path would pick, so both paths feed the model
-        // identical pixels.
-        let (rect, stride) = (self.rect_enabled(), self.metadata.stride);
+        // identical pixels. Computed from the model input, not the (stride-rounded)
+        // device buffer, and read before `cuda_preprocessor` borrows `self`.
+        let imgsz = self
+            .metadata
+            .imgsz
+            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ);
+        let target = if self.rect_enabled() {
+            calculate_rect_size(w, h, imgsz, self.metadata.stride)
+        } else {
+            imgsz
+        };
         let pre = self
             .cuda_preprocessor
             .as_mut()
             .expect("predict_image_cuda_pre invariant: cuda_preprocessor.is_some()");
-        let target = Self::letterbox_target(rect, w, h, pre.dst_hw(), stride);
         let geom = pre.preprocess(&rgb_bytes, h, w, false, target)?;
         let (dst_h, dst_w) = geom.dst_hw;
         let dev_ptr = pre.input_dev_ptr();
@@ -1303,9 +1300,12 @@ impl YOLOModel {
         // We will stack tensors later
         for image in images {
             // Determine target size for this image
-            let (w, h) = image.dimensions();
-            let current_target_size =
-                Self::letterbox_target(actual_rect, w, h, target_size, self.metadata.stride);
+            let current_target_size = if actual_rect {
+                let (w, h) = image.dimensions();
+                calculate_rect_size(w, h, target_size, self.metadata.stride)
+            } else {
+                target_size
+            };
 
             let res = if self.metadata.task == Task::Classify {
                 preprocess_image_center_crop(image, current_target_size, self.fp16_input)


### PR DESCRIPTION
The fused cuda-preprocess kernel diverged from the CPU letterbox: it sampled without the half-pixel offset and derived a single ratio from the uniform letterbox scale rather than per-axis ratios from the rounded resized extents, and it always padded to the model's square input instead of honoring rectangular inference. On the depth task this shifted the whole map so `--device cuda` produced a different depth range than `--device cpu`; this aligns the kernel with the CPU path (per-axis half-pixel sampling and the same stride-aligned rect target) and sizes the device buffer for the largest target rect can produce.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improved CUDA preprocessing to support rectangular inference and closely match CPU letterboxing for more consistent, reliable predictions.

### 📊 Key Changes

- Updated the CUDA preprocessing kernel to:
  - Support per-axis resize ratios and non-square targets.
  - Use half-pixel bilinear sampling consistent with CPU/OpenCV preprocessing.
  - Handle dynamically calculated rectangular letterbox dimensions.
- Added CUDA-versus-CPU preprocessing tests using gradient images and varied aspect ratios.
- Resized the CUDA input buffer to accommodate stride-aligned rectangular inference targets.
- Added logic to enable `rect` inference only for dynamic-shape models.
- Updated batch inference behavior so mixed-size batches fall back to square preprocessing.
- Expanded CUDA documentation to explain:
  - How mixed aspect ratios can trigger multiple TensorRT engine builds.
  - How to use `--rect false` for a fixed square input.
  - Expected CPU/CUDA preprocessing agreement.

### 🎯 Purpose & Impact

- ✅ Improves consistency between `--device cpu` and `--device cuda`, reducing prediction differences caused by preprocessing.
- 📐 Enables CUDA inference with rectangular, aspect-ratio-preserving inputs instead of always using square targets.
- ⚡ Helps maintain efficient TensorRT engine caching when input dimensions remain consistent.
- 🧪 Adds regression coverage for rounded resize dimensions, padding, color handling, and dynamic input sizes.
- 👥 Users should see more reliable CUDA results, especially with dynamic-shape models and sources containing varied image aspect ratios.