### PR TITLE
Share the letterbox geometry between the CPU and CUDA preprocess

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -186,9 +186,9 @@ pub fn annotate_image(
 ///
 /// Only depth results use `colormap`/`viz`/`depth_alpha`; every other task ignores them.
 /// `depth_alpha` is the depth-overlay opacity in `0.0..=1.0`:
-/// [`DEPTH_ALPHA`](crate::visualizer::color::DEPTH_ALPHA) (`0.6`, the [`annotate_image`]
-/// default) blends it over the image; `1.0` renders the full colorized map, `0.0` shows only
-/// the source. See [`annotate_image`] for the general behavior.
+/// [`DEPTH_ALPHA`] (`0.6`) is the [`annotate_image`] default and blends it over the image;
+/// `1.0` renders the full colorized map, `0.0` shows only the source. See [`annotate_image`]
+/// for the general behavior.
 #[must_use]
 pub fn annotate_image_with(
     image: &DynamicImage,

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -270,18 +270,17 @@ impl CudaPreprocessor {
             .memcpy_htod(frame_hwc, &mut self.frame_dev)
             .map_err(|e| InferenceError::InferenceError(format!("htod: {e:?}")))?;
 
-        // Letterbox into the (possibly non-square) dst_h × dst_w target:
-        // single uniform scale = min over both axes, centered padding.
-        let scale = (dst_h as f32 / src_h as f32).min(dst_w as f32 / src_w as f32);
-        let resized_w = (src_w as f32 * scale).round() as i32;
-        let resized_h = (src_h as f32 * scale).round() as i32;
-        let pad_x = (dst_w as i32 - resized_w) / 2;
-        let pad_y = (dst_h as i32 - resized_h) / 2;
+        // Letterbox geometry from the shared CPU helper, so the kernel and the CPU path
+        // can never disagree on scale/rounding/padding. `scale` is the uniform gain
+        // post-processing back-projects with.
+        let (geom, scale) =
+            crate::preprocessing::LetterboxGeometry::compute(src_w, src_h, (dst_h, dst_w));
+        let (resized_w, resized_h) = (geom.new_w as i32, geom.new_h as i32);
+        let (pad_x, pad_y) = (geom.pad_left as i32, geom.pad_top as i32);
         // Resampling ratios are src-per-dst on each axis, matching the CPU letterbox
-        // (`get_or_compute_x_lut(src_w, new_w)` / `scale_y = src_h / new_h`). `scale`
-        // itself stays the uniform gain, which is what post-processing back-projects with.
-        let scale_x = src_w as f32 / resized_w as f32;
-        let scale_y = src_h as f32 / resized_h as f32;
+        // (`get_or_compute_x_lut(src_w, new_w)` / `scale_y = src_h / new_h`).
+        let scale_x = src_w as f32 / geom.new_w as f32;
+        let scale_y = src_h as f32 / geom.new_h as f32;
         let bgr_in_i = i32::from(bgr_in);
 
         let block_dim = (16u32, 16u32, 1u32);

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -80,11 +80,44 @@ pub struct PreprocessResult {
 
 /// Geometry parameters resolved by letterbox layout.
 #[derive(Clone, Copy)]
-struct LetterboxGeometry {
-    new_w: u32,
-    new_h: u32,
-    pad_left: u32,
-    pad_top: u32,
+pub(crate) struct LetterboxGeometry {
+    pub(crate) new_w: u32,
+    pub(crate) new_h: u32,
+    pub(crate) pad_left: u32,
+    pub(crate) pad_top: u32,
+}
+
+impl LetterboxGeometry {
+    /// Letterbox geometry for fitting `(orig_w, orig_h)` into `target` = `(height, width)`:
+    /// a uniform scale (`min` over both axes), rounded resized extents, and centered
+    /// padding. The returned `scale` is that uniform gain, used for coordinate
+    /// back-projection.
+    ///
+    /// The single source of this math for both the CPU letterbox and the `cuda-preprocess`
+    /// kernel, so the two can never disagree on where a pixel lands.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    pub(crate) fn compute(orig_w: u32, orig_h: u32, target: (usize, usize)) -> (Self, f32) {
+        let (target_h, target_w) = (target.0 as f32, target.1 as f32);
+        let (orig_hf, orig_wf) = (orig_h as f32, orig_w as f32);
+        let scale = (target_h / orig_hf).min(target_w / orig_wf);
+        let new_w = (orig_wf * scale).round() as u32;
+        let new_h = (orig_hf * scale).round() as u32;
+        let pad_left = (target.1 as u32).saturating_sub(new_w) / 2;
+        let pad_top = (target.0 as u32).saturating_sub(new_h) / 2;
+        (
+            Self {
+                new_w,
+                new_h,
+                pad_left,
+                pad_top,
+            },
+            scale,
+        )
+    }
 }
 
 /// Build a `PreprocessResult` from a resolved letterbox geometry.
@@ -451,40 +484,10 @@ fn calculate_letterbox_params(
     target_size: (usize, usize),
     _stride: u32,
 ) -> (LetterboxGeometry, (f32, f32)) {
-    #[allow(clippy::cast_precision_loss)]
-    let (target_h, target_w) = (target_size.0 as f32, target_size.1 as f32);
-    #[allow(clippy::cast_precision_loss)]
-    let (orig_h, orig_w) = (orig_height as f32, orig_width as f32);
-
-    // Calculate scale to fit within target while maintaining aspect ratio
-    let scale = (target_h / orig_h).min(target_w / orig_w);
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let new_w = (orig_w * scale).round() as u32;
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let new_h = (orig_h * scale).round() as u32;
-
-    #[allow(clippy::cast_possible_truncation)]
-    let pad_w = (target_size.1 as u32).saturating_sub(new_w);
-    #[allow(clippy::cast_possible_truncation)]
-    let pad_h = (target_size.0 as u32).saturating_sub(new_h);
-
-    // Center alignment: divide padding equally on both sides
-    let pad_left = pad_w / 2;
-    let pad_top = pad_h / 2;
-
-    // Use a single `gain = min(target_h / orig_h, target_w / orig_w)` on both axes for
-    // coordinate back-projection. Per-axis gains computed from rounded `new_w`/`new_h`
-    // can diverge slightly, shifting boxes and changing NMS results.
-    (
-        LetterboxGeometry {
-            new_w,
-            new_h,
-            pad_left,
-            pad_top,
-        },
-        (scale, scale),
-    )
+    // A single uniform `gain` on both axes for coordinate back-projection; per-axis gains
+    // from the rounded extents can diverge slightly, shifting boxes and changing NMS.
+    let (geom, scale) = LetterboxGeometry::compute(orig_width, orig_height, target_size);
+    (geom, (scale, scale))
 }
 
 /// Convert an RGB image to a normalized NCHW tensor (FP32).


### PR DESCRIPTION
The fused cuda-preprocess kernel recomputed the letterbox scale, rounded resized extents, and centered padding inline, duplicating the exact math in the CPU letterbox that #343 had to hand-align after the two drifted apart. This lifts that math into a single `LetterboxGeometry::compute` that both `calculate_letterbox_params` and the kernel call, so the CPU and GPU paths share one source of truth and cannot diverge again; verified byte-identical depth output on CPU and CUDA before and after, with detection/segment/pose/obb unchanged across devices.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Unifies letterbox geometry calculations across CPU and CUDA preprocessing for more consistent inference results. 🎯

### 📊 Key Changes

- Added a shared `LetterboxGeometry::compute` helper for resize dimensions, scaling, and centered padding.
- Updated CPU preprocessing to use the shared geometry implementation.
- Updated CUDA preprocessing to use the same calculations, including matching rounding and padding behavior.
- Preserved a single uniform scale for accurate coordinate back-projection and post-processing.
- Simplified an internal documentation link in `annotate.rs`.

### 🎯 Purpose & Impact

- Prevents CPU and GPU inference paths from disagreeing about pixel placement. ✅
- Improves bounding-box and detection-coordinate accuracy, especially for non-square input sizes.
- Reduces subtle shifts that could affect post-processing and non-maximum suppression results.
- Makes future preprocessing changes safer by maintaining one source of truth for letterbox calculations. 🚀