### PR TITLE
Include the ONNX Runtime build in the CoreML cache key

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -598,6 +598,11 @@ impl YOLOModel {
             .with_static_input_shapes(true);
 
         if let Some(cache_base) = dirs::cache_dir() {
+            let fnv1a = |bytes: &[u8]| {
+                bytes.iter().fold(14_695_981_039_346_656_037u64, |h, &b| {
+                    h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
+                })
+            };
             let canonical = model_path
                 .canonicalize()
                 .unwrap_or_else(|_| model_path.to_path_buf());
@@ -1798,13 +1803,6 @@ fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {
     provider == "CoreMLExecutionProvider"
         && msg.contains("GatherElements")
         && msg.contains("Out of range")
-}
-
-/// FNV-1a over `bytes`, for naming cache directories from a path and a runtime build.
-fn fnv1a(bytes: &[u8]) -> u64 {
-    bytes.iter().fold(14_695_981_039_346_656_037u64, |h, &b| {
-        h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
-    })
 }
 
 /// Convert an ONNX Runtime tensor shape (`i64` dims) to `usize` for indexing.

--- a/src/model.rs
+++ b/src/model.rs
@@ -606,11 +606,6 @@ impl YOLOModel {
             let canonical = model_path
                 .canonicalize()
                 .unwrap_or_else(|_| model_path.to_path_buf());
-            // Compiled CoreML artifacts belong to the ONNX Runtime build that wrote them.
-            // Loading ones written by another build fails with "Feature ... is required but
-            // not specified" on models CoreML partitions differently between versions (the
-            // TopK in YOLO26 detect and in OBB), so the runtime build is part of the key and
-            // an upgrade recompiles instead of reusing something it cannot run.
             let ort_build = fnv1a(ort::info().as_bytes());
             let stem = canonical
                 .file_stem()

--- a/src/model.rs
+++ b/src/model.rs
@@ -601,20 +601,20 @@ impl YOLOModel {
             let canonical = model_path
                 .canonicalize()
                 .unwrap_or_else(|_| model_path.to_path_buf());
+            // Compiled CoreML artifacts belong to the ONNX Runtime build that wrote them.
+            // Loading ones written by another build fails with "Feature ... is required but
+            // not specified" on models CoreML partitions differently between versions (the
+            // TopK in YOLO26 detect and in OBB), so the runtime build is part of the key and
+            // an upgrade recompiles instead of reusing something it cannot run.
+            let ort_build = fnv1a(ort::info().as_bytes());
             let stem = canonical
                 .file_stem()
                 .map_or_else(|| "model".to_owned(), |s| s.to_string_lossy().into_owned());
-            let hash = canonical
-                .as_os_str()
-                .as_encoded_bytes()
-                .iter()
-                .fold(14_695_981_039_346_656_037u64, |h, &b| {
-                    h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
-                });
+            let hash = fnv1a(canonical.as_os_str().as_encoded_bytes());
             let cache_dir = cache_base
                 .join("ultralytics-inference")
                 .join("coreml")
-                .join(format!("{stem}_{hash:016x}_mlprogram"));
+                .join(format!("{stem}_{hash:016x}_{ort_build:016x}_mlprogram"));
             if std::fs::create_dir_all(&cache_dir).is_ok() {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }
@@ -1798,6 +1798,13 @@ fn is_benign_coreml_warmup_error(provider: &str, msg: &str) -> bool {
     provider == "CoreMLExecutionProvider"
         && msg.contains("GatherElements")
         && msg.contains("Out of range")
+}
+
+/// FNV-1a over `bytes`, for naming cache directories from a path and a runtime build.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(14_695_981_039_346_656_037u64, |h, &b| {
+        h.wrapping_mul(1_099_511_628_211) ^ u64::from(b)
+    })
 }
 
 /// Convert an ONNX Runtime tensor shape (`i64` dims) to `usize` for indexing.


### PR DESCRIPTION
Compiled CoreML artifacts are only valid for the runtime that wrote them, but the cache directory was keyed on model name and path alone. Upgrading ONNX Runtime therefore reuses the old artifacts and fails at load with `Feature _model_23_TopK_output_1 is required but not specified` on models CoreML partitions differently between versions, which is YOLO26 detect and OBB. It happens in both directions, so going back to an older build breaks too.

Hashing `ort::info()` into the directory name means a runtime change misses the old cache and recompiles.

Tested on both runtimes, cold and warm cache, all tasks on CoreML: detect (yolo26n, yolo26s, yolov8n, yolo11n), segment, pose, classify, obb, semantic, depth. Annotated output identical between the two, and the two caches coexist without clobbering each other.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves Core ML model caching by separating cached models across ONNX Runtime builds. 🚀

### 📊 Key Changes

- Added a reusable FNV-1a hashing function for cache identifiers.
- Computes a hash of the ONNX Runtime build information with `ort::info()`.
- Includes both the model path hash and ONNX Runtime build hash in the Core ML cache directory name.
- Preserves the existing cache structure while making cache entries more specific.

### 🎯 Purpose & Impact

- Prevents incompatible or outdated Core ML cache artifacts from being reused after an ONNX Runtime change. 🔒
- Reduces potential runtime errors caused by stale cached models.
- Allows different ONNX Runtime builds to maintain independent cache entries.
- May increase disk usage slightly because separate builds can create separate cached models.