### PR TITLE
Merge overlapping unit tests into table-driven cases

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -110,27 +110,15 @@ mod tests {
     }
 
     #[test]
-    fn test_device_display() {
-        assert_eq!(Device::Cpu.to_string(), "cpu");
-        assert_eq!(Device::Cuda(0).to_string(), "cuda:0");
-        assert_eq!(Device::Cuda(1).to_string(), "cuda:1");
-        assert_eq!(Device::CoreMl.to_string(), "coreml");
-        assert_eq!(Device::DirectMl(0).to_string(), "directml:0");
-        assert_eq!(Device::IntelCpu.to_string(), "intel:cpu");
-        assert_eq!(Device::IntelGpu.to_string(), "intel:gpu");
-        assert_eq!(Device::IntelNpu.to_string(), "intel:npu");
-        assert_eq!(Device::Xnnpack.to_string(), "xnnpack");
-        assert_eq!(Device::TensorRt(2).to_string(), "tensorrt:2");
-        assert_eq!(Device::Rocm(3).to_string(), "rocm:3");
-    }
-
-    #[test]
     fn test_device_display_roundtrip() {
         for s in [
             "cpu",
             "cuda:0",
+            "cuda:1",
             "coreml",
             "directml:0",
+            "tensorrt:2",
+            "rocm:3",
             "intel:cpu",
             "intel:gpu",
             "intel:npu",

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -2059,17 +2059,32 @@ mod tests {
 
     #[test]
     fn test_parse_detect_shape() {
-        // Standard YOLO output [1, 84, 8400]
-        let (nc, np, transposed) = parse_detect_shape(&[1, 84, 8400], 80);
-        assert_eq!(nc, 80);
-        assert_eq!(np, 8400);
-        assert!(!transposed);
+        // (shape, expected_classes) -> (nc, num_preds, transposed). `expected_classes == 0`
+        // means the model had no metadata, so the class count is inferred as features - 4
+        // and the layout from which dimension is smaller.
+        type Case<'a> = (&'a [usize], usize, (usize, usize, bool));
+        let cases: &[Case<'_>] = &[
+            // 3D, with and without metadata, both layouts.
+            (&[1, 84, 8400], 80, (80, 8400, false)),
+            (&[1, 8400, 84], 80, (80, 8400, true)),
+            (&[1, 84, 8400], 0, (80, 8400, false)),
+            (&[1, 8400, 84], 0, (80, 8400, true)),
+            // 2D [features, preds] and its transpose.
+            (&[84, 8400], 80, (80, 8400, false)),
+            (&[84, 8400], 0, (80, 8400, false)),
+            (&[8400, 84], 0, (80, 8400, true)),
+        ];
+        for (shape, expected_classes, expected) in cases {
+            assert_eq!(
+                parse_detect_shape(shape, *expected_classes),
+                *expected,
+                "shape {shape:?}, expected_classes {expected_classes}"
+            );
+        }
 
-        // Transposed format [1, 8400, 84]
-        let (nc, np, transposed) = parse_detect_shape(&[1, 8400, 84], 80);
-        assert_eq!(nc, 80);
-        assert_eq!(np, 8400);
-        assert!(transposed);
+        // Degenerate dims and unsupported ranks yield zero predictions.
+        assert_eq!(parse_detect_shape(&[2, 3], 80).1, 0);
+        assert_eq!(parse_detect_shape(&[1, 2, 3, 4], 80).1, 0);
     }
 
     #[test]
@@ -2084,22 +2099,6 @@ mod tests {
         assert_eq!(infer_end2end_kpt_shape(&[1, 56, 8400]), None);
         // shape[2] <= 6 -> None (no keypoint features)
         assert_eq!(infer_end2end_kpt_shape(&[1, 300, 6]), None);
-    }
-
-    #[test]
-    fn test_parse_detect_shape_no_metadata() {
-        // When metadata is missing (expected_classes == 0), infer from shape
-        // Standard YOLO output [1, 84, 8400] with no metadata
-        let (nc, np, transposed) = parse_detect_shape(&[1, 84, 8400], 0);
-        assert_eq!(nc, 80); // Inferred: 84 - 4 = 80 classes
-        assert_eq!(np, 8400);
-        assert!(!transposed);
-
-        // Transposed format [1, 8400, 84] with no metadata
-        let (nc, np, transposed) = parse_detect_shape(&[1, 8400, 84], 0);
-        assert_eq!(nc, 80); // Inferred: 84 - 4 = 80 classes
-        assert_eq!(np, 8400);
-        assert!(transposed);
     }
 
     #[test]
@@ -2484,9 +2483,10 @@ mod tests {
 
     #[test]
     fn test_postprocess_semantic_binary_fast_path() {
-        // nc=1 (binary segmentation): positive logit → foreground (1), non-positive → background (0).
-        let (oh, ow, nc) = (1, 4, 1);
-        let output = vec![1.0f32, -1.0, 0.001, -0.001];
+        // nc=1 (binary segmentation): a positive logit is foreground (1), anything else is
+        // background (0). Exactly 0.0 is not > 0, so it lands on background too.
+        let (oh, ow, nc) = (1, 5, 1);
+        let output = vec![1.0f32, -1.0, 0.001, -0.001, 0.0];
         let result = postprocess_semantic(
             &output,
             &[1, nc, oh, ow],
@@ -2497,50 +2497,10 @@ mod tests {
             (oh as u32, ow as u32),
         );
         let sm = result.semantic_mask.unwrap();
-        assert_eq!(sm.data[[0, 0]], 1);
-        assert_eq!(sm.data[[0, 1]], 0);
-        assert_eq!(sm.data[[0, 2]], 1);
-        assert_eq!(sm.data[[0, 3]], 0);
-    }
-
-    #[test]
-    fn test_postprocess_semantic_binary_zero_logit() {
-        // Exactly 0.0 is not > 0, so it must be treated as background (class 0).
-        let (oh, ow, nc) = (1, 1, 1);
-        let result = postprocess_semantic(
-            &[0.0f32],
-            &[1, nc, oh, ow],
-            make_names(2),
-            ndarray::Array3::zeros((oh, ow, 3)),
-            String::new(),
-            Speed::default(),
-            (oh as u32, ow as u32),
+        assert_eq!(
+            sm.data.iter().copied().collect::<Vec<u16>>(),
+            [1, 0, 1, 0, 0]
         );
-        assert_eq!(result.semantic_mask.unwrap().data[[0, 0]], 0);
-    }
-
-    #[test]
-    fn test_postprocess_semantic_large_nc_fast_path() {
-        // nc=33 exceeds the old 32-element stack buffer; verify no panic and correct argmax.
-        let (oh, ow, nc) = (2, 2, 33);
-        let plane = oh * ow;
-        let mut output = vec![0.0f32; nc * plane];
-        for px in 0..plane {
-            output[32 * plane + px] = 1.0; // class 32 wins everywhere
-        }
-        let result = postprocess_semantic(
-            &output,
-            &[1, nc, oh, ow],
-            make_names(nc),
-            ndarray::Array3::zeros((oh, ow, 3)),
-            String::new(),
-            Speed::default(),
-            (oh as u32, ow as u32),
-        );
-        let sm = result.semantic_mask.unwrap();
-        for &val in &sm.data {
-            assert_eq!(val, 32);
-        }
     }
 
     #[test]
@@ -2574,29 +2534,27 @@ mod tests {
     }
 
     #[test]
-    fn test_postprocess_semantic_large_nc_slow_path() {
-        // nc=33 through the letterbox bilinear path (lh!=oh triggers it).
-        // oh=2, ow=4 wide image letterboxed into 8x8:
-        //   gain=2.0, pad rows=2 top+bottom, crop rows 2..6, crop_w=8 (no x padding).
-        let (oh, ow, lh, lw, nc) = (2, 4, 8, 8, 33);
-        let plane = lh * lw;
-        let mut output = vec![0.0f32; nc * plane];
-        for px in 0..plane {
-            output[32 * plane + px] = 1.0; // class 32 wins everywhere in model space
-        }
-        let result = postprocess_semantic(
-            &output,
-            &[1, nc, lh, lw],
-            make_names(nc),
-            ndarray::Array3::zeros((oh, ow, 3)),
-            String::new(),
-            Speed::default(),
-            (lh as u32, lw as u32),
-        );
-        let sm = result.semantic_mask.unwrap();
-        assert_eq!(sm.data.shape(), &[oh, ow]);
-        for &val in &sm.data {
-            assert_eq!(val, 32);
+    fn test_postprocess_semantic_large_nc() {
+        // nc=33 exceeds the old 32-element stack buffer. Class 32 wins everywhere, through
+        // the fast path (lh==oh) and the letterbox bilinear path (a 2x4 image padded into
+        // 8x8: gain=2.0, 2 pad rows top and bottom, crop rows 2..6, no x padding).
+        const NC: usize = 33;
+        for (oh, ow, lh, lw) in [(2usize, 2usize, 2usize, 2usize), (2, 4, 8, 8)] {
+            let plane = lh * lw;
+            let mut output = vec![0.0f32; NC * plane];
+            output[32 * plane..].fill(1.0);
+            let result = postprocess_semantic(
+                &output,
+                &[1, NC, lh, lw],
+                make_names(NC),
+                ndarray::Array3::zeros((oh, ow, 3)),
+                String::new(),
+                Speed::default(),
+                (lh as u32, lw as u32),
+            );
+            let sm = result.semantic_mask.unwrap();
+            assert_eq!(sm.data.shape(), &[oh, ow]);
+            assert!(sm.data.iter().all(|&v| v == 32), "{lh}x{lw} -> {oh}x{ow}");
         }
     }
 
@@ -2689,57 +2647,51 @@ mod tests {
     }
 
     #[test]
-    fn test_postprocess_semantic_mask_passthrough() {
-        // Pre-argmaxed u8 output at native resolution: values map 1:1 to u16 class map.
+    fn test_postprocess_semantic_mask() {
+        // Fast path: pre-argmaxed u8 output already at the original resolution maps 1:1
+        // onto the u16 class map, in both the 2D [h, w] and 3D [1, h, w] layouts.
         let (oh, ow) = (2, 3);
         let output: Vec<u8> = vec![0, 5, 3, 7, 2, 19];
-        let result = postprocess_semantic_mask(
-            &output,
-            &[oh, ow],
-            make_names(20),
-            ndarray::Array3::zeros((oh, ow, 3)),
-            String::new(),
-            Speed::default(),
-            (oh as u32, ow as u32),
-        );
-        let sm = result.semantic_mask.unwrap();
-        assert_eq!(sm.data.shape(), &[oh, ow]);
-        assert_eq!(sm.data[[0, 0]], 0);
-        assert_eq!(sm.data[[0, 1]], 5);
-        assert_eq!(sm.data[[0, 2]], 3);
-        assert_eq!(sm.data[[1, 0]], 7);
-        assert_eq!(sm.data[[1, 1]], 2);
-        assert_eq!(sm.data[[1, 2]], 19);
-        assert_eq!(sm.orig_shape(), (oh as u32, ow as u32));
-    }
+        for shape in [vec![oh, ow], vec![1, oh, ow]] {
+            let result = postprocess_semantic_mask(
+                &output,
+                &shape,
+                make_names(20),
+                ndarray::Array3::zeros((oh, ow, 3)),
+                String::new(),
+                Speed::default(),
+                (oh as u32, ow as u32),
+            );
+            let sm = result.semantic_mask.unwrap();
+            assert_eq!(sm.data.shape(), &[oh, ow]);
+            assert_eq!(
+                sm.data.iter().copied().collect::<Vec<u16>>(),
+                [0, 5, 3, 7, 2, 19]
+            );
+            assert_eq!(sm.orig_shape(), (oh as u32, ow as u32));
+            assert_eq!(sm.classes_present(), 6);
+        }
 
-    #[test]
-    fn test_postprocess_semantic_mask_empty_no_panic() {
+        // Slow path, plain upscale: a 4x4 mask of one class fills an 8x8 image.
         let r = postprocess_semantic_mask(
-            &[],
-            &[4, 4],
-            make_names(10),
-            ndarray::Array3::zeros((4, 4, 3)),
+            &[5u8; 16],
+            &[1, 4, 4],
+            make_names(6),
+            ndarray::Array3::zeros((8, 8, 3)),
             String::new(),
             Speed::default(),
-            (4, 4),
+            (8, 8),
         );
-        assert!(r.semantic_mask.is_none());
-    }
+        let sm = r.semantic_mask.unwrap();
+        assert_eq!(sm.data.shape(), [8, 8]);
+        assert!(sm.data.iter().all(|&v| v == 5));
 
-    #[test]
-    fn test_postprocess_semantic_mask_letterbox_nn_upsample() {
-        // oh=2, ow=4 wide image letterboxed into 8x8.
-        // letterbox_crop_bounds gives top=2, left=0, crop_h=4, crop_w=8.
-        // Content rows 2..6 set to class 7; padding rows 0..2 and 6..8 set to 99.
-        // After NN upsample all orig pixels should map into content → class 7.
+        // Slow path, letterboxed: a 2x4 wide image padded into 8x8 puts content in rows
+        // 2..6 (letterbox_crop_bounds -> top=2, left=0, crop 4x8). Padding rows carry a
+        // sentinel class that must be cropped away, so every output pixel is class 7.
         let (oh, ow, lh, lw) = (2, 4, 8, 8);
         let mut output = vec![99u8; lh * lw];
-        for row in 2..6 {
-            for col in 0..lw {
-                output[row * lw + col] = 7;
-            }
-        }
+        output[2 * lw..6 * lw].fill(7);
         let result = postprocess_semantic_mask(
             &output,
             &[lh, lw],
@@ -2751,8 +2703,20 @@ mod tests {
         );
         let sm = result.semantic_mask.unwrap();
         assert_eq!(sm.data.shape(), &[oh, ow]);
-        for &val in &sm.data {
-            assert_eq!(val, 7, "expected class 7 but got {val}");
+        assert!(sm.data.iter().all(|&v| v == 7));
+
+        // Empty output yields no mask instead of panicking, at either rank.
+        for shape in [vec![4, 4], vec![1, 0, 0]] {
+            let r = postprocess_semantic_mask(
+                &[],
+                &shape,
+                make_names(10),
+                ndarray::Array3::zeros((4, 4, 3)),
+                String::new(),
+                Speed::default(),
+                (4, 4),
+            );
+            assert!(r.semantic_mask.is_none(), "shape {shape:?}");
         }
     }
 
@@ -2819,25 +2783,6 @@ mod tests {
         // Segment predicate needs proto channel count to disambiguate nm.
         assert!(is_end2end_segment_shape(&[1, 300, 6 + 32], Some(32)));
         assert!(!is_end2end_segment_shape(&[1, 300, 6 + 32], None));
-    }
-
-    #[test]
-    fn test_parse_detect_shape_2d_and_fallback() {
-        // 2D [features, preds] with metadata.
-        let (nc, np, t) = parse_detect_shape(&[84, 8400], 80);
-        assert_eq!((nc, np, t), (80, 8400, false));
-        // No metadata: layout inferred from which dim is smaller.
-        let (nc, np, t) = parse_detect_shape(&[84, 8400], 0);
-        assert_eq!((nc, np, t), (80, 8400, false));
-        // No metadata, transposed [preds, features].
-        let (nc, np, t) = parse_detect_shape(&[8400, 84], 0);
-        assert_eq!((nc, np, t), (80, 8400, true));
-        // Degenerate small dims -> zero predictions.
-        let (_, np, _) = parse_detect_shape(&[2, 3], 80);
-        assert_eq!(np, 0);
-        // Unsupported rank -> zero predictions.
-        let (_, np, _) = parse_detect_shape(&[1, 2, 3, 4], 80);
-        assert_eq!(np, 0);
     }
 
     #[test]
@@ -2911,29 +2856,6 @@ mod tests {
     }
 
     #[test]
-    fn test_postprocess_obb_single_box() {
-        let names = make_names(1);
-        let pre = unit_preprocess((100, 100));
-        let config = InferenceConfig::default();
-        // [features=6, preds=1] layout: [cx, cy, w, h, class_score, angle]
-        let output = [50.0, 50.0, 20.0, 10.0, 0.9, 0.0];
-        let r = postprocess_obb(
-            &output,
-            &[1, 6, 1],
-            &pre,
-            &config,
-            names,
-            ndarray::Array3::zeros((100, 100, 3)),
-            String::new(),
-            Speed::default(),
-            (640, 640),
-        );
-        let obb = r.obb.unwrap();
-        assert_eq!(obb.len(), 1);
-        assert!((obb.conf()[0] - 0.9).abs() < 1e-6);
-    }
-
-    #[test]
     fn test_postprocess_detect_end2end_thresholds() {
         let names = make_names(1);
         let pre = unit_preprocess((100, 100));
@@ -2955,40 +2877,6 @@ mod tests {
             (640, 640),
         );
         assert_eq!(r.boxes.unwrap().len(), 1);
-    }
-
-    #[test]
-    fn test_postprocess_semantic_mask_fast_and_slow() {
-        let names = make_names(3);
-        // Fast path: model output already at original resolution (lh==oh, lw==ow).
-        let out: Vec<u8> = vec![0, 1, 1, 2];
-        let r = postprocess_semantic_mask(
-            &out,
-            &[1, 2, 2],
-            Arc::clone(&names),
-            ndarray::Array3::zeros((2, 2, 3)),
-            String::new(),
-            Speed::default(),
-            (2, 2),
-        );
-        let sm = r.semantic_mask.unwrap();
-        assert_eq!(sm.data.shape(), [2, 2]);
-        assert_eq!(sm.classes_present(), 3);
-
-        // Slow path: mask smaller than the original image triggers NN upsample.
-        let small: Vec<u8> = vec![5u8; 4 * 4];
-        let r = postprocess_semantic_mask(
-            &small,
-            &[1, 4, 4],
-            names,
-            ndarray::Array3::zeros((8, 8, 3)),
-            String::new(),
-            Speed::default(),
-            (8, 8),
-        );
-        let sm = r.semantic_mask.unwrap();
-        assert_eq!(sm.data.shape(), [8, 8]);
-        assert!(sm.data.iter().all(|&v| v == 5));
     }
 
     #[test]
@@ -3260,21 +3148,5 @@ mod tests {
         let sm = r.semantic_mask.unwrap();
         // All originally class-1 pixels are filtered out to IGNORE.
         assert!(sm.data.iter().all(|&v| v == SemanticMask::IGNORE));
-    }
-
-    #[test]
-    fn test_postprocess_semantic_mask_degenerate() {
-        let names = make_names(1);
-        // Empty output -> no mask, no panic.
-        let r = postprocess_semantic_mask(
-            &[],
-            &[1, 0, 0],
-            names,
-            ndarray::Array3::zeros((4, 4, 3)),
-            String::new(),
-            Speed::default(),
-            (4, 4),
-        );
-        assert!(r.semantic_mask.is_none());
     }
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -824,7 +824,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn test_preprocess_image_public_wrapper() {
         let img = image::DynamicImage::new_rgb8(320, 240);
         let res = preprocess_image(&img, (640, 640), 32);

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -736,22 +736,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_letterbox_params_square() {
+    fn test_letterbox_params() {
+        // Square input into a square target: exact fit, no padding.
         let (geom, _scale) = calculate_letterbox_params(640, 640, (640, 640), 32);
+        assert_eq!((geom.new_w, geom.new_h), (640, 640));
+        assert_eq!((geom.pad_left, geom.pad_top), (0, 0));
 
-        assert_eq!(geom.new_w, 640);
-        assert_eq!(geom.new_h, 640);
-        assert_eq!(geom.pad_left, 0);
-        assert_eq!(geom.pad_top, 0);
-    }
-
-    #[test]
-    fn test_letterbox_params_wide() {
+        // Wide input is scaled down to fit and padded top/bottom, not left/right.
         let (geom, _) = calculate_letterbox_params(1280, 720, (640, 640), 32);
+        assert!(geom.new_w <= 640 && geom.new_h <= 640);
+        assert_eq!(geom.pad_left, 0);
 
-        // Wide image should be scaled down with height padded
-        assert!(geom.new_w <= 640);
-        assert!(geom.new_h <= 640);
+        // Tall input is the mirror case: padded left/right, not top/bottom.
+        let (geom, _) = calculate_letterbox_params(480, 640, (640, 640), 32);
+        assert!(geom.pad_left > 0);
+        assert_eq!(geom.pad_top, 0);
     }
 
     #[test]
@@ -825,23 +824,6 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_rect_size_square_is_stride_aligned() {
-        let (h, w) = calculate_rect_size(640, 640, (640, 640), 32);
-        assert_eq!((h, w), (640, 640));
-        // Result is always a multiple of the stride.
-        let (h, w) = calculate_rect_size(800, 600, (640, 640), 32);
-        assert_eq!(h % 32, 0);
-        assert_eq!(w % 32, 0);
-    }
-
-    #[test]
-    fn test_letterbox_params_tall_pads_width() {
-        // Tall image (height > width) letterboxed into a square pads left/right.
-        let (geom, _) = calculate_letterbox_params(480, 640, (640, 640), 32);
-        assert!(geom.pad_left > 0);
-        assert_eq!(geom.pad_top, 0);
-    }
-
     #[test]
     fn test_preprocess_image_public_wrapper() {
         let img = image::DynamicImage::new_rgb8(320, 240);
@@ -882,12 +864,16 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_rect_size_various() {
-        // Portrait and landscape both round up to stride multiples and stay within target.
-        let (h, w) = calculate_rect_size(400, 1000, (640, 640), 32);
-        assert_eq!((h % 32, w % 32), (0, 0));
-        assert!(h <= 640 && w <= 640);
-        let (h, w) = calculate_rect_size(1000, 400, (640, 640), 32);
-        assert_eq!((h % 32, w % 32), (0, 0));
+    fn test_calculate_rect_size() {
+        // A square input at the target size is returned unchanged.
+        assert_eq!(calculate_rect_size(640, 640, (640, 640), 32), (640, 640));
+
+        // Portrait, landscape, and non-aligned inputs all round to stride multiples
+        // and stay within the target.
+        for (w, h) in [(400u32, 1000u32), (1000, 400), (800, 600)] {
+            let (rh, rw) = calculate_rect_size(w, h, (640, 640), 32);
+            assert_eq!((rh % 32, rw % 32), (0, 0));
+            assert!(rh <= 640 && rw <= 640);
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -283,23 +283,15 @@ mod tests {
 
     #[test]
     fn test_calculate_iou() {
-        let box1 = [0.0, 0.0, 10.0, 10.0];
-        let box2 = [5.0, 5.0, 15.0, 15.0];
-        let iou = calculate_iou(&box1, &box2);
-        assert!((iou - 0.142_857).abs() < 0.001); // 25 / (100 + 100 - 25)
-    }
-
-    #[test]
-    fn test_calculate_iou_full_overlap() {
-        let box1 = [0.0, 0.0, 10.0, 10.0];
-        assert!((calculate_iou(&box1, &box1) - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_calculate_iou_no_overlap() {
-        let box1 = [0.0, 0.0, 5.0, 5.0];
-        let box2 = [10.0, 10.0, 20.0, 20.0];
-        assert!(calculate_iou(&box1, &box2) < 1e-6);
+        // (box1, box2, expected): partial overlap 25 / (100 + 100 - 25), identical, disjoint.
+        let cases = [
+            ([0.0, 0.0, 10.0, 10.0], [5.0, 5.0, 15.0, 15.0], 0.142_857),
+            ([0.0, 0.0, 10.0, 10.0], [0.0, 0.0, 10.0, 10.0], 1.0),
+            ([0.0, 0.0, 5.0, 5.0], [10.0, 10.0, 20.0, 20.0], 0.0),
+        ];
+        for (box1, box2, expected) in cases {
+            assert!((calculate_iou(&box1, &box2) - expected).abs() < 0.001);
+        }
     }
 
     #[test]
@@ -318,48 +310,39 @@ mod tests {
 
     #[test]
     fn test_nms_per_class() {
-        // Two overlapping boxes of different classes should both be kept
+        // Overlapping boxes of different classes are kept; non-overlapping ones always are.
         let boxes = vec![
-            ([0.0, 0.0, 10.0, 10.0], 0.9, 0),        // class 0
-            ([1.0, 1.0, 11.0, 11.0], 0.8, 1),        // class 1 (different class)
-            ([100.0, 100.0, 110.0, 110.0], 0.95, 0), // class 0, non-overlapping
+            ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
+            ([1.0, 1.0, 11.0, 11.0], 0.8, 1),
+            ([100.0, 100.0, 110.0, 110.0], 0.95, 0),
+        ];
+        assert_eq!(nms_per_class(&boxes, 0.5).len(), 3);
+
+        // Overlapping within one class: the lower score is suppressed.
+        let boxes = vec![
+            ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
+            ([1.0, 1.0, 11.0, 11.0], 0.8, 0),
         ];
         let keep = nms_per_class(&boxes, 0.5);
-        // All 3 boxes should be kept (overlapping boxes are different classes)
-        assert_eq!(keep.len(), 3);
+        assert_eq!(keep, vec![0]);
     }
 
     #[test]
-    fn test_nms_per_class_suppression() {
-        // Two overlapping boxes of the same class - lower score suppressed
-        let boxes = vec![
-            ([0.0, 0.0, 10.0, 10.0], 0.9, 0), // class 0, higher score
-            ([1.0, 1.0, 11.0, 11.0], 0.8, 0), // class 0, lower score (suppressed)
-        ];
-        let keep = nms_per_class(&boxes, 0.5);
-        assert_eq!(keep.len(), 1);
-        assert!(keep.contains(&0)); // Keep higher score box
-    }
-
-    #[test]
-    fn test_nms_rotated_per_class_keeps_all_different_classes() {
-        let boxes = vec![
+    fn test_nms_rotated_per_class() {
+        // Same rotated box twice: kept across classes, suppressed within one.
+        let across = vec![
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
-            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 1), // same position, different class
+            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 1),
         ];
-        let keep = nms_rotated_per_class(&boxes, 0.5);
-        assert_eq!(keep.len(), 2);
+        assert_eq!(nms_rotated_per_class(&across, 0.5).len(), 2);
+
+        let within = vec![
+            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
+            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 0),
+        ];
+        assert_eq!(nms_rotated_per_class(&within, 0.5), vec![0]);
     }
 
-    #[test]
-    fn test_nms_rotated_per_class_suppresses_same_class() {
-        let boxes = vec![
-            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
-            ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 0), // identical box, same class, lower score
-        ];
-        let keep = nms_rotated_per_class(&boxes, 0.5);
-        assert_eq!(keep.len(), 1);
-    }
     #[test]
     fn test_pluralize() {
         assert_eq!(pluralize("person"), "persons");


### PR DESCRIPTION
Folds redundant test cases that cover the same function into single table-driven tests. No coverage loss: missed lines 453 -> 451, device.rs reaches 100%.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Consolidates and expands inference test coverage across device handling, detection shapes, segmentation masks, preprocessing, IoU, and NMS behavior.

### 📊 Key Changes

- 🔌 Simplified device display testing while expanding round-trip coverage for CUDA, TensorRT, and ROCm device formats.
- 📦 Consolidated detection-shape tests to cover:
  - 2D and 3D model outputs.
  - Transposed and non-transposed layouts.
  - Class-count inference when metadata is unavailable.
  - Invalid or unsupported tensor shapes.
- 🎨 Expanded semantic segmentation tests for:
  - Binary masks, including zero logits.
  - More than 32 classes.
  - Native-resolution and resized outputs.
  - Letterboxed outputs and padding removal.
  - Both 2D and 3D mask layouts.
  - Empty outputs without panics.
- 🖼️ Consolidated preprocessing tests for square, wide, tall, and stride-aligned inputs.
- 📐 Combined IoU and class-aware NMS tests, covering overlap, disjoint boxes, and same- versus different-class suppression.
- 🧹 Removed redundant tests and reorganized related cases into broader parameterized test groups.

### 🎯 Purpose & Impact

- ✅ Improves regression protection for common and edge-case inference scenarios.
- 🛡️ Helps ensure segmentation postprocessing remains safe for large class counts, unusual output shapes, and empty model results.
- 🔄 Increases confidence that outputs from different model export formats and tensor layouts are interpreted correctly.
- 🚀 Makes the test suite more concise and maintainable without changing the core inference behavior.