### PR TITLE
Skip pose keypoints clipped onto the frame border

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -746,6 +746,14 @@ fn draw_pose(
         let n_persons = kpt_data.shape()[0];
         let n_kpts = kpt_data.shape()[1];
 
+        // Post-processing clips keypoints into the frame, so one sitting exactly on a border
+        // was outside the image and is really "not seen": drawing it anchors a limb to the
+        // edge. Ultralytics drops these the same way (`x % w != 0 and y % h != 0`).
+        #[allow(clippy::cast_precision_loss)]
+        let visible = |x: f32, y: f32, conf: f32| {
+            conf >= KPT_CONF_THRES && x > 0.0 && y > 0.0 && x < width as f32 && y < height as f32
+        };
+
         for person_idx in 0..n_persons {
             for (limb_idx, &[kpt_a, kpt_b]) in skeleton.iter().enumerate() {
                 if kpt_a >= n_kpts || kpt_b >= n_kpts {
@@ -759,7 +767,7 @@ fn draw_pose(
                 let y2 = kpt_data[[person_idx, kpt_b, 1]];
                 let conf2 = kpt_data[[person_idx, kpt_b, 2]];
 
-                if conf1 >= KPT_CONF_THRES && conf2 >= KPT_CONF_THRES {
+                if visible(x1, y1, conf1) && visible(x2, y2, conf2) {
                     let color_idx = limb_colors[limb_idx % limb_colors.len()];
                     let color = Rgb(POSE_COLORS[color_idx]);
                     draw_line_segment(img, x1, y1, x2, y2, color, thickness);
@@ -771,12 +779,7 @@ fn draw_pose(
                 let y = kpt_data[[person_idx, kpt_idx, 1]];
                 let conf = kpt_data[[person_idx, kpt_idx, 2]];
 
-                if conf >= KPT_CONF_THRES
-                    && x >= 0.0
-                    && y >= 0.0
-                    && x < width as f32
-                    && y < height as f32
-                {
+                if visible(x, y, conf) {
                     let color_idx = kpt_colors[kpt_idx % kpt_colors.len()];
                     let color = Rgb(POSE_COLORS[color_idx]);
                     draw_filled_circle(img, x as i32, y as i32, radius, color);


### PR DESCRIPTION
Spotted while diffing our annotated output against Ultralytics Python on the same models: our pose renders draw limbs that run to the bottom edge of the image with no keypoint at the end. Most obvious on `zidane.jpg`, where both people have their legs out of frame. Post-processing clips keypoints into the image (`scale_keypoint`), exactly as Python does (`ops.scale_coords` -> `clip_coords`). A keypoint that was outside the frame therefore lands precisely on a border. Ultralytics treats that as "not visible" and skips it when drawing:

```python
if x_coord % shape[1] != 0 and y_coord % shape[0] != 0:              # circles
if pos1[0] % shape[1] == 0 or pos1[1] % shape[0] == 0 ...: continue  # limbs
```

`draw_pose` gated limbs on confidence alone. The circle check happened to reject `y == height`, but nothing rejected the limb, so the line was drawn to a keypoint that is not really there. Confidence thresholds were never the difference: both sides use 0.25.

## Fix

One predicate, applied to limbs and keypoints alike, so a point clipped onto any border is treated as missing.

## Results

Compared against Ultralytics 8.4.108 + onnxruntime 1.28.0 on the same ONNX models, and against current main.

| check | result |
|---|---|
| pose boxes vs Python (bus, zidane) | max delta 0.19 px, conf 0.0012 |
| pose keypoints vs Python | max delta 0.67 px |
| phantom border limbs | gone, matches Python |
| detect / segment / obb / classify renders | pixel-identical to main |
| tests | 189 pass |
| clippy -D warnings (stable 1.97.1), fmt | clean |

No API change, no change to `Keypoints` data; only what the annotator chooses to draw.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🦴 Improved pose visualization by excluding keypoints that lie exactly on image borders, preventing inaccurate limb and joint rendering.

### 📊 Key Changes

- Added a shared `visible` check for pose keypoints.
- Keypoints must now:
  - Meet the confidence threshold.
  - Fall strictly inside the image boundaries.
- Applied the visibility check to both:
  - Skeleton limb lines.
  - Individual keypoint markers.
- Changed border handling from inclusive to exclusive, so points at `x = 0`, `y = 0`, or the maximum image width/height are not drawn.

### 🎯 Purpose & Impact

- 🎯 Prevents limbs from being incorrectly anchored to image edges when a keypoint is clipped or not truly visible.
- 🖼️ Produces cleaner and more accurate pose annotations.
- ✅ Aligns Rust rendering behavior with Ultralytics’ existing post-processing logic.
- 🚀 Has minimal impact on normal detections while improving edge-case visualization quality.