### PR TITLE
Document CUDA 13 requirement and execution provider combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,9 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 combination is published, and asking for one that is not stops the build with
 `no builds available that satisfy the requested feature set`. To take the closest available build
 instead of an error, enable `lax-feature-matching` on `ort` in your own `Cargo.toml`; providers
-missing from that build are then absent at runtime and inference falls back to CPU.
+missing from that build are then absent at runtime and inference falls back to CPU. The
+CUDA and TensorRT binaries are built against CUDA 13; `ORT_CUDA_VERSION=12` rebuilds them for a
+CUDA 12 install.
 
 **Available Features:**
 

--- a/README.md
+++ b/README.md
@@ -523,13 +523,17 @@ cargo build --release --features "cuda,tensorrt"
 
 > NVIDIA setup, requirements, and the GPU preprocessing fast path are documented in [`docs/CUDA.md`](docs/CUDA.md).
 
-Each accelerator feature links a prebuilt ONNX Runtime containing that provider. Not every
-combination is published, and asking for one that is not stops the build with
-`no builds available that satisfy the requested feature set`. To take the closest available build
-instead of an error, enable `lax-feature-matching` on `ort` in your own `Cargo.toml`; providers
-missing from that build are then absent at runtime and inference falls back to CPU. The
-CUDA and TensorRT binaries are built against CUDA 13; `ORT_CUDA_VERSION=12` rebuilds them for a
-CUDA 12 install.
+Each accelerator feature links a prebuilt ONNX Runtime containing that provider. Not every combination is published, and asking for one that is not stops the build with `no builds available that satisfy the requested feature set`. To take the closest available build instead of an error, enable `lax-feature-matching` on `ort`:
+
+```toml
+[dependencies]
+ultralytics-inference = { version = "0.0.31", features = ["coreml", "xnnpack"] }
+ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
+```
+
+Providers missing from the chosen build are then absent at runtime and inference falls back to CPU.
+
+> The CUDA and TensorRT binaries are built against CUDA 13. On a CUDA 12 install, rebuild ONNX Runtime with `ORT_CUDA_VERSION=12`.
 
 **Available Features:**
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,12 @@ cargo build --release --features "cuda,tensorrt"
 
 > NVIDIA setup, requirements, and the GPU preprocessing fast path are documented in [`docs/CUDA.md`](docs/CUDA.md).
 
+Each accelerator feature links a prebuilt ONNX Runtime containing that provider. Not every
+combination is published, and asking for one that is not stops the build with
+`no builds available that satisfy the requested feature set`. To take the closest available build
+instead of an error, enable `lax-feature-matching` on `ort` in your own `Cargo.toml`; providers
+missing from that build are then absent at runtime and inference falls back to CPU.
+
 **Available Features:**
 
 Default features (enabled unless `--no-default-features` is passed): `annotate`, `visualize`.

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 
 Providers missing from the chosen build are then absent at runtime and inference falls back to CPU.
 
-> The CUDA and TensorRT binaries are built against CUDA 13. On a CUDA 12 install, rebuild ONNX Runtime with `ORT_CUDA_VERSION=12`.
+> The CUDA and TensorRT binaries are built against CUDA 13, and no CUDA 12 build is published. To run them on CUDA 12, compile ONNX Runtime yourself and link it with `ORT_LIB_PATH`.
 
 **Available Features:**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -529,7 +529,7 @@ ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 
 所选版本中缺失的 provider 在运行时将不可用，推理会回退到 CPU。
 
-> CUDA 与 TensorRT 二进制基于 CUDA 13 构建。在 CUDA 12 环境下，请使用 `ORT_CUDA_VERSION=12` 重新构建 ONNX Runtime。
+> CUDA 与 TensorRT 二进制基于 CUDA 13 构建，且未发布 CUDA 12 版本。若需在 CUDA 12 上运行，请自行编译 ONNX Runtime，并通过 `ORT_LIB_PATH` 链接该构建。
 
 **可用 Features：**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -519,6 +519,18 @@ cargo build --release --features "cuda,tensorrt"
 
 > NVIDIA 安装、要求和 GPU 预处理快速路径见 [`docs/CUDA.md`](docs/CUDA.md)。
 
+每个加速器 feature 都会链接包含该 provider 的预编译 ONNX Runtime。并非所有组合都有对应的预编译版本，请求不存在的组合会导致构建失败，并提示 `no builds available that satisfy the requested feature set`。若希望选用最接近的可用版本而不是直接报错，可在 `ort` 上启用 `lax-feature-matching`：
+
+```toml
+[dependencies]
+ultralytics-inference = { version = "0.0.31", features = ["coreml", "xnnpack"] }
+ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
+```
+
+所选版本中缺失的 provider 在运行时将不可用，推理会回退到 CPU。
+
+> CUDA 与 TensorRT 二进制基于 CUDA 13 构建。在 CUDA 12 环境下，请使用 `ORT_CUDA_VERSION=12` 重新构建 ONNX Runtime。
+
 **可用 Features：**
 
 默认 features（除非传入 `--no-default-features`）：`annotate`、`visualize`。

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -19,11 +19,13 @@
 | TensorRT               | 10.x        | `ldconfig -p \| grep libnvinfer` (only for `tensorrt` / `cuda-preprocess`)                                               |
 | GPU compute capability | sm_70+      | `nvidia-smi --query-gpu=compute_cap --format=csv`                                                                        |
 
-> **Prebuilt EP binaries are CUDA 13.** ONNX Runtime deprecated CUDA 12, so the `cuda` and
-> `tensorrt` libraries `ort` downloads are built against CUDA 13. On a CUDA 12 install, rebuild
-> ONNX Runtime for it with `ORT_CUDA_VERSION=12` (the loader suggests this too when the bundled
-> runtime's CUDA major does not match). The toolkit range above is what `cuda-preprocess`
-> compiles its kernel against through `cudarc`, independent of which EP binary is linked.
+> **Prebuilt EP binaries are CUDA 13.** ONNX Runtime deprecated CUDA 12, and the pinned `ort`
+> release ships no CUDA 12 distribution, so the `cuda` and `tensorrt` libraries it downloads are
+> built against CUDA 13. `ORT_CUDA_VERSION=12` does not help: it asks for a distribution that
+> does not exist and the build fails. To run the EPs on CUDA 12, compile ONNX Runtime yourself
+> and point `ort` at it with `ORT_LIB_PATH` (see [ort linking](https://ort.pyke.io/setup/linking)).
+> The toolkit range above is what `cuda-preprocess` compiles its kernel against through `cudarc`,
+> independent of which EP binary is linked.
 
 `cuda-preprocess` only needs `libcudart.so` and `libnvrtc.so` at **runtime**. Kernel code is compiled in-process via NVRTC, so `nvcc` is not invoked at runtime.
 
@@ -202,11 +204,11 @@ through `YOLOModel::predict_image` in library code.
 
 ## Troubleshooting
 
-| Symptom                                                                    | Fix                                                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).    |
-| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`. |
-| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.          |
-| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.           |
-| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.   |
-| CUDA EP fails to load on a CUDA 12 system                                  | The downloaded binaries are CUDA 13. Rebuild ONNX Runtime with `ORT_CUDA_VERSION=12`.    |
+| Symptom                                                                    | Fix                                                                                                                                      |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).                                                    |
+| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.                                                 |
+| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                                                          |
+| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                                                           |
+| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.                                                   |
+| CUDA EP fails to load on a CUDA 12 system                                  | The downloaded binaries are CUDA 13 and no CUDA 12 build is published. Compile ONNX Runtime for CUDA 12 and link it with `ORT_LIB_PATH`. |

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -199,45 +199,13 @@ through `YOLOModel::predict_image` in library code.
 
 [`YOLOModel::predict_image`]: crate::YOLOModel::predict_image
 
-## Combining execution providers
-
-EP support is decided at compile time: each feature pulls in the matching `ort` EP and links a
-prebuilt ONNX Runtime that contains it. Not every combination has a prebuilt binary, and asking
-for one that does not exist stops the build:
-
-```
-!!! The ort-sys crate did not download prebuilt binaries because there are no builds
-    available that satisfy the requested feature set 'coreml, xnnpack'.
-```
-
-That error is deliberate. It used to be a silent fallback to a CPU-only runtime, which left you
-with a build that quietly ignored the accelerator you asked for.
-
-If you would rather have the closest available build than an error, enable `lax-feature-matching`
-on `ort` in your own `Cargo.toml`:
-
-```toml
-[dependencies]
-ultralytics-inference = { version = "0.0.31", features = ["coreml", "xnnpack"] }
-ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
-```
-
-The build then succeeds, but any EP missing from the chosen binary is not there at runtime and
-inference falls back to CPU. Prefer one EP per build unless you have checked that the
-combination ships as a prebuilt.
-
-The browser build is separate: it runs on ONNX Runtime Web through `ort-web`, which pins its own
-runtime version. If you self-host that runtime with `ortBaseUrl` instead of the default CDN, copy
-the `dist/` folder matching the version `ort-web` pins (currently 1.27).
-
 ## Troubleshooting
 
-| Symptom                                                                    | Fix                                                                                                          |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).                        |
-| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.                     |
-| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                              |
-| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                               |
-| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.                       |
-| `no builds available that satisfy the requested feature set '...'`         | That EP combination has no prebuilt binary. Build with one EP, or enable `lax-feature-matching` (see above). |
-| CUDA EP fails to load on a CUDA 12 system                                  | `ort` ships CUDA 13 binaries only. Upgrade the driver stack, or build ONNX Runtime from source.              |
+| Symptom                                                                    | Fix                                                                                             |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).           |
+| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.        |
+| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                 |
+| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                  |
+| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.          |
+| CUDA EP fails to load on a CUDA 12 system                                  | `ort` ships CUDA 13 binaries only. Upgrade the driver stack, or build ONNX Runtime from source. |

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -19,6 +19,11 @@
 | TensorRT               | 10.x        | `ldconfig -p \| grep libnvinfer` (only for `tensorrt` / `cuda-preprocess`)                                               |
 | GPU compute capability | sm_70+      | `nvidia-smi --query-gpu=compute_cap --format=csv`                                                                        |
 
+> **CUDA 13 only.** ONNX Runtime deprecated CUDA 12, so the `cuda` and `tensorrt` EP libraries
+> shipped through `ort` are CUDA 13 builds. A CUDA 12 driver stack will fail to load them. The
+> toolkit range above still applies to `cuda-preprocess`, which compiles its own kernel through
+> `cudarc` and is independent of the EP binaries.
+
 `cuda-preprocess` only needs `libcudart.so` and `libnvrtc.so` at **runtime**. Kernel code is compiled in-process via NVRTC, so `nvcc` is not invoked at runtime.
 
 ## Enable in your project
@@ -194,12 +199,45 @@ through `YOLOModel::predict_image` in library code.
 
 [`YOLOModel::predict_image`]: crate::YOLOModel::predict_image
 
+## Combining execution providers
+
+EP support is decided at compile time: each feature pulls in the matching `ort` EP and links a
+prebuilt ONNX Runtime that contains it. Not every combination has a prebuilt binary, and asking
+for one that does not exist stops the build:
+
+```
+!!! The ort-sys crate did not download prebuilt binaries because there are no builds
+    available that satisfy the requested feature set 'coreml, xnnpack'.
+```
+
+That error is deliberate. It used to be a silent fallback to a CPU-only runtime, which left you
+with a build that quietly ignored the accelerator you asked for.
+
+If you would rather have the closest available build than an error, enable `lax-feature-matching`
+on `ort` in your own `Cargo.toml`:
+
+```toml
+[dependencies]
+ultralytics-inference = { version = "0.0.31", features = ["coreml", "xnnpack"] }
+ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
+```
+
+The build then succeeds, but any EP missing from the chosen binary is not there at runtime and
+inference falls back to CPU. Prefer one EP per build unless you have checked that the
+combination ships as a prebuilt.
+
+The browser build is separate: it runs on ONNX Runtime Web through `ort-web`, which pins its own
+runtime version. If you self-host that runtime with `ortBaseUrl` instead of the default CDN, copy
+the `dist/` folder matching the version `ort-web` pins (currently 1.27).
+
 ## Troubleshooting
 
-| Symptom                                                                    | Fix                                                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).    |
-| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`. |
-| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.          |
-| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.           |
-| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.   |
+| Symptom                                                                    | Fix                                                                                                          |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).                        |
+| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.                     |
+| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                              |
+| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                               |
+| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.                       |
+| `no builds available that satisfy the requested feature set '...'`         | That EP combination has no prebuilt binary. Build with one EP, or enable `lax-feature-matching` (see above). |
+| CUDA EP fails to load on a CUDA 12 system                                  | `ort` ships CUDA 13 binaries only. Upgrade the driver stack, or build ONNX Runtime from source.              |

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -19,10 +19,11 @@
 | TensorRT               | 10.x        | `ldconfig -p \| grep libnvinfer` (only for `tensorrt` / `cuda-preprocess`)                                               |
 | GPU compute capability | sm_70+      | `nvidia-smi --query-gpu=compute_cap --format=csv`                                                                        |
 
-> **CUDA 13 only.** ONNX Runtime deprecated CUDA 12, so the `cuda` and `tensorrt` EP libraries
-> shipped through `ort` are CUDA 13 builds. A CUDA 12 driver stack will fail to load them. The
-> toolkit range above still applies to `cuda-preprocess`, which compiles its own kernel through
-> `cudarc` and is independent of the EP binaries.
+> **Prebuilt EP binaries are CUDA 13.** ONNX Runtime deprecated CUDA 12, so the `cuda` and
+> `tensorrt` libraries `ort` downloads are built against CUDA 13. On a CUDA 12 install, rebuild
+> ONNX Runtime for it with `ORT_CUDA_VERSION=12` (the loader suggests this too when the bundled
+> runtime's CUDA major does not match). The toolkit range above is what `cuda-preprocess`
+> compiles its kernel against through `cudarc`, independent of which EP binary is linked.
 
 `cuda-preprocess` only needs `libcudart.so` and `libnvrtc.so` at **runtime**. Kernel code is compiled in-process via NVRTC, so `nvcc` is not invoked at runtime.
 
@@ -201,11 +202,11 @@ through `YOLOModel::predict_image` in library code.
 
 ## Troubleshooting
 
-| Symptom                                                                    | Fix                                                                                             |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).           |
-| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.        |
-| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                 |
-| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                  |
-| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.          |
-| CUDA EP fails to load on a CUDA 12 system                                  | `ort` ships CUDA 13 binaries only. Upgrade the driver stack, or build ONNX Runtime from source. |
+| Symptom                                                                    | Fix                                                                                      |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).    |
+| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`. |
+| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.          |
+| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.           |
+| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.   |
+| CUDA EP fails to load on a CUDA 12 system                                  | The downloaded binaries are CUDA 13. Rebuild ONNX Runtime with `ORT_CUDA_VERSION=12`.    |

--- a/src/model.rs
+++ b/src/model.rs
@@ -340,12 +340,11 @@ impl YOLOModel {
                         InferenceError::ModelLoadError(format!(
                             "{provider_name} failed to load, so the cuda-preprocess fast path \
                          cannot run on the GPU: {e}\n\
-                         Hint: ensure the matching CUDA runtime and cuDNN 9 (plus TensorRT 10 \
-                         for TensorRt) are installed and on the library path. If the bundled \
-                         ONNX Runtime picked the wrong CUDA major version, rebuild with \
-                         `ORT_CUDA_VERSION=12` or `ORT_CUDA_VERSION=13` to match your CUDA \
-                         install. To use CPU preprocessing instead, set \
-                         `InferenceConfig::with_cuda_preprocess(false)`."
+                         Hint: the downloaded ONNX Runtime is built against CUDA 13, so it needs \
+                         a CUDA 13 runtime and cuDNN 9 (plus TensorRT 10 for TensorRt) installed \
+                         and on the library path. On CUDA 12, compile ONNX Runtime for it and \
+                         link that build with `ORT_LIB_PATH`. To use CPU preprocessing instead, \
+                         set `InferenceConfig::with_cuda_preprocess(false)`."
                         ))
                     } else {
                         InferenceError::ModelLoadError(format!(


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Clarifies accelerator compatibility and CUDA 13 requirements, while improving troubleshooting guidance for ONNX Runtime and GPU inference.

### 📊 Key Changes

- Added README documentation explaining:
  - Prebuilt ONNX Runtime provider combinations may not all be available.
  - `lax-feature-matching` can select the closest compatible build instead of failing.
  - Missing providers fall back to CPU at runtime.
- Documented that the prebuilt CUDA and TensorRT binaries use **CUDA 13**; CUDA 12 builds are not published.
- Updated CUDA documentation with:
  - CUDA 13 runtime requirements.
  - Instructions for using a custom CUDA 12 ONNX Runtime build through `ORT_LIB_PATH`.
  - Clarification that `cuda-preprocess` toolkit compatibility is independent of the linked execution provider binary.
- Expanded the CUDA troubleshooting table with guidance for CUDA 12 systems.
- Updated model-loading error messages to remove outdated `ORT_CUDA_VERSION` instructions and recommend `ORT_LIB_PATH` for custom ONNX Runtime builds.
- Added equivalent guidance to the Chinese README.

### 🎯 Purpose & Impact

- ✅ Helps users understand why some accelerator feature combinations fail during builds.
- 🚀 Makes CUDA and TensorRT setup requirements clearer, reducing configuration issues.
- 🧩 Enables more flexible builds with `lax-feature-matching`, with CPU fallback when requested providers are unavailable.
- 🛠️ Provides a supported path for CUDA 12 users by linking a self-built ONNX Runtime library.
- ⚠️ Prevents misleading guidance by clearly stating that downloaded GPU binaries require CUDA 13 and that `ORT_CUDA_VERSION=12` cannot select an unavailable prebuilt package.