### PR TITLE
Optimize array_to_image by replacing manual pixel copying with a flat copy for RGB data

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -255,14 +255,8 @@ pub fn array_to_image(arr: &Array3<u8>) -> Result<DynamicImage> {
     let width = u32::try_from(shape[1])
         .map_err(|_| InferenceError::ImageError("Image width exceeds u32::MAX".to_string()))?;
 
-    let mut rgb_data = Vec::with_capacity((height * width * 3) as usize);
-    for y in 0..height as usize {
-        for x in 0..width as usize {
-            rgb_data.push(arr[[y, x, 0]]);
-            rgb_data.push(arr[[y, x, 1]]);
-            rgb_data.push(arr[[y, x, 2]]);
-        }
-    }
+    // HWC RGB is already row-major, so a flat copy matches the pixel order `RgbImage` expects.
+    let rgb_data: Vec<u8> = arr.iter().copied().collect();
 
     let img_buffer = image::RgbImage::from_raw(width, height, rgb_data).ok_or_else(|| {
         InferenceError::ImageError("Failed to create image from array".to_string())


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Optimizes RGB array-to-image conversion by replacing per-pixel copying with a direct flat buffer copy. ⚡

### 📊 Key Changes

- Removed nested loops that copied RGB channels pixel by pixel.
- Collects the existing row-major HWC array data directly into a `Vec<u8>`.
- Preserves compatibility with `image::RgbImage::from_raw` and existing error handling.

### 🎯 Purpose & Impact

- Improves conversion efficiency by reducing unnecessary iteration and indexing.
- Simplifies the implementation, making it easier to read and maintain.
- Produces the same image output for valid HWC RGB arrays, with potential performance benefits for larger images. 🚀