### PR TITLE
Release 0.0.31 with CUDA depth parity, blend visualization, and shared letterbox geometry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.30"
+version = "0.0.31"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.29 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.31 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -219,7 +219,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.29 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.31 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -316,7 +316,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.29"
+ultralytics-inference = "0.0.31"
 ```
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -198,7 +198,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.29 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.31 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -218,7 +218,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.29 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.31 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -315,7 +315,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.29"
+ultralytics-inference = "0.0.31"
 ```
 
 ```toml

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.30"
+version = "0.0.31"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -27,9 +27,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.29", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.31", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.29", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.31", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -59,7 +59,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.29", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.31", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps the crate, wasm crate, and npm package to 0.0.31 with both lockfiles refreshed, releasing the depth CUDA-parity, blend visualization, and letterbox-geometry work. Also brings the README and CUDA doc version strings current (they still referenced 0.0.29).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Bumps Ultralytics Inference and web package versions from 0.0.30 to 0.0.31 and updates documentation references.

### 📊 Key Changes
- Updated the Rust package version to `0.0.31`.
- Updated the browser/WebAssembly package version to `0.0.31`.
- Refreshed README examples in English and Chinese to display version `0.0.31`.
- Updated installation instructions to reference `ultralytics-inference = "0.0.31"`.
- Updated CUDA and TensorRT feature configuration examples to use version `0.0.31`.
- Updated generated dependency lockfiles, including `Cargo.lock` and `web/package-lock.json`.

### 🎯 Purpose & Impact
- 📦 Publishes a consistent new release version across Rust, WebAssembly, and JavaScript packages.
- 📚 Keeps user-facing documentation aligned with the latest package versions.
- ✅ Makes installation examples for CPU, CUDA, and TensorRT configurations accurate for new users.
- 🔄 No functional inference changes are shown in this diff; the primary impact is release versioning and dependency consistency.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
