### PR TITLE
fix imgsz resolution for models with a fixed input shape

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -148,7 +148,7 @@ where
             return batch_results;
         }
 
-        eprintln!("WARNING ⚠️ Batch inference failed. Falling back to single-image inference...");
+        crate::warn!("Batch inference failed. Falling back to single-image inference...");
 
         let mut fallback_results = Vec::with_capacity(self.images.len());
         for (idx, img) in self.images.iter().enumerate() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -227,7 +227,7 @@ impl YOLOModel {
                     if matches!(Self::macos_version(), Some((major, _)) if major >= 11) {
                         eps.push((Self::build_coreml_ep(path), "CoreMLExecutionProvider"));
                     } else {
-                        warn!("WARNING ⚠️  CoreML requires macOS 11+; falling back to CPU.");
+                        warn!("CoreML requires macOS 11+; falling back to CPU.");
                     }
                 }
                 #[cfg(feature = "tensorrt")]
@@ -416,47 +416,41 @@ impl YOLOModel {
             .map(|o| o.name().to_string())
             .collect();
 
-        // Resolve image size
-        // Priority:
-        // 1. User config
-        // 2. Model metadata
-        // 3. Dynamic default (1024 for OBB, 640 for others)
-        // 4. Static input shape
-        // 5. Hard default (640)
-        let resolved_imgsz = if let Some(sz) = config.imgsz {
+        // The input's own [1, 3, H, W] shape, when the export pinned it.
+        let fixed_imgsz = if is_dynamic {
+            None
+        } else {
+            input_info.and_then(|i| match i.dtype() {
+                ValueType::Tensor { shape, .. }
+                    if shape.len() == 4 && shape[2] > 0 && shape[3] > 0 =>
+                {
+                    #[allow(clippy::cast_sign_loss)]
+                    Some((shape[2] as usize, shape[3] as usize))
+                }
+                _ => None,
+            })
+        };
+
+        let resolved_imgsz = if let Some(fixed) = fixed_imgsz {
+            if let Some(requested) = config.imgsz
+                && requested != fixed
+            {
+                warn!(
+                    "imgsz={requested:?} ignored: this model has a fixed input shape of {fixed:?}."
+                );
+            }
+            fixed
+        } else if let Some(sz) = config.imgsz {
             sz
         } else if let Some(sz) = metadata.imgsz {
             sz
-        } else if is_dynamic {
-            // Dynamic input without metadata -> apply robust defaults
+        } else {
             match metadata.task {
                 Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
                 _ => InferenceConfig::DEFAULT_IMGSZ,
             }
-        } else {
-            // Static input without metadata -> try to read from tensor shape
-            // Typically [1, 3, H, W]
-            let task_default = match metadata.task {
-                Task::Obb => InferenceConfig::DEFAULT_OBB_IMGSZ,
-                _ => InferenceConfig::DEFAULT_IMGSZ,
-            };
-            input_info
-                .and_then(|i| {
-                    if let ValueType::Tensor { shape, .. } = i.dtype() {
-                        if shape.len() == 4 && shape[2] > 0 && shape[3] > 0 {
-                            #[allow(clippy::cast_sign_loss)]
-                            Some((shape[2] as usize, shape[3] as usize))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(task_default)
         };
 
-        // Update config with resolved values
         let config = InferenceConfig {
             imgsz: Some(resolved_imgsz),
             half: config.half || metadata.half, // Use half if user requested OR model was exported with half
@@ -1248,7 +1242,7 @@ impl YOLOModel {
         let stride = self.metadata.stride as usize;
         if target_size.0 % stride != 0 || target_size.1 % stride != 0 {
             warn!(
-                "WARNING ⚠️ imgsz=[{:?}] must be multiple of max stride {}, updating to [{}, {}]",
+                "imgsz=[{:?}] must be multiple of max stride {}, updating to [{}, {}]",
                 target_size,
                 stride,
                 (target_size.0 as f32 / stride as f32).ceil() as usize * stride,

--- a/src/model.rs
+++ b/src/model.rs
@@ -399,15 +399,13 @@ impl YOLOModel {
             )
         });
 
-        // Check for dynamic input dimensions
-        // Dimensions are typically [-1, 3, -1, -1] for dynamic batch/height/width
-        // ort 2.0 returns Option<i64> (None means dynamic/unknown)
+        // Check for a dynamic spatial input shape, i.e. `[N, 3, -1, -1]`.
+        // ort 2.0 reports a dynamic/unknown dim as -1 or 0. Only the height and width
+        // matter: a dynamic batch (`[-1, 3, 640, 640]`) still pins the spatial size, and
+        // ONNX Runtime rejects any other height/width.
         let is_dynamic = input_info.is_some_and(|i| {
-            if let ValueType::Tensor { shape, .. } = i.dtype() {
-                shape.iter().any(|d| *d == -1 || *d == 0)
-            } else {
-                false
-            }
+            matches!(i.dtype(), ValueType::Tensor { shape, .. }
+                if shape.len() == 4 && (shape[2] <= 0 || shape[3] <= 0))
         });
 
         let output_names: Vec<String> = session
@@ -416,20 +414,15 @@ impl YOLOModel {
             .map(|o| o.name().to_string())
             .collect();
 
-        // The input's own [1, 3, H, W] shape, when the export pinned it.
-        let fixed_imgsz = if is_dynamic {
-            None
-        } else {
-            input_info.and_then(|i| match i.dtype() {
-                ValueType::Tensor { shape, .. }
-                    if shape.len() == 4 && shape[2] > 0 && shape[3] > 0 =>
-                {
-                    #[allow(clippy::cast_sign_loss)]
-                    Some((shape[2] as usize, shape[3] as usize))
-                }
-                _ => None,
-            })
-        };
+        // The height and width the export pinned, whatever the batch dimension does.
+        let fixed_imgsz = input_info.and_then(|i| match i.dtype() {
+            ValueType::Tensor { shape, .. } if shape.len() == 4 && shape[2] > 0 && shape[3] > 0 =>
+            {
+                #[allow(clippy::cast_sign_loss)]
+                Some((shape[2] as usize, shape[3] as usize))
+            }
+            _ => None,
+        });
 
         let resolved_imgsz = if let Some(fixed) = fixed_imgsz {
             if let Some(requested) = config.imgsz
@@ -1265,8 +1258,9 @@ impl YOLOModel {
         };
         let actual_rect = use_rect && uniform_shape;
 
-        // Warn if rect requested but disabled due to mixed batch
-        if self.config.rect && !uniform_shape {
+        // Warn if rect was actually in play but disabled due to mixed batch. `use_rect` is
+        // already false on a fixed-shape input, where rect never applied to begin with.
+        if use_rect && !uniform_shape {
             warn!(
                 "Batch contains images of different sizes. Rectangular inference disabled for this batch (falling back to square padding)."
             );

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -222,9 +222,11 @@ fn test_depth_results_has_map() {
     let mut model =
         YOLOModel::load(model_path.to_string_lossy().as_ref()).expect("depth model should load");
     assert_eq!(model.task(), Task::Depth);
-    let results = model
-        .predict("https://ultralytics.com/images/bus.jpg")
-        .expect("prediction should succeed");
+    // `predict` takes a filesystem path, so fetch the sample image first.
+    let source =
+        ultralytics_inference::download::download_image("https://ultralytics.com/images/bus.jpg")
+            .expect("sample image should download");
+    let results = model.predict(&source).expect("prediction should succeed");
 
     let depth = results[0]
         .depth


### PR DESCRIPTION

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves input-shape handling, warning consistency, and integration-test reliability in the Rust inference library. 🛠️

### 📊 Key Changes

- 🧠 Correctly detects dynamic ONNX input dimensions by checking only height and width, while allowing dynamic batch sizes.
- 📐 Prioritizes fixed model input dimensions and warns when a user-provided `imgsz` conflicts with a fixed shape.
- ⚠️ Standardizes warnings through the crate logging system and removes duplicated “WARNING” prefixes.
- 🖼️ Refines rectangular-inference warnings so they appear only when rectangular inference was actually enabled before being disabled for mixed-size batches.
- 🌐 Updates the depth integration test to download the sample image before passing it to `predict`, which expects a local filesystem path.

### 🎯 Purpose & Impact

- ✅ Prevents invalid image-size overrides and reduces ONNX Runtime input-shape errors.
- 🚀 Makes inference behavior more predictable for models with static, dynamic, or partially dynamic input shapes.
- 📣 Provides cleaner, more consistent warning output for applications and developers.
- 🧪 Improves integration-test correctness and reliability by using the expected local image input format.