### PR TITLE
Blend the depth map over the image instead of side by side

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Depth results are rendered by blending the colorized depth map over the source image at
 `alpha = 0.6`, using the `jet` colormap and `disparity` normalization. This matches the
-Ultralytics Python `Annotator.depth_map` default exactly, so the CLI needs no depth flags
-and `--save` always produces the same image Python's `plot()` does.
+Ultralytics Python `Annotator.depth_map` default, so the CLI needs no depth flags and
+`--save` produces the same image Python's `plot()` does.
 
 Set the colormap and normalization explicitly through the library (`Jet` + `Disparity`
 below are the defaults; swap in any other variant):

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
 # Semantic segmentation: write per-image PNG class maps to runs/semantic/predictN/results/
 ultralytics-inference predict --task semantic --source cityscapes/ --save-json
 
-# Depth estimation: save a colorized side-by-side (image | depth) to runs/depth/predictN/
+# Depth estimation: blend the colorized depth over the image into runs/depth/predictN/
 ultralytics-inference predict --task depth --source image.jpg
 ```
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,6 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--save`        |       | Save annotated results to runs/\<task\>/predict                                                                                                                                                       | `true`                                |
 | `--save-frames` |       | Save individual frames for video input (instead of video file)                                                                                                                                        | `false`                               |
 | `--save-json`   |       | Save semantic segmentation class-map PNGs for external evaluation                                                                                                                                     | `false`                               |
-| `--colormap`    |       | Depth colormap: `jet`, `inferno`, `spectral`, or `gray` (depth task only)                                                                                                                             | `jet`                                 |
-| `--depth-viz`   |       | Depth normalization: `disparity` (inverse depth, near = high color) or `metric` (min/max, near = low color) (depth task only)                                                                         | `disparity`                           |
 | `--show`        |       | Display results in a window                                                                                                                                                                           | `false`                               |
 | `--device`      |       | Device string, e.g. cpu, cuda:0, coreml, directml:0, intel:cpu, intel:gpu, intel:npu, tensorrt:0, rocm:0, xnnpack; additional providers selectable when their feature is enabled (see Features table) | `cpu`                                 |
 | `--verbose`     |       | Show verbose output                                                                                                                                                                                   | `true`                                |
@@ -408,6 +406,44 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+**Depth Visualization:**
+
+Depth results are rendered by blending the colorized depth map over the source image at
+`alpha = 0.6`, using the `jet` colormap and `disparity` normalization. This matches the
+Ultralytics Python `Annotator.depth_map` default exactly, so the CLI needs no depth flags
+and `--save` always produces the same image Python's `plot()` does.
+
+Set the colormap and normalization explicitly through the library (`Jet` + `Disparity`
+below are the defaults; swap in any other variant):
+
+```rust
+use ultralytics_inference::YOLOModel;
+use ultralytics_inference::annotate::{annotate_image_with, load_image};
+use ultralytics_inference::visualizer::color::{Colormap, DepthViz};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut model = YOLOModel::load("yolo26n-depth.onnx")?;
+    let results = model.predict("image.jpg")?;
+
+    // Per-pixel depth in meters, at the original image resolution
+    if let Some(depth) = &results[0].depth {
+        println!("{:?} {:?}m", depth.data.shape(), depth.min_depth());
+    }
+
+    // inferno / jet / spectral / gray, and disparity (inverse depth) or metric (linear)
+    let image = load_image("image.jpg")?;
+    let annotated = annotate_image_with(&image, &results[0], None, Colormap::Jet, DepthViz::Disparity);
+    annotated.save("depth.jpg")?;
+
+    Ok(())
+}
+```
+
+`disparity` colors `1/d` instead of `d`, clipped to the 2nd-98th percentile. Inverting the
+depth spends the color range on nearby detail rather than the distant background, so near
+objects read warm and a few stray pixels cannot wash out the rest. `metric` colors depth
+directly, linearly between its min and max.
 
 For runnable programs you can copy and adapt, see the [examples](examples/README.md) directory.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -185,7 +185,7 @@ ultralytics-inference predict --model yolo26n.onnx --source image.jpg --rect
 # 语义分割：将每张图片的 PNG 类别图写入 runs/semantic/predictN/results/
 ultralytics-inference predict --task semantic --source cityscapes/ --save-json
 
-# 深度估计：将彩色化的并排图（原图 | 深度）保存到 runs/depth/predictN/
+# 深度估计：将彩色化的深度图叠加到原图并保存到 runs/depth/predictN/
 ultralytics-inference predict --task depth --source image.jpg
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -409,8 +409,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 **深度可视化：**
 
 深度结果的渲染方式是将彩色化的深度图以 `alpha = 0.6` 叠加到原图上，使用 `jet` 配色和
-`disparity` 归一化。这与 Ultralytics Python 的 `Annotator.depth_map` 默认行为完全一致，
-因此 CLI 无需任何深度相关参数，`--save` 始终产出与 Python `plot()` 相同的图像。
+`disparity` 归一化。这与 Ultralytics Python 的 `Annotator.depth_map` 默认行为一致，
+因此 CLI 无需任何深度相关参数，`--save` 产出与 Python `plot()` 相同的图像。
 
 可通过库接口显式指定配色与归一化方式（下面的 `Jet` + `Disparity` 即默认值，可替换为其他变体）：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -263,8 +263,6 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 | `--save`        |      | 将标注结果保存到 runs/\<task\>/predict                                                                                                                            | `true`                            |
 | `--save-frames` |      | 为视频输入保存单帧（而不是视频文件）                                                                                                                              | `false`                           |
 | `--save-json`   |      | 保存语义分割类别图 PNG，便于外部评估                                                                                                                              | `false`                           |
-| `--colormap`    |      | 深度着色方案：`jet`、`inferno`、`spectral` 或 `gray`（仅深度任务）                                                                                                | `jet`                             |
-| `--depth-viz`   |      | 深度归一化方式：`disparity`（逆深度，近处为高值色）或 `metric`（最小/最大值，近处为低值色）（仅深度任务）                                                         | `disparity`                       |
 | `--show`        |      | 在窗口中显示结果                                                                                                                                                  | `false`                           |
 | `--device`      |      | 设备字符串，例如 cpu、cuda:0、coreml、directml:0、intel:cpu、intel:gpu、intel:npu、tensorrt:0、rocm:0、xnnpack；启用 feature 后可选择更多提供方（见 Features 表） | `cpu`                             |
 | `--verbose`     |      | 显示详细输出                                                                                                                                                      | `true`                            |
@@ -407,6 +405,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+**深度可视化：**
+
+深度结果的渲染方式是将彩色化的深度图以 `alpha = 0.6` 叠加到原图上，使用 `jet` 配色和
+`disparity` 归一化。这与 Ultralytics Python 的 `Annotator.depth_map` 默认行为完全一致，
+因此 CLI 无需任何深度相关参数，`--save` 始终产出与 Python `plot()` 相同的图像。
+
+可通过库接口显式指定配色与归一化方式（下面的 `Jet` + `Disparity` 即默认值，可替换为其他变体）：
+
+```rust
+use ultralytics_inference::YOLOModel;
+use ultralytics_inference::annotate::{annotate_image_with, load_image};
+use ultralytics_inference::visualizer::color::{Colormap, DepthViz};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut model = YOLOModel::load("yolo26n-depth.onnx")?;
+    let results = model.predict("image.jpg")?;
+
+    // 原图分辨率下的逐像素深度（米）
+    if let Some(depth) = &results[0].depth {
+        println!("{:?} {:?}m", depth.data.shape(), depth.min_depth());
+    }
+
+    // inferno / jet / spectral / gray，以及 disparity（逆深度）或 metric（线性）
+    let image = load_image("image.jpg")?;
+    let annotated = annotate_image_with(&image, &results[0], None, Colormap::Jet, DepthViz::Disparity);
+    annotated.save("depth.jpg")?;
+
+    Ok(())
+}
+```
+
+`disparity` 着色的是 `1/d` 而非 `d`，并裁剪到第 2 至第 98 百分位。取倒数后色彩范围会集中在近处
+细节而非远处背景，因此近处呈暖色，且少量离群像素不会冲淡其余部分；`metric` 则直接对深度在其
+最小值与最大值之间做线性着色。
 
 可复制并修改的可运行程序，请参见 [examples](examples/README.md) 目录。
 

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -261,8 +261,8 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
 /// no depth map or its resolution does not match the image.
 ///
 /// Alpha is [`DEPTH_ALPHA`], so drawing this over the frame composites to the
-/// `(1 - alpha) * image + alpha * depth` blend the native annotator and Python produce
-/// (within the canvas backing store's 8-bit premultiplied rounding).
+/// `(1 - alpha) * image + alpha * depth` blend (within the canvas backing store's
+/// 8-bit premultiplied rounding).
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8> {
     let Some(depth) = &r.depth else {

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use ultralytics_inference::Task;
 use ultralytics_inference::results::{Results, SemanticMask};
-use ultralytics_inference::visualizer::color::{Color, Colormap, DepthViz};
+use ultralytics_inference::visualizer::color::{Color, Colormap, DEPTH_ALPHA, DepthViz};
 
 /// One detected box, mirroring `Boxes` in the Ultralytics API (pixel `xyxy`).
 /// `color` is the Ultralytics palette color for the class (`#rrggbb`).
@@ -91,9 +91,9 @@ pub(crate) struct JsResults {
     /// class-filtered pixels.
     #[serde(with = "serde_bytes")]
     semantic_mask: Vec<u8>,
-    /// Depth map as an opaque `RGBA` image (`width*height*4`), colorized with the
+    /// Depth map as a translucent `RGBA` overlay (`width*height*4`), colorized with the
     /// requested colormap over valid (`>0`) pixels; empty for other tasks. A
-    /// `Uint8Array`, drawable straight onto a canvas.
+    /// `Uint8Array`, drawable straight onto a canvas to blend over the frame.
     #[serde(with = "serde_bytes")]
     depth: Vec<u8>,
     /// Depth range `[min, max]` in meters over valid pixels; `None` for other tasks.
@@ -256,9 +256,12 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
     Vec::new()
 }
 
-/// Colorize the depth map into an opaque RGBA image (`width*height*4`) with the given
+/// Colorize the depth map into an RGBA overlay (`width*height*4`) with the given
 /// `colormap` and normalization `viz`; invalid pixels are black. Empty when the result has
 /// no depth map or its resolution does not match the image.
+///
+/// Alpha is [`DEPTH_ALPHA`], so drawing this over the frame composites to the same
+/// `(1 - alpha) * image + alpha * depth` blend the native annotator and Python produce.
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8> {
     let Some(depth) = &r.depth else {
@@ -268,9 +271,10 @@ fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8
     if depth.data.dim() != (h, w) {
         return Vec::new();
     }
+    let alpha = (DEPTH_ALPHA * 255.0).round() as u8;
     let mut buf = vec![0u8; w * h * 4];
     for (px, rgb) in buf.chunks_exact_mut(4).zip(depth.colorize(colormap, viz)) {
-        px.copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]); // invalid pixels are [0,0,0] -> opaque black
+        px.copy_from_slice(&[rgb[0], rgb[1], rgb[2], alpha]);
     }
     buf
 }

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -260,8 +260,9 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
 /// `colormap` and normalization `viz`; invalid pixels are black. Empty when the result has
 /// no depth map or its resolution does not match the image.
 ///
-/// Alpha is [`DEPTH_ALPHA`], so drawing this over the frame composites to the same
-/// `(1 - alpha) * image + alpha * depth` blend the native annotator and Python produce.
+/// Alpha is [`DEPTH_ALPHA`], so drawing this over the frame composites to the
+/// `(1 - alpha) * image + alpha * depth` blend the native annotator and Python produce
+/// (within the canvas backing store's 8-bit premultiplied rounding).
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8> {
     let Some(depth) = &r.depth else {

--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use ultralytics_inference::Task;
 use ultralytics_inference::results::{Results, SemanticMask};
-use ultralytics_inference::visualizer::color::{Color, Colormap, DEPTH_ALPHA, DepthViz};
+use ultralytics_inference::visualizer::color::{Color, Colormap, DepthViz};
 
 /// One detected box, mirroring `Boxes` in the Ultralytics API (pixel `xyxy`).
 /// `color` is the Ultralytics palette color for the class (`#rrggbb`).
@@ -260,10 +260,9 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
 /// `colormap` and normalization `viz`; invalid pixels are black. Empty when the result has
 /// no depth map or its resolution does not match the image.
 ///
-/// Alpha is [`DEPTH_ALPHA`], so drawing this over the frame composites to the
-/// `(1 - alpha) * image + alpha * depth` blend (within the canvas backing store's
-/// 8-bit premultiplied rounding).
-#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+/// Fully opaque (`alpha = 255`): the blend opacity is applied by the consumer at draw
+/// time (`annotate` composites at `0.6` to match native, the demo exposes a slider), so
+/// this stays the raw colorized map and can be shown at full opacity.
 fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8> {
     let Some(depth) = &r.depth else {
         return Vec::new();
@@ -272,10 +271,9 @@ fn build_depth_overlay(r: &Results, colormap: Colormap, viz: DepthViz) -> Vec<u8
     if depth.data.dim() != (h, w) {
         return Vec::new();
     }
-    let alpha = (DEPTH_ALPHA * 255.0).round() as u8;
     let mut buf = vec![0u8; w * h * 4];
     for (px, rgb) in buf.chunks_exact_mut(4).zip(depth.colorize(colormap, viz)) {
-        px.copy_from_slice(&[rgb[0], rgb[1], rgb[2], alpha]);
+        px.copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
     }
     buf
 }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -177,14 +177,18 @@ pub fn annotate_image(
         top_k,
         Colormap::default(),
         DepthViz::default(),
+        DEPTH_ALPHA,
     )
 }
 
-/// Annotate an image like [`annotate_image`], but with an explicit depth `colormap` and
-/// normalization `viz`.
+/// Annotate an image like [`annotate_image`], but with an explicit depth `colormap`,
+/// normalization `viz`, and overlay opacity `depth_alpha`.
 ///
-/// Only depth results use `colormap`/`viz`; every other task ignores them. See
-/// [`annotate_image`] for the general behavior.
+/// Only depth results use `colormap`/`viz`/`depth_alpha`; every other task ignores them.
+/// `depth_alpha` is the depth-overlay opacity in `0.0..=1.0`:
+/// [`DEPTH_ALPHA`](crate::visualizer::color::DEPTH_ALPHA) (`0.6`, the [`annotate_image`]
+/// default) blends it over the image; `1.0` renders the full colorized map, `0.0` shows only
+/// the source. See [`annotate_image`] for the general behavior.
 #[must_use]
 pub fn annotate_image_with(
     image: &DynamicImage,
@@ -192,6 +196,7 @@ pub fn annotate_image_with(
     top_k: Option<usize>,
     colormap: Colormap,
     viz: DepthViz,
+    depth_alpha: f32,
 ) -> DynamicImage {
     let mut img = image.to_rgb8();
 
@@ -221,19 +226,25 @@ pub fn annotate_image_with(
     draw_obb(&mut img, result, font.as_ref());
     draw_classification(&mut img, result, font.as_ref(), top_k.unwrap_or(5));
 
-    draw_depth_map(&mut img, result, colormap, viz);
+    draw_depth_map(&mut img, result, colormap, viz, depth_alpha);
 
     DynamicImage::ImageRgb8(img)
 }
 
-/// Blend the colorized depth map over `img` in place, mirroring Python's
-/// `Annotator.depth_map`: `(1 - alpha) * image + alpha * depth` at [`DEPTH_ALPHA`].
+/// Draw the colorized depth map over `img` in place at opacity `alpha`
+/// (`(1 - alpha) * image + alpha * depth`): `1.0` is the full colorized map, lower blends.
 ///
 /// No-op when the result carries no depth map or the map's resolution disagrees with the
 /// image. Colorization (`colormap` + normalization `viz`) is delegated to
 /// [`DepthMap::colorize`](crate::results::DepthMap::colorize).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn draw_depth_map(img: &mut image::RgbImage, result: &Results, colormap: Colormap, viz: DepthViz) {
+fn draw_depth_map(
+    img: &mut image::RgbImage,
+    result: &Results,
+    colormap: Colormap,
+    viz: DepthViz,
+    alpha: f32,
+) {
     let Some(depth) = result.depth.as_ref() else {
         return;
     };
@@ -242,11 +253,12 @@ fn draw_depth_map(img: &mut image::RgbImage, result: &Results, colormap: Colorma
     if depth.data.shape() != [height as usize, width as usize] {
         return;
     }
+    let alpha = alpha.clamp(0.0, 1.0);
     // `colorize` returns row-major RGB, the same order `pixels_mut` walks.
     for (px, heat) in img.pixels_mut().zip(depth.colorize(colormap, viz)) {
         for (channel, &h) in px.0.iter_mut().zip(heat.iter()) {
             *channel = f32::from(*channel)
-                .mul_add(1.0 - DEPTH_ALPHA, f32::from(h) * DEPTH_ALPHA)
+                .mul_add(1.0 - alpha, f32::from(h) * alpha)
                 .round() as u8;
         }
     }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -221,43 +221,38 @@ pub fn annotate_image_with(
     draw_obb(&mut img, result, font.as_ref());
     draw_classification(&mut img, result, font.as_ref(), top_k.unwrap_or(5));
 
-    // Depth is rendered side-by-side (original | colorized depth), matching the Python
-    // `plot(side_by_side=True)`, so it replaces the returned image rather than drawing in place.
-    if let Some(side_by_side) = compose_depth_side_by_side(&img, result, colormap, viz) {
-        return DynamicImage::ImageRgb8(side_by_side);
-    }
+    draw_depth_map(&mut img, result, colormap, viz);
 
     DynamicImage::ImageRgb8(img)
 }
 
-/// Build an `original | colorized-depth` side-by-side image, or `None` when the result
-/// has no depth map. Colorization (`colormap` + normalization `viz`) is delegated to
-/// [`DepthMap::colorize`](crate::results::DepthMap::colorize).
-fn compose_depth_side_by_side(
-    img: &image::RgbImage,
-    result: &Results,
-    colormap: Colormap,
-    viz: DepthViz,
-) -> Option<image::RgbImage> {
-    let depth = result.depth.as_ref()?;
-    let (width, height) = img.dimensions();
-    let (w, h) = (width as usize, height as usize);
-    // Depth map is stored at original image resolution; bail if it disagrees with the image.
-    if depth.data.shape() != [h, w] {
-        return None;
-    }
-    let colored = depth.colorize(colormap, viz);
+/// Blend factor for the depth overlay, matching Python's `Annotator.depth_map` default.
+const DEPTH_ALPHA: f32 = 0.6;
 
-    let mut out = image::RgbImage::new(width * 2, height);
-    for y in 0..h {
-        for x in 0..w {
-            #[allow(clippy::cast_possible_truncation)]
-            let (px, py) = (x as u32, y as u32);
-            out.put_pixel(px, py, *img.get_pixel(px, py));
-            out.put_pixel(px + width, py, Rgb(colored[y * w + x]));
+/// Blend the colorized depth map over `img` in place, mirroring Python's
+/// `Annotator.depth_map`: `(1 - alpha) * image + alpha * depth` at [`DEPTH_ALPHA`].
+///
+/// No-op when the result carries no depth map or the map's resolution disagrees with the
+/// image. Colorization (`colormap` + normalization `viz`) is delegated to
+/// [`DepthMap::colorize`](crate::results::DepthMap::colorize).
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn draw_depth_map(img: &mut image::RgbImage, result: &Results, colormap: Colormap, viz: DepthViz) {
+    let Some(depth) = result.depth.as_ref() else {
+        return;
+    };
+    let (width, height) = img.dimensions();
+    // Depth map is stored at original image resolution; bail if it disagrees with the image.
+    if depth.data.shape() != [height as usize, width as usize] {
+        return;
+    }
+    // `colorize` returns row-major RGB, the same order `pixels_mut` walks.
+    for (px, heat) in img.pixels_mut().zip(depth.colorize(colormap, viz)) {
+        for (channel, &h) in px.0.iter_mut().zip(heat.iter()) {
+            *channel = f32::from(*channel)
+                .mul_add(1.0 - DEPTH_ALPHA, f32::from(h) * DEPTH_ALPHA)
+                .round() as u8;
         }
     }
-    Some(out)
 }
 
 /// Draw a thick line segment between two points using Bresenham's algorithm.
@@ -1191,15 +1186,17 @@ mod tests {
     }
 
     #[test]
-    fn test_annotate_depth_side_by_side() {
+    fn test_annotate_depth_blends_in_place() {
         let mut r = base_results(HashMap::new());
         let mut depth = ndarray::Array2::<f32>::zeros((128, 128));
         depth[[10, 10]] = 5.0;
         depth[[20, 20]] = 2.0;
         r.depth = Some(DepthMap::new(depth, (128, 128)));
         let out = annotate_image(&DynamicImage::new_rgb8(128, 128), &r, None);
-        // Depth renders original | colorized-depth, so the output is double width.
-        assert_eq!(out.width(), 256);
+        // Depth blends over the image, so the output keeps the input size.
+        assert_eq!(out.width(), 128);
         assert_eq!(out.height(), 128);
+        // A valid pixel picks up the colormap, so it no longer matches the black input.
+        assert_ne!(out.to_rgb8().get_pixel(10, 10).0, [0, 0, 0]);
     }
 }

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -6,7 +6,7 @@
 //! annotations on images based on inference results.
 
 use crate::results::Results;
-use crate::visualizer::color::{COLORS, Colormap, DepthViz, POSE_COLORS};
+use crate::visualizer::color::{COLORS, Colormap, DEPTH_ALPHA, DepthViz, POSE_COLORS};
 use crate::visualizer::skeleton::{KPT_COLOR_INDICES, LIMB_COLOR_INDICES, SKELETON};
 use ab_glyph::{Font, FontRef, PxScale, ScaleFont};
 use image::{DynamicImage, Rgb};
@@ -225,9 +225,6 @@ pub fn annotate_image_with(
 
     DynamicImage::ImageRgb8(img)
 }
-
-/// Blend factor for the depth overlay, matching Python's `Annotator.depth_map` default.
-const DEPTH_ALPHA: f32 = 0.6;
 
 /// Blend the colorized depth map over `img` in place, mirroring Python's
 /// `Annotator.depth_map`: `(1 - alpha) * image + alpha * depth` at [`DEPTH_ALPHA`].

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,6 @@
 
 use crate::InferenceConfig;
 use crate::task::Task;
-use crate::visualizer::color::{Colormap, DepthViz};
 use clap::{Args, Parser, Subcommand};
 
 /// CLI arguments parser.
@@ -24,8 +23,6 @@ use clap::{Args, Parser, Subcommand};
     --save                 Save annotated images to runs/<task>/predict [default: true]
     --save-frames          Save individual frames for video input (instead of video file)
     --save-json            Save semantic segmentation class-map PNGs for external evaluation
-    --colormap <MAP>       Depth colormap: jet (default), inferno, spectral, or gray; depth task only
-    --depth-viz <MODE>     Depth normalization: disparity (default, DepthAnything-style) or metric; depth only
     --show                 Display results in a window [default: false]
     --device <DEVICE>      Device (cpu, cuda:0, coreml, directml:0, intel:cpu, intel:gpu, intel:npu, tensorrt:0, rocm:0, xnnpack)
     --verbose              Show verbose output [default: true]
@@ -39,8 +36,6 @@ Examples:
     ultralytics-inference predict --task classify --source image.jpg
     ultralytics-inference predict --task semantic --source image.jpg
     ultralytics-inference predict --task depth --source image.jpg
-    ultralytics-inference predict --task depth --source image.jpg --colormap jet
-    ultralytics-inference predict --task depth --source image.jpg --colormap spectral --depth-viz disparity
     ultralytics-inference predict --model yolo26n.onnx --source image.jpg
     ultralytics-inference predict --source video.mp4 --rect
     ultralytics-inference predict --source video.mp4 --save-frames
@@ -143,15 +138,6 @@ pub struct PredictArgs {
     /// shell argument parsing issues (e.g. use --classes 0,1 not --classes 0, 1).
     #[arg(long, allow_hyphen_values = true)]
     pub classes: Option<String>,
-
-    /// Depth colormap for visualization (`jet`, `inferno`, `spectral`, or `gray`); depth task only
-    #[arg(long, default_value_t = Colormap::default())]
-    pub colormap: Colormap,
-
-    /// Depth normalization: `disparity` (default, DepthAnything-style, inverse depth +
-    /// percentile clip) or `metric` (min/max); depth task only
-    #[arg(long, default_value_t = DepthViz::default())]
-    pub depth_viz: DepthViz,
 }
 
 /// Parse class IDs from various formats: `"1,2,3"`, `"[1,2,3]"`, `"(1,2,3)"`

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -6,7 +6,7 @@ use std::process;
 use std::time::Duration;
 
 #[cfg(feature = "annotate")]
-use crate::annotate::annotate_image_with;
+use crate::annotate::annotate_image;
 use crate::io::find_next_run_dir;
 
 #[cfg(feature = "visualize")]
@@ -41,8 +41,6 @@ pub fn run_prediction(args: &PredictArgs) {
     let save = args.save;
     let save_frames = args.save_frames;
     let save_json = args.save_json;
-    let colormap = args.colormap;
-    let depth_viz = args.depth_viz;
     let half = args.half;
     let verbose = args.verbose;
     let batch_size = args.batch as usize;
@@ -327,8 +325,7 @@ pub fn run_prediction(args: &PredictArgs) {
 
                         #[cfg(feature = "annotate")]
                         if save {
-                            let annotated =
-                                annotate_image_with(img, &result, None, colormap, depth_viz);
+                            let annotated = annotate_image(img, &result, None);
 
                             if let Some(saver) = &mut result_saver
                                 && let Err(e) = saver.save(is_video, meta, &annotated)
@@ -356,8 +353,7 @@ pub fn run_prediction(args: &PredictArgs) {
                             }
 
                             if let Some(ref mut v) = viewer {
-                                let annotated =
-                                    annotate_image_with(img, &result, None, colormap, depth_viz);
+                                let annotated = annotate_image(img, &result, None);
 
                                 if v.update(&annotated).is_ok() {
                                     // Main thread is blocking on channel, so visualizer wait is less critical
@@ -582,8 +578,6 @@ mod tests {
             device: None,
             verbose: true,
             classes: None,
-            colormap: crate::visualizer::color::Colormap::default(),
-            depth_viz: crate::visualizer::color::DepthViz::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //! ```
 //!
 //! Annotated depth is the colorized map blended over the image at `alpha = 0.6` with the
-//! `jet` colormap and `disparity` normalization, matching Python's `Annotator.depth_map`.
+//! `jet` colormap and `disparity` normalization.
 //! [`annotate_image_with`](annotate::annotate_image_with) selects a different
 //! [`Colormap`](visualizer::color::Colormap) or [`DepthViz`](visualizer::color::DepthViz);
 //! the CLI always renders the default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,6 @@
 //! | `--save` | | Save annotated results to runs/\<task\>/predict | `true` |
 //! | `--save-frames` | | Save individual frames for video input | `false` |
 //! | `--save-json` | | Save semantic segmentation class-map PNGs for external evaluation | `false` |
-//! | `--colormap` | | Depth colormap: `jet`, `inferno`, `spectral`, or `gray` (depth task only) | `jet` |
-//! | `--depth-viz` | | Depth normalization: `disparity` or `metric` (depth task only) | `disparity` |
 //! | `--show` | | Display results in a window | `false` |
 //! | `--device` | | Device (cpu, cuda:0, coreml, directml:0, intel:cpu, intel:gpu, intel:npu, tensorrt:0, xnnpack) | `cpu` |
 //! | `--verbose` | | Show verbose output | `true` |
@@ -247,6 +245,12 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Annotated depth is the colorized map blended over the image at `alpha = 0.6` with the
+//! `jet` colormap and `disparity` normalization, matching Python's `Annotator.depth_map`.
+//! [`annotate_image_with`](annotate::annotate_image_with) selects a different
+//! [`Colormap`](visualizer::color::Colormap) or [`DepthViz`](visualizer::color::DepthViz);
+//! the CLI always renders the default.
 //!
 //! ## Custom Configuration
 //!

--- a/src/results.rs
+++ b/src/results.rs
@@ -156,8 +156,8 @@ impl DepthMap {
     ///
     /// Uses `colormap` and normalization `viz`; shared by the native and web depth renderers.
     /// `Metric` normalizes the valid-pixel depth min/max (matches Python). `Disparity`
-    /// normalizes inverse depth clipped to the 2–98 percentile — the `DepthAnything` look,
-    /// where near pixels read warm and single-pixel outliers no longer wash out the range.
+    /// normalizes inverse depth (`1/d`) clipped to the 2–98 percentile, so near pixels read
+    /// warm and single-pixel outliers no longer wash out the range.
     #[must_use]
     pub fn colorize(&self, colormap: Colormap, viz: DepthViz) -> Vec<[u8; 3]> {
         let data = &self.data;

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -181,18 +181,14 @@ fn gray(t: f32) -> [u8; 3] {
     [g, g, g]
 }
 
-/// A continuous colormap for depth visualization.
+/// A continuous colormap for depth visualization; see each variant for its ramp.
 ///
-/// `Jet` (default) is the classic rainbow, matching Python's `colorize_depth` default and
-/// the ramp the Ultralytics iOS app renders depth with; `Inferno` and the diverging
-/// `Spectral` (`Spectral_r`) are Python's other two options; `Gray` is raw grayscale,
-/// available here and in the wasm API only.
-///
-/// The CLI always renders the default (`Jet`), like Python's `yolo predict`. Pick another
-/// through [`annotate_image_with`](crate::annotate::annotate_image_with).
+/// The CLI always renders the default (`Jet`). Pick another through
+/// [`annotate_image_with`](crate::annotate::annotate_image_with) in Rust, or the
+/// `colormap` option of `predict` in the wasm/npm API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Colormap {
-    /// Perceptual black → purple → orange → yellow (matches Python depth plots).
+    /// Perceptual black → purple → orange → yellow.
     Inferno,
     /// Classic rainbow: blue → cyan → green → yellow → red.
     #[default]
@@ -308,7 +304,7 @@ mod tests {
             DepthViz::Disparity
         );
         assert!("log".parse::<DepthViz>().is_err());
-        // Depth defaults to the rainbow ramp with near = warm, matching the Ultralytics iOS app.
+        // Depth defaults to the rainbow ramp (jet) with near = warm (disparity).
         assert_eq!(Colormap::default(), Colormap::Jet);
         assert_eq!(DepthViz::default(), DepthViz::Disparity);
     }

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -228,8 +228,7 @@ impl std::str::FromStr for Colormap {
     }
 }
 
-/// Blend factor for the colorized depth overlay: `(1 - alpha) * image + alpha * depth`,
-/// matching Python's `Annotator.depth_map` default.
+/// Blend factor for the colorized depth overlay: `(1 - alpha) * image + alpha * depth`.
 ///
 /// Shared by the native annotator and the browser crate, which bakes it into the overlay's
 /// alpha channel so the canvas composites to the same result.

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -228,10 +228,12 @@ impl std::str::FromStr for Colormap {
     }
 }
 
-/// Blend factor for the colorized depth overlay: `(1 - alpha) * image + alpha * depth`.
+/// Default depth-overlay opacity: `(1 - alpha) * image + alpha * depth`.
 ///
-/// Shared by the native annotator and the browser crate, which bakes it into the overlay's
-/// alpha channel so the canvas composites to the same result.
+/// The default [`annotate_image`](crate::annotate::annotate_image) (and the CLI's `--save`)
+/// blend at this; callers of
+/// [`annotate_image_with`](crate::annotate::annotate_image_with) or the wasm `annotate`'s
+/// `depthAlpha` can pass any opacity (`1.0` for the full colorized map).
 pub const DEPTH_ALPHA: f32 = 0.6;
 
 /// How depth values are normalized before colormapping.

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -142,8 +142,8 @@ fn jet(t: f32) -> [u8; 3] {
 
 /// Sample the reversed-Spectral colormap at normalized position `t` (clamped to `[0, 1]`).
 ///
-/// Diverging blue → cyan → green → yellow → red (matplotlib `Spectral_r`, the colormap
-/// `DepthAnything` uses), linearly interpolated between its 11 anchor colors.
+/// Diverging blue → cyan → green → yellow → red (matplotlib `Spectral_r`), linearly
+/// interpolated between its 11 anchor colors.
 #[must_use]
 #[allow(
     clippy::cast_possible_truncation,
@@ -173,7 +173,7 @@ fn spectral(t: f32) -> [u8; 3] {
 }
 
 /// Sample a grayscale ramp at normalized position `t` (clamped to `[0, 1]`): black (low) → white
-/// (high). Raw normalized depth with no color, matching Python's `colorize_depth(cmap="gray")`.
+/// (high). Raw normalized depth with no color.
 #[must_use]
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn gray(t: f32) -> [u8; 3] {
@@ -183,10 +183,13 @@ fn gray(t: f32) -> [u8; 3] {
 
 /// A continuous colormap for depth visualization.
 ///
-/// `Jet` (default) is the classic rainbow, the closest match to the rainbow ramp the
-/// Ultralytics iOS app renders depth with; `Inferno` matches Ultralytics' Python
-/// `colorize_depth`; `Spectral` is the diverging `Spectral_r` used by `DepthAnything`;
-/// `Gray` is raw grayscale.
+/// `Jet` (default) is the classic rainbow, matching Python's `colorize_depth` default and
+/// the ramp the Ultralytics iOS app renders depth with; `Inferno` and the diverging
+/// `Spectral` (`Spectral_r`) are Python's other two options; `Gray` is raw grayscale,
+/// available here and in the wasm API only.
+///
+/// The CLI always renders the default (`Jet`), like Python's `yolo predict`. Pick another
+/// through [`annotate_image_with`](crate::annotate::annotate_image_with).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Colormap {
     /// Perceptual black → purple → orange → yellow (matches Python depth plots).
@@ -246,9 +249,10 @@ pub enum DepthViz {
     /// Metric min/max over valid pixels — near = low color, far = high color. Matches
     /// Python's `colorize_depth`.
     Metric,
-    /// Inverse depth (disparity) with a 2–98 percentile clip — near = high color (warm).
-    /// The `DepthAnything`-style visualization, and the default: better contrast,
-    /// outlier-robust, and it renders near = warm like the Ultralytics iOS app.
+    /// Inverse depth (`1/d`, disparity) with a 2–98 percentile clip — near = high color
+    /// (warm). The default: inverting depth spreads the color range over nearby detail
+    /// instead of the distant background, and the percentile clip keeps a few stray
+    /// pixels from washing it out.
     #[default]
     Disparity,
 }

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -243,6 +243,13 @@ impl std::fmt::Display for Colormap {
     }
 }
 
+/// Blend factor for the colorized depth overlay: `(1 - alpha) * image + alpha * depth`,
+/// matching Python's `Annotator.depth_map` default.
+///
+/// Shared by the native annotator and the browser crate, which bakes it into the overlay's
+/// alpha channel so the canvas composites to the same result.
+pub const DEPTH_ALPHA: f32 = 0.6;
+
 /// How depth values are normalized before colormapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DepthViz {

--- a/src/visualizer/color.rs
+++ b/src/visualizer/color.rs
@@ -232,17 +232,6 @@ impl std::str::FromStr for Colormap {
     }
 }
 
-impl std::fmt::Display for Colormap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::Inferno => "inferno",
-            Self::Jet => "jet",
-            Self::Spectral => "spectral",
-            Self::Gray => "gray",
-        })
-    }
-}
-
 /// Blend factor for the colorized depth overlay: `(1 - alpha) * image + alpha * depth`,
 /// matching Python's `Annotator.depth_map` default.
 ///
@@ -275,15 +264,6 @@ impl std::str::FromStr for DepthViz {
                 "invalid depth-viz '{s}', expected one of: metric, disparity"
             )),
         }
-    }
-}
-
-impl std::fmt::Display for DepthViz {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::Metric => "metric",
-            Self::Disparity => "disparity",
-        })
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,7 +11,6 @@ use tempfile::tempdir;
 use ultralytics_inference::cli::args::PredictArgs;
 use ultralytics_inference::cli::predict::run_prediction;
 use ultralytics_inference::task::Task;
-use ultralytics_inference::visualizer::color::Colormap;
 use ultralytics_inference::{Boxes, InferenceConfig, Results, Speed};
 #[cfg(any(feature = "coreml", feature = "cuda"))]
 use ultralytics_inference::{Device, YOLOModel};
@@ -64,8 +63,6 @@ fn test_run_prediction_e2e() {
         device: None,
         verbose: false,
         classes: None,
-        colormap: Colormap::default(),
-        depth_viz: ultralytics_inference::visualizer::color::DepthViz::default(),
     };
 
     run_prediction(&args);
@@ -117,8 +114,6 @@ fn test_run_prediction_e2e_semantic() {
         device: None,
         verbose: false,
         classes: None,
-        colormap: Colormap::default(),
-        depth_viz: ultralytics_inference::visualizer::color::DepthViz::default(),
     };
 
     run_prediction(&args);
@@ -148,8 +143,6 @@ fn test_semantic_save_class_map() {
         device: None,
         verbose: false,
         classes: None,
-        colormap: Colormap::default(),
-        depth_viz: ultralytics_inference::visualizer::color::DepthViz::default(),
     };
 
     run_prediction(&args);
@@ -213,8 +206,6 @@ fn test_run_prediction_e2e_depth() {
         device: None,
         verbose: false,
         classes: None,
-        colormap: Colormap::default(),
-        depth_viz: ultralytics_inference::visualizer::color::DepthViz::default(),
     };
 
     run_prediction(&args);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -109,7 +109,7 @@ export interface Results {
    * Depth map as a translucent colorized RGBA overlay (`width*height*4`), using the
    * colormap from {@link PredictOptions.colormap}; empty for other tasks. Drawable
    * straight onto a canvas via `ImageData`, where its alpha blends it over the frame
-   * exactly as the native annotator and Python do.
+   * as the native annotator and Python do.
    */
   depth: Uint8Array;
   /** Depth range `[min, max]` in meters over valid pixels, for depth models. */
@@ -807,7 +807,7 @@ export async function annotate(
   }
 
   // Depth: the engine returns a translucent colorized depth overlay; drawing it over
-  // the frame blends it in, matching the native annotator and Python.
+  // the frame blends it in, like the native annotator and Python.
   const depth = results.depth;
   if (depth && depth.length === width * height * 4) {
     const tmp = makeCanvas(width, height);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -108,8 +108,7 @@ export interface Results {
   /**
    * Depth map as a translucent colorized RGBA overlay (`width*height*4`), using the
    * colormap from {@link PredictOptions.colormap}; empty for other tasks. Drawable
-   * straight onto a canvas via `ImageData`, where its alpha blends it over the frame
-   * as the native annotator and Python do.
+   * straight onto a canvas via `ImageData`, where its alpha blends it over the frame.
    */
   depth: Uint8Array;
   /** Depth range `[min, max]` in meters over valid pixels, for depth models. */
@@ -807,7 +806,9 @@ export async function annotate(
   }
 
   // Depth: the engine returns a translucent colorized depth overlay; drawing it over
-  // the frame blends it in, like the native annotator and Python.
+  // the frame blends it in. Like the segment overlay above, this assumes an opaque
+  // source (photo/camera/video frame): a source with transparent pixels keeps that
+  // transparency through the blend, so feed opaque frames for a fully opaque result.
   const depth = results.depth;
   if (depth && depth.length === width * height * 4) {
     const tmp = makeCanvas(width, height);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -226,13 +226,13 @@ export interface PredictOptions {
   classes?: number[];
   /**
    * Depth colormap for the `depth` overlay: `"jet"` (default, classic rainbow),
-   * `"inferno"`, `"spectral"` (`Spectral_r`, DepthAnything-style), or `"gray"` (raw
-   * grayscale). Ignored by every other task.
+   * `"inferno"`, `"spectral"` (`Spectral_r`), or `"gray"` (raw grayscale). Ignored by
+   * every other task.
    */
   colormap?: "inferno" | "jet" | "spectral" | "gray";
   /**
-   * Depth normalization: `"disparity"` (default, inverse depth + percentile clip, the
-   * DepthAnything look) or `"metric"` (min/max). Ignored by every other task.
+   * Depth normalization: `"disparity"` (default, inverse depth + percentile clip) or
+   * `"metric"` (min/max). Ignored by every other task.
    */
   depthViz?: "metric" | "disparity";
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -106,9 +106,10 @@ export interface Results {
    */
   semantic_mask?: Uint16Array;
   /**
-   * Depth map as a translucent colorized RGBA overlay (`width*height*4`), using the
-   * colormap from {@link PredictOptions.colormap}; empty for other tasks. Drawable
-   * straight onto a canvas via `ImageData`, where its alpha blends it over the frame.
+   * Depth map as an opaque colorized RGBA image (`width*height*4`), using the colormap
+   * from {@link PredictOptions.colormap}; empty for other tasks. {@link annotate} blends
+   * it over the frame at {@link AnnotateOptions.depthAlpha} (default 0.6); draw it directly
+   * for the raw map.
    */
   depth: Uint8Array;
   /** Depth range `[min, max]` in meters over valid pixels, for depth models. */
@@ -249,6 +250,11 @@ export interface AnnotateOptions {
   keypoints?: boolean;
   /** Keypoint confidence threshold for drawing. Default `0.25` (matches Ultralytics). */
   keypointThreshold?: number;
+  /**
+   * Blend opacity for the depth overlay, `0`..`1`. Default `0.6` (matches the native
+   * annotator); `1` shows the raw colorized depth map, `0` shows only the source.
+   */
+  depthAlpha?: number;
 }
 
 /** Image-like inputs accepted by {@link YOLO.predict}. */
@@ -805,15 +811,17 @@ export async function annotate(
     ctx.drawImage(tmp as CanvasImageSource, 0, 0, width, height);
   }
 
-  // Depth: the engine returns a translucent colorized depth overlay; drawing it over
-  // the frame blends it in. Like the segment overlay above, this assumes an opaque
-  // source (photo/camera/video frame): a source with transparent pixels keeps that
-  // transparency through the blend, so feed opaque frames for a fully opaque result.
+  // Depth: the engine returns the opaque colorized depth map, blended over the frame here
+  // at `depthAlpha` (default 0.6; pass 1 for the raw map, 0 for none). Like the segment
+  // overlay above, this assumes an opaque source (photo/camera/video frame): a source with
+  // transparent pixels keeps that transparency through the blend.
   const depth = results.depth;
   if (depth && depth.length === width * height * 4) {
     const tmp = makeCanvas(width, height);
     get2d(tmp).putImageData(new ImageData(new Uint8ClampedArray(depth), width, height), 0, 0);
+    ctx.globalAlpha = options?.depthAlpha ?? 0.6;
     ctx.drawImage(tmp as CanvasImageSource, 0, 0, width, height);
+    ctx.globalAlpha = 1;
   }
 
   const lineWidth = options?.lineWidth ?? Math.max(2, Math.round(width / 320));

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -106,9 +106,10 @@ export interface Results {
    */
   semantic_mask?: Uint16Array;
   /**
-   * Depth map as an opaque colorized RGBA image (`width*height*4`), using the
-   * colormap from {@link PredictOptions.colormap}; empty for other tasks.
-   * Drawable straight onto a canvas via `ImageData`.
+   * Depth map as a translucent colorized RGBA overlay (`width*height*4`), using the
+   * colormap from {@link PredictOptions.colormap}; empty for other tasks. Drawable
+   * straight onto a canvas via `ImageData`, where its alpha blends it over the frame
+   * exactly as the native annotator and Python do.
    */
   depth: Uint8Array;
   /** Depth range `[min, max]` in meters over valid pixels, for depth models. */
@@ -805,8 +806,8 @@ export async function annotate(
     ctx.drawImage(tmp as CanvasImageSource, 0, 0, width, height);
   }
 
-  // Depth: the engine returns an opaque colorized depth image; draw it over the
-  // frame so the canvas shows the depth map.
+  // Depth: the engine returns a translucent colorized depth overlay; drawing it over
+  // the frame blends it in, matching the native annotator and Python.
   const depth = results.depth;
   if (depth && depth.length === width * height * 4) {
     const tmp = makeCanvas(width, height);


### PR DESCRIPTION
Ultralytics Python's `Annotator.depth_map` blends the colorized depth over the image at alpha 0.6 and has no `side_by_side` parameter, and `yolo predict` exposes no depth visualization arguments; this matches that across all three surfaces. The native annotator now blends in place instead of composing an `image | depth` pair, the `--colormap` and `--depth-viz` CLI flags are removed (colormap and normalization stay selectable from the library and wasm API), and the browser overlay carries the same 0.6 alpha so the canvas composites the same blend. The now-dead `Display` impls the clap flags relied on are deleted too.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🖼️ Depth visualizations now blend colorized depth maps directly over the original image instead of displaying them side by side.

### 📊 Key Changes

- Changed native and CLI depth rendering to use an in-place overlay with a default opacity of `0.6`.
- Standardized depth visualization defaults to the `jet` colormap and `disparity` normalization.
- Removed `--colormap` and `--depth-viz` CLI options; customization remains available through the Rust library and web APIs.
- Added configurable `depth_alpha` support to Rust annotation and `depthAlpha` support to the web annotator.
- Updated web depth rendering to apply opacity during canvas composition while retaining the raw colorized RGBA map.
- Updated documentation, examples, tests, and API comments in English and Chinese.

### 🎯 Purpose & Impact

- ✅ Produces compact, intuitive depth results at the original image dimensions.
- 👀 Makes nearby objects easier to interpret by emphasizing near-depth detail and reducing outlier influence.
- 🔄 Aligns Rust CLI output with Ultralytics Python depth visualization behavior.
- 🧩 Simplifies the CLI by removing depth-specific visualization flags and providing sensible defaults.
- 🛠️ Preserves advanced customization for Rust and web developers through annotation APIs and opacity controls.
- ⚠️ Users relying on the previous side-by-side output or removed CLI flags will need to update their workflows.