### PR TITLE
Bump `ort` to `2.0.0-rc.13`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "half",
  "ndarray",
@@ -1712,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "glob",
  "hmac-sha256",
@@ -1724,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "ort-web"
-version = "0.2.1+1.24"
+version = "0.3.0+1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbfb28fde2a1443c2905a2a523a722f78b0cd7ffa677bebcd3d2d25bd959862"
+checksum = "bf2469978623be74836e83c8d9910f9a45d7a36b4edf478ff7a0c309f184ae39"
 dependencies = [
  "js-sys",
  "ort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ab_glyph = { version = "^0.2", optional = true }
 
 # Native-only dependencies. None of these build for `wasm32-unknown-unknown`
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# ONNX Runtime 1.24.2
-ort = { version = "2.0.0-rc.12", default-features = false, features = [
+# ONNX Runtime 1.28.0
+ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "std",
     "ndarray",
     "download-binaries",

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -28,9 +28,9 @@ ultralytics-inference = { path = "../..", default-features = false }
 # `download-binaries` ort under Cargo feature unification) and never tries to
 # build the browser-only crates for the host.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# Same ONNX Runtime version as the native crate (ort-web 0.3.0+1.27 pins it),
-# but with `alternative-backend` so ort bridges to ort-web instead of linking
-# the native runtime.
+# The browser runtime is whatever ort-web pins (0.3.0 pins ONNX Runtime 1.27), so it can
+# trail the native crate by a minor version until a matching ort-web is published. Uses
+# `alternative-backend` so ort bridges to ort-web instead of linking the native runtime.
 ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "std",
     "ndarray",

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -28,16 +28,16 @@ ultralytics-inference = { path = "../..", default-features = false }
 # `download-binaries` ort under Cargo feature unification) and never tries to
 # build the browser-only crates for the host.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# Same ONNX Runtime version as the native crate (ort-web 0.2.1+1.24 pins it),
+# Same ONNX Runtime version as the native crate (ort-web 0.3.0+1.27 pins it),
 # but with `alternative-backend` so ort bridges to ort-web instead of linking
 # the native runtime.
-ort = { version = "=2.0.0-rc.12", default-features = false, features = [
+ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "std",
     "ndarray",
     "alternative-backend",
     "half",
 ] }
-ort-web = "0.2.1"
+ort-web = "0.3.0"
 wasm-bindgen = "0.2.126"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/src/model.rs
+++ b/src/model.rs
@@ -294,26 +294,23 @@ impl YOLOModel {
             }
 
             #[cfg(feature = "rocm")]
-            eps.push((
-                ort::execution_providers::ROCmExecutionProvider::default().build(),
-                "ROCmExecutionProvider",
-            ));
+            eps.push((ort::ep::ROCm::default().build(), "ROCmExecutionProvider"));
 
             #[cfg(feature = "directml")]
             eps.push((
-                ort::execution_providers::DirectMLExecutionProvider::default().build(),
+                ort::ep::DirectML::default().build(),
                 "DirectMLExecutionProvider",
             ));
 
             #[cfg(feature = "openvino")]
             eps.push((
-                ort::execution_providers::OpenVINOExecutionProvider::default().build(),
+                ort::ep::OpenVINO::default().build(),
                 "OpenVINOExecutionProvider",
             ));
 
             #[cfg(feature = "xnnpack")]
             eps.push((
-                ort::execution_providers::XNNPACKExecutionProvider::default().build(),
+                ort::ep::XNNPACK::default().build(),
                 "XNNPACKExecutionProvider",
             ));
         }
@@ -523,8 +520,8 @@ impl YOLOModel {
     fn build_cuda_ep(
         device_id: i32,
         compute_stream: Option<*mut ()>,
-    ) -> ort::execution_providers::ExecutionProviderDispatch {
-        let ep = ort::execution_providers::CUDAExecutionProvider::default()
+    ) -> ort::ep::ExecutionProviderDispatch {
+        let ep = ort::ep::CUDA::default()
             .with_device_id(device_id)
             .with_tf32(true);
         bind_compute_stream!(ep, compute_stream)
@@ -547,7 +544,7 @@ impl YOLOModel {
         device_id: i32,
         fp16: bool,
         compute_stream: Option<*mut ()>,
-    ) -> ort::execution_providers::ExecutionProviderDispatch {
+    ) -> ort::ep::ExecutionProviderDispatch {
         let stem = model_path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -557,7 +554,7 @@ impl YOLOModel {
         let cache_dir = parent.join(".trt_cache").join(format!("{stem}_{suffix}"));
         let _ = std::fs::create_dir_all(&cache_dir);
         let cache_str = cache_dir.to_string_lossy().into_owned();
-        let ep = ort::execution_providers::TensorRTExecutionProvider::default()
+        let ep = ort::ep::TensorRT::default()
             .with_device_id(device_id)
             .with_fp16(fp16)
             .with_engine_cache(true)
@@ -586,13 +583,13 @@ impl YOLOModel {
 
     /// Build the `CoreML` execution provider, tuned for the model at `model_path`.
     #[cfg(feature = "coreml")]
-    fn build_coreml_ep(model_path: &Path) -> ort::execution_providers::ExecutionProviderDispatch {
+    fn build_coreml_ep(model_path: &Path) -> ort::ep::ExecutionProviderDispatch {
         use ort::ep::coreml::{ModelFormat, SpecializationStrategy};
 
         // MLProgram with static input shapes and FastPrediction avoids the ORT CoreML EP
         // input-rename bug: the rename ("images" -> "graph_input_cast_0") only occurs when
         // CoreML inserts a dynamic FP32->FP16 cast, which static-shape specialization skips.
-        let mut ep = ort::execution_providers::CoreMLExecutionProvider::default()
+        let mut ep = ort::ep::CoreML::default()
             .with_model_format(ModelFormat::MLProgram)
             .with_specialization_strategy(SpecializationStrategy::FastPrediction)
             .with_static_input_shapes(true);
@@ -633,7 +630,7 @@ impl YOLOModel {
     fn build_openvino_ep(
         model_path: &Path,
         device_type: &str,
-    ) -> ort::execution_providers::ExecutionProviderDispatch {
+    ) -> ort::ep::ExecutionProviderDispatch {
         let stem = model_path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -643,7 +640,7 @@ impl YOLOModel {
             .join(".ov_cache")
             .join(format!("{stem}_{}", device_type.to_ascii_lowercase()));
         let _ = std::fs::create_dir_all(&cache_dir);
-        ort::execution_providers::OpenVINOExecutionProvider::default()
+        ort::ep::OpenVINO::default()
             .with_device_type(device_type)
             .with_cache_dir(cache_dir.to_string_lossy())
             .build()

--- a/src/model.rs
+++ b/src/model.rs
@@ -211,7 +211,7 @@ impl YOLOModel {
         // `(provider, name)` pairs in registration order: the first one registered is the
         // one ORT will prefer, so it names the session (CPU when none are registered).
         #[allow(unused_mut)]
-        let mut eps: Vec<(ort::execution_providers::ExecutionProviderDispatch, &str)> = Vec::new();
+        let mut eps: Vec<(ort::ep::ExecutionProviderDispatch, &str)> = Vec::new();
 
         if let Some(device) = &config.device {
             // User requested specific device
@@ -237,14 +237,12 @@ impl YOLOModel {
                 )),
                 #[cfg(feature = "rocm")]
                 crate::Device::Rocm(i) => eps.push((
-                    ort::execution_providers::ROCmExecutionProvider::default()
-                        .with_device_id(*i as i32)
-                        .build(),
+                    ort::ep::ROCm::default().with_device_id(*i as i32).build(),
                     "ROCmExecutionProvider",
                 )),
                 #[cfg(feature = "directml")]
                 crate::Device::DirectMl(i) => eps.push((
-                    ort::execution_providers::DirectMLExecutionProvider::default()
+                    ort::ep::DirectML::default()
                         .with_device_id(*i as i32)
                         .build(),
                     "DirectMLExecutionProvider",
@@ -263,7 +261,7 @@ impl YOLOModel {
                 }
                 #[cfg(feature = "xnnpack")]
                 crate::Device::Xnnpack => eps.push((
-                    ort::execution_providers::XNNPACKExecutionProvider::default().build(),
+                    ort::ep::XNNPACK::default().build(),
                     "XNNPACKExecutionProvider",
                 )),
                 // Handle cases where feature is disabled but enum variant exists


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates ONNX Runtime dependencies to `ort` `2.0.0-rc.13` and modernizes execution provider APIs.

### 📊 Key Changes
- Bumps native and WebAssembly `ort` dependencies to `2.0.0-rc.13`.
- Updates `ort-web` from `0.2.1` to `0.3.0`.
- Migrates ROCm, DirectML, OpenVINO, XNNPACK, CUDA, TensorRT, and CoreML providers to the new `ort::ep` API.
- Refreshes the generated `Cargo.lock` dependency data.

### 🎯 Purpose & Impact
- Keeps inference builds compatible with the newer ONNX Runtime release.
- Enables continued native and WebAssembly support while adopting the updated execution provider interfaces.
- Uses an exact `ort` version pin to improve dependency reproducibility.
- Provider-specific features should be validated across supported platforms because upstream API changes may affect compilation or runtime behavior.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
