### PR TITLE
Parallelize depth annotation, drop needless copies in annotate and postprocess

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -5,7 +5,12 @@
 //! This module provides functions for drawing bounding boxes, labels, and other
 //! annotations on images based on inference results.
 
+#[allow(clippy::wildcard_imports)] // native: rayon prelude; wasm: sequential shims
+use crate::parallel::*;
 use crate::results::Results;
+
+/// Pixels handed to one task when blending a full-frame overlay across cores.
+const BLEND_CHUNK: usize = 4096;
 use crate::visualizer::color::{COLORS, Colormap, DEPTH_ALPHA, DepthViz, POSE_COLORS};
 use crate::visualizer::skeleton::{KPT_COLOR_INDICES, LIMB_COLOR_INDICES, SKELETON};
 use ab_glyph::{Font, FontRef, PxScale, ScaleFont};
@@ -249,14 +254,23 @@ fn draw_depth_map(
         return;
     }
     let alpha = alpha.clamp(0.0, 1.0);
-    // `colorize` returns row-major RGB, the same order `pixels_mut` walks.
-    for (px, heat) in img.pixels_mut().zip(depth.colorize(colormap, viz)) {
-        for (channel, &h) in px.0.iter_mut().zip(heat.iter()) {
-            *channel = f32::from(*channel)
-                .mul_add(1.0 - alpha, f32::from(h) * alpha)
-                .round() as u8;
-        }
-    }
+    // `colorize` returns row-major RGB, the same order the sample buffer walks. Blending a
+    // full frame is per-pixel independent, so it splits across cores like the colorize
+    // itself; `crate::parallel` is sequential on wasm.
+    let heat = depth.colorize(colormap, viz);
+    img.as_flat_samples_mut()
+        .samples
+        .par_chunks_mut(BLEND_CHUNK * 3)
+        .enumerate()
+        .for_each(|(c, dst)| {
+            for (k, channel) in dst.iter_mut().enumerate() {
+                let i = c * BLEND_CHUNK * 3 + k;
+                let h = heat[i / 3][i % 3];
+                *channel = f32::from(*channel)
+                    .mul_add(1.0 - alpha, f32::from(h) * alpha)
+                    .round() as u8;
+            }
+        });
 }
 
 /// Draw a thick line segment between two points using Bresenham's algorithm.
@@ -533,12 +547,13 @@ fn draw_detection(img: &mut image::RgbImage, result: &Results, font: Option<&Fon
         let conf = boxes.conf();
         let cls = boxes.cls();
 
-        // Create an overlay image for masks to handle overlaps correctly
-        let mut overlay = img.clone();
+        // Overlay copy so overlapping masks compose against the original pixels. Only the
+        // mask path needs it, so a box-only result (detect/pose/obb) never pays for it.
+        let mut overlay = result.masks.is_some().then(|| img.clone());
         let mut mask_present = false;
 
         // Draw masks onto the overlay
-        if let Some(ref masks) = result.masks {
+        if let (Some(masks), Some(overlay)) = (result.masks.as_ref(), overlay.as_mut()) {
             let mask_n = masks.data.dim().0;
 
             for i in 0..boxes.len() {
@@ -566,24 +581,17 @@ fn draw_detection(img: &mut image::RgbImage, result: &Results, font: Option<&Fon
             }
         }
 
-        // Blend overlay with original image
-        if mask_present {
+        // Blend overlay with original image. Walking the two sample buffers directly keeps
+        // this a linear pass; `get_pixel_mut` recomputed the offset for all 300k+ pixels.
+        if let Some(overlay) = overlay.filter(|_| mask_present) {
             let alpha = 0.3;
-            for y in 0..height {
-                for x in 0..width {
-                    let p_img = img.get_pixel_mut(x, y);
-                    let p_overlay = overlay.get_pixel(x, y);
-
-                    p_img.0[0] = f32::from(p_overlay.0[0])
-                        .mul_add(alpha, f32::from(p_img.0[0]) * (1.0 - alpha))
-                        as u8;
-                    p_img.0[1] = f32::from(p_overlay.0[1])
-                        .mul_add(alpha, f32::from(p_img.0[1]) * (1.0 - alpha))
-                        as u8;
-                    p_img.0[2] = f32::from(p_overlay.0[2])
-                        .mul_add(alpha, f32::from(p_img.0[2]) * (1.0 - alpha))
-                        as u8;
-                }
+            for (px, src) in img
+                .as_flat_samples_mut()
+                .samples
+                .iter_mut()
+                .zip(overlay.as_raw())
+            {
+                *px = f32::from(*src).mul_add(alpha, f32::from(*px) * (1.0 - alpha)) as u8;
             }
         }
 

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -24,7 +24,7 @@ use wide::f32x8;
 use crate::parallel::*;
 use fast_image_resize::images::{Image, ImageRef};
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
-use ndarray::{Array2, Array3, ArrayView1, ArrayViewMut2, Zip, s};
+use ndarray::{Array2, Array3, ArrayView1, ArrayView2, ArrayViewMut2, Zip, s};
 
 use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
@@ -393,13 +393,20 @@ fn output_to_2d(
     features: usize,
     is_transposed: bool,
 ) -> Array2<f32> {
-    if is_transposed {
-        Array2::from_shape_vec((num_preds, features), data.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)))
+    let shape = if is_transposed {
+        (num_preds, features)
     } else {
-        let arr = Array2::from_shape_vec((features, num_preds), data.to_vec())
-            .unwrap_or_else(|_| Array2::zeros((0, 0)));
-        arr.t().to_owned()
+        (features, num_preds)
+    };
+    let Ok(view) = ArrayView2::from_shape(shape, data) else {
+        return Array2::zeros((0, 0));
+    };
+    // The transpose is materialized on purpose: callers walk a prediction at a time, and a
+    // strided view would read a column per access.
+    if is_transposed {
+        view.to_owned()
+    } else {
+        view.t().to_owned()
     }
 }
 
@@ -730,8 +737,8 @@ fn build_instance_masks(
     inference_shape: (u32, u32),
 ) -> Option<Array3<f32>> {
     // Protos: [1, num_masks, mh, mw] -> [num_masks, mh*mw]
-    let protos = match Array2::from_shape_vec((num_masks, mh * mw), protos_data.to_vec()) {
-        Ok(arr) => arr,
+    let protos = match ArrayView2::from_shape((num_masks, mh * mw), protos_data) {
+        Ok(view) => view,
         Err(e) => {
             eprintln!("WARNING ⚠️ Failed to build protos array: {e}. Skipping mask generation.");
             return None;
@@ -872,8 +879,6 @@ fn postprocess_segment(
         }
     }
 
-    results.boxes = Some(Boxes::new(boxes_data.clone(), preprocess.orig_shape));
-
     // Protos: [1, 32, 160, 160] -> [32, 25600]
     // Validate protos shape before indexing to prevent panic
     if shape1.len() < 4 {
@@ -881,6 +886,7 @@ fn postprocess_segment(
             "WARNING ⚠️ Protos output has unexpected shape (expected 4 dims, got {}). Skipping mask generation.",
             shape1.len()
         );
+        results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
         return results;
     }
     let mh = shape1[2];
@@ -894,7 +900,7 @@ fn postprocess_segment(
         );
     }
 
-    let Some(masks_data) = build_instance_masks(
+    let masks_data = build_instance_masks(
         &mask_coeffs,
         output1,
         num_masks,
@@ -903,10 +909,11 @@ fn postprocess_segment(
         &boxes_data,
         preprocess,
         inference_shape,
-    ) else {
-        return results;
-    };
-    results.masks = Some(Masks::new(masks_data, preprocess.orig_shape));
+    );
+    results.boxes = Some(Boxes::new(boxes_data, preprocess.orig_shape));
+    if let Some(masks_data) = masks_data {
+        results.masks = Some(Masks::new(masks_data, preprocess.orig_shape));
+    }
 
     results
 }
@@ -996,7 +1003,7 @@ fn postprocess_pose(
     let num_classes = derived_classes.max(1);
 
     // Filter and NMS - store candidates with keypoints
-    let mut candidates: Vec<([f32; 4], f32, usize, Vec<[f32; 3]>)> = Vec::new();
+    let mut candidates: Vec<([f32; 4], f32, usize, Vec<[f32; 3]>)> = Vec::with_capacity(256);
 
     for i in 0..num_preds {
         let Some((bbox, best_score, best_class)) =
@@ -1150,7 +1157,8 @@ fn postprocess_obb(
     let num_classes = derived_classes.max(1);
 
     // Filter and NMS - store candidates with angle
-    let mut candidates: Vec<([f32; 5], f32, usize)> = Vec::new(); // [cx, cy, w, h, angle], conf, class
+    // [cx, cy, w, h, angle], conf, class
+    let mut candidates: Vec<([f32; 5], f32, usize)> = Vec::with_capacity(256);
 
     for i in 0..num_preds {
         // Get class scores

--- a/src/results.rs
+++ b/src/results.rs
@@ -10,8 +10,13 @@ use std::sync::Arc;
 
 use ndarray::{Array1, Array2, Array3, ArrayView1, ArrayView2, Axis, s};
 
+#[allow(clippy::wildcard_imports)] // native: rayon prelude; wasm: sequential shims
+use crate::parallel::*;
 use crate::utils::pluralize;
 use crate::visualizer::color::{Colormap, DepthViz};
+
+/// Pixels handed to one task when colorizing a depth map across cores.
+const COLORIZE_CHUNK: usize = 4096;
 
 /// Timing information for inference operations (in milliseconds).
 #[derive(Debug, Clone, Default)]
@@ -183,16 +188,44 @@ impl DepthMap {
                 (lo, 1.0 / (hi - lo).max(1e-6), true)
             }
         };
-        data.iter()
-            .map(|&d| {
-                if d > 0.0 {
-                    let v = if disparity { 1.0 / d } else { d };
-                    colormap.sample(((v - lo) * inv).clamp(0.0, 1.0))
-                } else {
-                    black
+        // Per-pixel colormap sampling over a full frame (590k pixels at 768x768), so it is
+        // worth spreading across cores; `crate::parallel` is sequential on wasm.
+        let Some(src) = data.as_slice() else {
+            // Non-contiguous storage cannot be chunked; fall back to the sequential map.
+            return data
+                .iter()
+                .map(|&d| Self::pixel(d, lo, inv, disparity, colormap, black))
+                .collect();
+        };
+        let mut out = vec![black; src.len()];
+        out.par_chunks_mut(COLORIZE_CHUNK)
+            .enumerate()
+            .for_each(|(c, dst)| {
+                let base = c * COLORIZE_CHUNK;
+                for (k, px) in dst.iter_mut().enumerate() {
+                    *px = Self::pixel(src[base + k], lo, inv, disparity, colormap, black);
                 }
-            })
-            .collect()
+            });
+        out
+    }
+
+    /// Map one depth sample to its color: invalid (non-positive) pixels stay `black`,
+    /// everything else is normalized into `[0, 1]` and sampled from `colormap`.
+    #[inline]
+    fn pixel(
+        d: f32,
+        lo: f32,
+        inv: f32,
+        disparity: bool,
+        colormap: Colormap,
+        black: [u8; 3],
+    ) -> [u8; 3] {
+        if d > 0.0 {
+            let v = if disparity { 1.0 / d } else { d };
+            colormap.sample(((v - lo) * inv).clamp(0.0, 1.0))
+        } else {
+            black
+        }
     }
 }
 


### PR DESCRIPTION
Two separate things, both verified to produce byte-identical output. Depth turned out to be the most expensive annotator by a wide margin: 4.1 ms at its native 768x768, roughly five times the segment mask overlay. `colorize` samples a colormap per pixel over the whole frame and `draw_depth_map` walks the frame again to blend, both single threaded. Both now split across cores via the existing `crate::parallel` shim, so wasm keeps the sequential path.

Separately, `draw_detection` cloned the entire image on every call that had boxes, roughly 900 KB at 640x480, even for detect, pose and obb where there are no masks and the overlay is never read. The clone is now taken only when masks exist, and the blend iterates the sample buffers instead of calling `get_pixel_mut` for all 300k+ pixels.

| annotate bench (median of 4-5 interleaved runs) | main | branch | change |
|---|---|---|---|
| depth at 768x768 | 4.125 ms | 2.232 ms | -45.9% |
| depth at 640x480 | 2.231 ms | 1.333 ms | -40.2% |
| segment | 0.861 ms | 0.718 ms | -16.6% |
| semantic | 0.564 ms | 0.520 ms | -7.7% |
| detect | 0.294 ms | 0.275 ms | -6.5% |
| pose | 0.320 ms | 0.307 ms | -4.3% |
| obb | 0.265 ms | 0.266 ms | no change (no boxes, so no clone either way) |
| semantic at 1024 | 1.865 ms | 1.872 ms | no change (different code path) |

End to end that is worth about 2 to 4 percent of wall clock on a segment or depth run with `--save`, since annotation is a small slice of the pipeline.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Optimizes image annotation and postprocessing performance while improving robustness for segmentation and depth results.

### 📊 Key Changes

- ⚡ Parallelized depth-map colorization and full-frame blending on native platforms, with sequential fallbacks for WebAssembly.
- 🖼️ Optimized mask overlay blending by:
  - Creating overlay images only when masks are present.
  - Processing raw pixel buffers directly instead of repeatedly calculating pixel offsets.
- 🧩 Improved postprocessing array construction with borrowed `ndarray` views to reduce unnecessary data copies.
- 🛡️ Ensured segmentation results retain bounding boxes even when mask generation fails or prototype data is invalid.
- 📦 Added initial capacity for pose and OBB candidate collections to reduce vector reallocations.
- 🧹 Refactored per-pixel depth color mapping into a reusable helper with safer handling of non-contiguous data.

### 🎯 Purpose & Impact

- 🚄 Faster depth visualization, mask rendering, and image annotation, particularly for larger images and native multi-core systems.
- 💾 Lower memory usage and fewer unnecessary allocations during postprocessing.
- ✅ More reliable segmentation outputs: valid boxes remain available even if masks cannot be generated.
- 🌐 Preserves WebAssembly compatibility through sequential parallelism shims.
- 📈 Improves overall inference responsiveness without changing the expected visual output or detection behavior.