### PR TITLE
Speed up fp16 conversion and drop the center crop source clone

### DIFF
--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -406,7 +406,15 @@ fn fused_zerocopy_preprocess(
 
 /// Convert f32 tensor to f16 tensor.
 fn tensor_f32_to_f16(tensor: &Array4<f32>) -> Array4<half::f16> {
-    tensor.mapv(half::f16::from_f32)
+    use half::slice::HalfFloatSliceExt;
+    // `mapv` converts one element at a time; `half`'s slice conversion is vectorized where
+    // the target supports it. Falls back to `mapv` if the tensor is not contiguous.
+    let Some(src) = tensor.as_slice() else {
+        return tensor.mapv(half::f16::from_f32);
+    };
+    let mut out = vec![half::f16::ZERO; src.len()];
+    out.convert_from_f32_slice(src);
+    Array4::from_shape_vec(tensor.raw_dim(), out).expect("shape matches the source tensor")
 }
 
 /// Calculate target size for rectangular inference mode.
@@ -648,7 +656,10 @@ pub fn preprocess_image_center_crop(
 /// 2. `scale`: Scale factors applied (same for x and y).
 #[allow(clippy::similar_names)]
 fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbImage, (f32, f32)) {
-    use fast_image_resize::{PixelType, ResizeAlg, ResizeOptions, Resizer, images::Image};
+    use fast_image_resize::{
+        PixelType, ResizeAlg, ResizeOptions, Resizer,
+        images::{Image, ImageRef},
+    };
 
     let (src_w, src_h) = image.dimensions();
     #[allow(clippy::cast_possible_truncation)]
@@ -678,9 +689,17 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
         ((src_w as f32 * scale_y) as u32, target_h)
     };
 
-    // Resize first
-    let src_rgb = image.to_rgb8();
-    let src_image = Image::from_vec_u8(src_w, src_h, src_rgb.into_raw(), PixelType::U8x3)
+    // Resize first. Borrow the source samples when the image is already RGB8 (the common
+    // case): `to_rgb8` would clone the full frame just to hand it straight to the resizer.
+    let owned_rgb;
+    let src_bytes: &[u8] = match image {
+        DynamicImage::ImageRgb8(rgb) => rgb.as_raw(),
+        other => {
+            owned_rgb = other.to_rgb8();
+            owned_rgb.as_raw()
+        }
+    };
+    let src_image = ImageRef::new(src_w, src_h, src_bytes, PixelType::U8x3)
         .expect("Failed to create source image");
 
     // Valid dimensions check


### PR DESCRIPTION
Two preprocessing paths cost noticeably more than the work they do. Both showed up while benchmarking the pipeline stage by stage: fp16 preprocessing was three times the price of fp32, and center cropping to 224 cost more than a full 640 letterbox despite producing eight times fewer pixels. `tensor_f32_to_f16` used `mapv`, which converts element by element over 1.2 M values. The `half` crate ships `convert_from_f32_slice`, which is vectorized where the target supports it. `mapv` stays as the fallback for a non-contiguous tensor. `center_crop_image` called `image.to_rgb8()`, cloning the entire source frame just to pass the samples to the resizer, even when the image was already RGB8. It now borrows them through `ImageRef`, which is what `build_preprocess_result` already does on the letterbox path.

| preprocess bench (median of 5 interleaved runs) | main | branch | change |
|---|---|---|---|
| fp16 at 640 | 0.693 ms | 0.398 ms | -42.5% |
| center crop to 224 | 0.629 ms | 0.537 ms | -14.7% |
| letterbox 640 | 0.197 ms | 0.189 ms | within noise |
| letterbox 768 | 0.249 ms | 0.264 ms | within noise |
| letterbox 1024 | 0.400 ms | 0.398 ms | within noise |

Exported `yolo11n.pt` to ONNX and converted its IO to float16 (`convert_float_to_float16(keep_io_types=False)`), which is the case the fp16 preprocessing path exists for, then ran the CLI over 24 images on both builds.

| measure, fp16-input model | main | branch | change |
|---|---|---|---|
| preprocess per image, median of 7 | 0.80 ms | 0.60 ms | -25% |
| detections on bus.jpg | 4 persons, 1 bus | 4 persons, 1 bus | same |
| annotated output, bus and zidane | reference | byte-identical | same |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Optimizes image preprocessing by accelerating f32-to-f16 conversion and reducing unnecessary RGB image copies.

### 📊 Key Changes

- ⚡ Uses `half`’s vectorized slice conversion for contiguous tensors, with a fallback for non-contiguous data.
- 🖼️ Avoids cloning RGB8 image data during center-crop preprocessing by borrowing existing pixel buffers.
- 🔄 Uses `ImageRef` for zero-copy access to source image data, while retaining conversion support for other image formats.

### 🎯 Purpose & Impact

- ✅ Improves preprocessing performance, especially for large tensors and RGB8 images.
- 💾 Reduces temporary memory allocations and image-copy overhead.
- 🛡️ Preserves compatibility and behavior through fallback paths for non-contiguous tensors and non-RGB8 images.
- 📈 May improve overall inference throughput and latency without changing the public API.