### PR TITLE
reuse shared helpers instead of duplicated wrappers

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -16,6 +16,10 @@ use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 
+/// Re-exported so `annotate::find_next_run_dir` keeps working; the implementation lives in
+/// [`crate::io`] alongside the other save-path helpers.
+pub use crate::io::find_next_run_dir;
+
 /// Assets URL for downloading fonts
 const ASSETS_URL: &str = "https://github.com/ultralytics/assets/releases/download/v0.0.0";
 

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -48,15 +48,6 @@ fn render_scale(width: u32, height: u32) -> (f32, i32) {
     (scale_factor, thickness)
 }
 
-/// Return the next unused run directory under `base` with the given `prefix`.
-///
-/// Tries `<base>/<prefix>` first, then `<base>/<prefix>2`, `<base>/<prefix>3`, and so on
-/// until a path that does not yet exist is found.
-#[must_use]
-pub fn find_next_run_dir(base: &str, prefix: &str) -> String {
-    crate::io::find_next_run_dir(base, prefix)
-}
-
 /// Load an image from `path`, working around a zune-jpeg stride bug for JPEG files.
 ///
 /// JPEG files are decoded with `jpeg_decoder` directly to avoid a stride mismatch
@@ -1075,17 +1066,6 @@ mod tests {
         // Indexing beyond the palette wraps rather than panicking.
         let _ = get_class_color(0);
         let _ = get_class_color(1000);
-    }
-
-    #[test]
-    fn test_find_next_run_dir_numbering() {
-        let tmp = tempfile::tempdir().unwrap();
-        let base = tmp.path().to_string_lossy().into_owned();
-        let first = find_next_run_dir(&base, "predict");
-        assert!(first.ends_with("predict"));
-        std::fs::create_dir_all(&first).unwrap();
-        let second = find_next_run_dir(&base, "predict");
-        assert!(second.ends_with("predict2"));
     }
 
     #[test]

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -128,8 +128,8 @@ pub fn run_prediction(args: &PredictArgs) {
     let need_predict_dir = needs_predict_dir(save, save_json, model.task());
 
     let save_dir: Option<std::path::PathBuf> = if need_predict_dir {
-        let parent_dir = predict_parent_dir(model.task());
-        let dir = find_next_run_dir(parent_dir, "predict");
+        let parent_dir = format!("runs/{}", model.task().as_str());
+        let dir = find_next_run_dir(&parent_dir, "predict");
         if let Err(e) = crate::io::ensure_dir(Path::new(&dir)) {
             error!("Failed to create save directory '{dir}': {e}");
             process::exit(1);
@@ -482,18 +482,6 @@ fn needs_predict_dir(save: bool, save_json: bool, task: Task) -> bool {
     }
 }
 
-const fn predict_parent_dir(task: Task) -> &'static str {
-    match task {
-        Task::Detect => "runs/detect",
-        Task::Segment => "runs/segment",
-        Task::Pose => "runs/pose",
-        Task::Classify => "runs/classify",
-        Task::Obb => "runs/obb",
-        Task::Semantic => "runs/semantic",
-        Task::Depth => "runs/depth",
-    }
-}
-
 fn needs_results_dir(save_json: bool, task: Task) -> bool {
     save_json && task == Task::Semantic
 }
@@ -699,17 +687,6 @@ mod tests {
             default_source_urls(Task::Obb),
             &[crate::download::DEFAULT_OBB_IMAGE]
         );
-    }
-
-    #[test]
-    fn test_predict_parent_dir_by_task() {
-        assert_eq!(predict_parent_dir(Task::Detect), "runs/detect");
-        assert_eq!(predict_parent_dir(Task::Segment), "runs/segment");
-        assert_eq!(predict_parent_dir(Task::Pose), "runs/pose");
-        assert_eq!(predict_parent_dir(Task::Classify), "runs/classify");
-        assert_eq!(predict_parent_dir(Task::Obb), "runs/obb");
-        assert_eq!(predict_parent_dir(Task::Semantic), "runs/semantic");
-        assert_eq!(predict_parent_dir(Task::Depth), "runs/depth");
     }
 
     #[test]

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -245,7 +245,7 @@ pub fn run_prediction(args: &PredictArgs) {
                 {
                     for result in results {
                         // Build detection summary
-                        let detection_summary = format_detection_summary(&result);
+                        let detection_summary = result.detection_summary();
 
                         // Get image dimensions from result
                         let inference_shape = result.inference_shape();
@@ -520,12 +520,6 @@ fn semantic_output_stem(image_path: &str, frame_idx: usize, total_frames: Option
     }
 }
 
-/// Count detections per class and format as summary string (e.g., "4 persons, 1 bus").
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn format_detection_summary(result: &Results) -> String {
-    result.detection_summary()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -734,7 +728,7 @@ mod tests {
         );
     }
 
-    /// Test `format_detection_summary` with boxes - single detection.
+    /// Test `Results::detection_summary` with boxes - single detection.
     #[test]
     fn test_format_summary_single_box() {
         // Boxes data: [x1, y1, x2, y2, conf, cls] - 6 columns
@@ -751,11 +745,11 @@ mod tests {
         );
         result.boxes = Some(boxes);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "1 person");
     }
 
-    /// Test `format_detection_summary` with boxes - multiple classes.
+    /// Test `Results::detection_summary` with boxes - multiple classes.
     #[test]
     fn test_format_summary_multiple_boxes() {
         // 3 boxes: 2 persons (class 0), 1 bus (class 2)
@@ -779,11 +773,11 @@ mod tests {
         );
         result.boxes = Some(boxes);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "2 persons, 1 bus");
     }
 
-    /// Test `format_detection_summary` with empty boxes.
+    /// Test `Results::detection_summary` with empty boxes.
     #[test]
     fn test_format_summary_empty_boxes() {
         let data = Array2::from_shape_vec((0, 6), vec![]).unwrap();
@@ -798,7 +792,7 @@ mod tests {
         );
         result.boxes = Some(boxes);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "(no detections)");
     }
 
@@ -816,11 +810,11 @@ mod tests {
             (2, 3),
         ));
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "person, car, bus");
     }
 
-    /// Test `format_detection_summary` with OBB detections.
+    /// Test `Results::detection_summary` with OBB detections.
     #[test]
     fn test_format_summary_obb() {
         // OBB data: [x, y, w, h, rotation, conf, cls] - 7 columns
@@ -843,11 +837,11 @@ mod tests {
         );
         result.obb = Some(obb);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "2 cars");
     }
 
-    /// Test `format_detection_summary` with empty OBB.
+    /// Test `Results::detection_summary` with empty OBB.
     #[test]
     fn test_format_summary_empty_obb() {
         let data = Array2::from_shape_vec((0, 7), vec![]).unwrap();
@@ -862,11 +856,11 @@ mod tests {
         );
         result.obb = Some(obb);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "(no detections)");
     }
 
-    /// Test `format_detection_summary` with classification probs.
+    /// Test `Results::detection_summary` with classification probs.
     #[test]
     fn test_format_summary_probs() {
         let data = ndarray::Array1::from_vec(vec![0.1, 0.7, 0.15, 0.03, 0.02]);
@@ -891,13 +885,13 @@ mod tests {
         );
         result.probs = Some(probs);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         // Top5 should include dog (0.7)
         assert!(summary.contains("dog"));
         assert!(summary.contains("0.70"));
     }
 
-    /// Test `format_detection_summary` with no results (empty result).
+    /// Test `Results::detection_summary` with no results (empty result).
     #[test]
     fn test_format_summary_no_results() {
         let result = Results::new(
@@ -908,11 +902,11 @@ mod tests {
             (640, 640),
         );
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "(no detections)");
     }
 
-    /// Test `format_detection_summary` with unknown class (uses "object" fallback).
+    /// Test `Results::detection_summary` with unknown class (uses "object" fallback).
     #[test]
     fn test_format_summary_unknown_class() {
         // Class 99 doesn't exist in names
@@ -929,7 +923,7 @@ mod tests {
         );
         result.boxes = Some(boxes);
 
-        let summary = format_detection_summary(&result);
+        let summary = result.detection_summary();
         assert_eq!(summary, "1 object");
     }
 }

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1665,31 +1665,29 @@ fn postprocess_obb_end2end(
             let user_cap = config.max_det.min(max_det);
             flat.reserve(user_cap * 7);
 
-            for i in 0..max_det {
-                let base = i * feats;
-                let conf = output[base + 4];
-                if conf < config.confidence_threshold {
-                    break;
-                }
-                let cls = output[base + 5] as usize;
-                if !config.keep_class(cls) {
-                    continue;
-                }
-                let cx = (output[base] - pad_left) / scale_x;
-                let cy = (output[base + 1] - pad_top) / scale_y;
-                flat.extend_from_slice(&[
-                    cx.clamp(0.0, max_w),
-                    cy.clamp(0.0, max_h),
-                    output[base + 2] / scale_x,
-                    output[base + 3] / scale_y,
-                    output[base + 6],
-                    conf,
-                    cls as f32,
-                ]);
-                if flat.len() >= user_cap * 7 {
-                    break;
-                }
-            }
+            // The shared decoder's xyxy box is unused here: OBB keeps `xywhr`, so the raw
+            // row is rescaled below and the rotation angle is read from column 6.
+            decode_end2end(
+                output,
+                max_det,
+                feats,
+                preprocess,
+                config,
+                user_cap,
+                |base, _bbox, conf, cls| {
+                    let cx = (output[base] - pad_left) / scale_x;
+                    let cy = (output[base + 1] - pad_top) / scale_y;
+                    flat.extend_from_slice(&[
+                        cx.clamp(0.0, max_w),
+                        cy.clamp(0.0, max_h),
+                        output[base + 2] / scale_x,
+                        output[base + 3] / scale_y,
+                        output[base + 6],
+                        conf,
+                        cls as f32,
+                    ]);
+                },
+            );
         }
     }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1030,7 +1030,7 @@ fn postprocess_segment(
 /// `min_transposed_features` (pose passes `4 + kpt_features`, OBB passes `6`); otherwise
 /// the output is treated as the transposed `[1, preds, features]`. 2D shapes pick the
 /// larger axis as the prediction count; anything else yields `(0, false)`.
-fn parse_transposed_shape(
+const fn parse_transposed_shape(
     shape: &[usize],
     expected_features: usize,
     min_transposed_features: usize,

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -780,6 +780,24 @@ mod tests {
     }
 
     #[test]
+    fn test_preprocess_image_center_crop() {
+        // Classification path: center-crop to the model size, normalize to [0, 1], and
+        // emit the FP16 tensor only when asked. A non-square source exercises the crop.
+        let img = image::DynamicImage::new_rgb8(400, 300);
+        for half in [false, true] {
+            let res = preprocess_image_center_crop(&img, (224, 224), half);
+            assert_eq!(res.tensor.dim(), (1, 3, 224, 224));
+            assert_eq!(res.orig_shape, (300, 400));
+            assert_eq!(res.padding, (0.0, 0.0));
+            assert!(res.tensor.iter().all(|v| (0.0..=1.0).contains(v)));
+            assert_eq!(res.tensor_f16.is_some(), half);
+            if let Some(t16) = &res.tensor_f16 {
+                assert_eq!(t16.dim(), res.tensor.dim());
+            }
+        }
+    }
+
+    #[test]
     fn test_preprocess_image_static_centered_letterbox() {
         // 480×640 wide image, target=1024×1024, is_dynamic=false.
         // Scale = min(1024/480, 1024/640) = 1024/640 = 1.6; nh=768, nw=1024, pad_top≈128.

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -492,12 +492,11 @@ fn calculate_letterbox_params(
 
 /// Convert an RGB image to a normalized NCHW tensor, planar (CHW) layout.
 ///
-/// Shared structure for the f32 and f16 variants: allocates the `(1, 3, H, W)`
-/// tensor, splits it into per-channel slices, and fills each pixel with
-/// `convert` applied to the source byte. The caller supplies the element type's
-/// zero value and the per-byte conversion so each variant keeps its exact
-/// arithmetic (the f16 path hoists its scale constant into the closure).
-fn image_to_tensor_generic<T: Clone>(
+/// Allocates the `(1, 3, H, W)` tensor, splits it into per-channel slices, and fills each
+/// pixel with `convert` applied to the source byte. The caller supplies the element type's
+/// zero value and the per-byte conversion, so the f32 and f16 callers each keep their exact
+/// arithmetic (the f16 one hoists its scale constant into the closure).
+fn image_to_tensor<T: Clone>(
     image: &RgbImage,
     zero: T,
     mut convert: impl FnMut(u8) -> T,
@@ -608,12 +607,12 @@ pub fn preprocess_image_center_crop(
     let (cropped, scale) = center_crop_image(image, target_size);
 
     // Convert to normalized NCHW tensor
-    let tensor = image_to_tensor_generic(&cropped, 0.0, |v| f32::from(v) / 255.0);
+    let tensor = image_to_tensor(&cropped, 0.0, |v| f32::from(v) / 255.0);
 
     // Optionally compute FP16 tensor, converting u8 straight to f16 with a hoisted 1/255.
     let tensor_f16 = half.then(|| {
         let scale = f16::from_f32(1.0 / 255.0);
-        image_to_tensor_generic(&cropped, f16::ZERO, move |v| {
+        image_to_tensor(&cropped, f16::ZERO, move |v| {
             f16::from_f32(f32::from(v)) * scale
         })
     });

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -490,19 +490,6 @@ fn calculate_letterbox_params(
     (geom, (scale, scale))
 }
 
-/// Convert an RGB image to a normalized NCHW tensor (FP32).
-///
-/// # Arguments
-///
-/// * `image` - RGB image to convert.
-///
-/// # Returns
-///
-/// Array4 with shape (1, 3, H, W) and values in [0, 1].
-fn image_to_tensor(image: &RgbImage) -> Array4<f32> {
-    image_to_tensor_generic(image, 0.0, |v| f32::from(v) / 255.0)
-}
-
 /// Convert an RGB image to a normalized NCHW tensor, planar (CHW) layout.
 ///
 /// Shared structure for the f32 and f16 variants: allocates the `(1, 3, H, W)`
@@ -532,25 +519,6 @@ fn image_to_tensor_generic<T: Clone>(
     }
 
     tensor
-}
-
-/// Convert an RGB image to a normalized NCHW tensor (FP16).
-///
-/// Converts directly from u8 to f16, avoiding intermediate f32 conversion.
-///
-/// # Arguments
-///
-/// * `image` - RGB image to convert.
-///
-/// # Returns
-///
-/// Array4 with shape (1, 3, H, W) and f16 values in [0, 1].
-fn image_to_tensor_f16(image: &RgbImage) -> Array4<f16> {
-    // Precompute 1/255 as f16 for direct conversion
-    let scale = f16::from_f32(1.0 / 255.0);
-    image_to_tensor_generic(image, f16::ZERO, move |v| {
-        f16::from_f32(f32::from(v)) * scale
-    })
 }
 
 /// Convert a `DynamicImage` to an HWC ndarray.
@@ -640,14 +608,15 @@ pub fn preprocess_image_center_crop(
     let (cropped, scale) = center_crop_image(image, target_size);
 
     // Convert to normalized NCHW tensor
-    let tensor = image_to_tensor(&cropped);
+    let tensor = image_to_tensor_generic(&cropped, 0.0, |v| f32::from(v) / 255.0);
 
-    // Optionally compute FP16 tensor
-    let tensor_f16 = if half {
-        Some(image_to_tensor_f16(&cropped))
-    } else {
-        None
-    };
+    // Optionally compute FP16 tensor, converting u8 straight to f16 with a hoisted 1/255.
+    let tensor_f16 = half.then(|| {
+        let scale = f16::from_f32(1.0 / 255.0);
+        image_to_tensor_generic(&cropped, f16::ZERO, move |v| {
+            f16::from_f32(f32::from(v)) * scale
+        })
+    });
 
     // For classification, we don't need complex coordinate mapping back to original
     // But we provide approximate scale/padding to satisfy strict types if needed.


### PR DESCRIPTION
Deletes four duplicated code paths, no behavior change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refactors inference utilities and prediction output handling while improving OBB decoding, preprocessing reuse, and test coverage. 🛠️

### 📊 Key Changes

- Re-exported `find_next_run_dir` from `annotate` while centralizing its implementation in `io`.
- Simplified prediction output paths to use `runs/<task>/predict*`, removing task-specific mapping code.
- Replaced a local detection-summary wrapper with the existing `Results::detection_summary()` method.
- Reused the shared end-to-end decoder for oriented bounding box (OBB) postprocessing.
- Consolidated FP32 and FP16 image-to-tensor conversion into a generic `image_to_tensor` helper.
- Made `parse_transposed_shape` a compile-time `const fn`.
- Added center-crop preprocessing tests covering tensor dimensions, normalization, padding, and optional FP16 output. ✅

### 🎯 Purpose & Impact

- Reduces duplicated code and keeps shared inference behavior in common utilities.
- Makes prediction directory handling more consistent across detection, segmentation, pose, classification, OBB, semantic, and depth tasks.
- Improves maintainability and consistency of OBB end-to-end decoding while preserving rotated-box output.
- Keeps FP32 and FP16 preprocessing behavior aligned, with FP16 conversion performed directly from image bytes.
- Strengthens regression protection through broader preprocessing and result-summary tests. 🔍