### PR TITLE
Skip the batch concat when there is only one image

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1376,18 +1376,34 @@ impl YOLOModel {
 
         // One forward pass, whatever the input precision: the batch tensor only lives
         // long enough to be uploaded, while the outputs outlive it.
-        let (outputs, inference_ms_total) = if self.fp16_input {
-            let batch_tensor = {
-                let pre_borrow = preprocessed_results_opt.borrow();
-                Self::concat_f16_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
-            };
-            Self::run_f16_input(&mut self.session, &self.input_name, &batch_tensor)?
-        } else {
-            let batch_tensor = {
-                let pre_borrow = preprocessed_results_opt.borrow();
-                Self::concat_f32_batch(pre_borrow.as_ref().expect("preprocessed_results"))?
-            };
-            Self::run_f32_input(&mut self.session, &self.input_name, &batch_tensor)?
+        // A batch of one is the common case (single image, video, webcam) and there is
+        // nothing to join: `concatenate` would allocate and copy the whole NCHW tensor to
+        // reproduce the one already sitting in `preprocessed_results`, so feed that instead.
+        let (outputs, inference_ms_total) = {
+            let pre_borrow = preprocessed_results_opt.borrow();
+            let pre = pre_borrow.as_deref().expect("preprocessed_results");
+            if self.fp16_input {
+                match pre {
+                    [single] => {
+                        let tensor = single.tensor_f16.as_ref().expect("fp16 tensor");
+                        Self::run_f16_input(&mut self.session, &self.input_name, tensor)?
+                    }
+                    batch => {
+                        let batch_tensor = Self::concat_f16_batch(batch)?;
+                        Self::run_f16_input(&mut self.session, &self.input_name, &batch_tensor)?
+                    }
+                }
+            } else {
+                match pre {
+                    [single] => {
+                        Self::run_f32_input(&mut self.session, &self.input_name, &single.tensor)?
+                    }
+                    batch => {
+                        let batch_tensor = Self::concat_f32_batch(batch)?;
+                        Self::run_f32_input(&mut self.session, &self.input_name, &batch_tensor)?
+                    }
+                }
+            }
         };
 
         if semantic_mask_output {


### PR DESCRIPTION
`predict_internal` always built the input tensor with `ndarray::concatenate`, including when the batch holds a single image. With nothing to join, that allocates and copies the whole NCHW tensor to reproduce the one preprocessing just produced: about 4.9 MB per frame at 640x640.

It is also invisible in the reported timings. `run_timed` wraps only `session.run()`, so the copy lands in neither the preprocess nor the inference figure of the `Speed:` line, just in wall clock.

A slice pattern feeds the single tensor straight to the run. Multi-image batches take the existing concat path untouched.

| measure | main | branch | change |
|---|---|---|---|
| isolated concat, 1x3x640x640 | 0.085 ms | not run | -0.085 ms per frame |
| 24 images, median of 7 | 397 ms | 383 ms | -3.5% |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ Optimizes single-image inference by avoiding unnecessary tensor concatenation before model execution.

### 📊 Key Changes
- Detects when an inference batch contains only one item.
- Directly reuses the existing FP16 or FP32 tensor for single-item batches.
- Retains tensor concatenation for multi-item batches.
- Applies the optimization consistently across both input precision modes.

### 🎯 Purpose & Impact
- 🚀 Reduces memory allocations and tensor-copy overhead for common single-input workflows such as images, video, and webcam inference.
- ⏱️ May improve inference latency and overall efficiency, especially for smaller or frequent inference calls.
- ✅ Preserves existing batch behavior and model results for multi-image inference.