### PR TITLE
Read the input shape from the model on both web paths

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -545,7 +545,10 @@ impl YoloModel {
         let t_post = now_ms();
         let config = make_config(conf, iou, classes);
         let names: Arc<HashMap<usize, String>> = Arc::clone(&self.metadata.names);
-        let inference_shape = (self.imgsz.0 as u32, self.imgsz.1 as u32);
+        // The tensor actually fed to the model, which `rect` makes differ from `imgsz`.
+        // `build_instance_masks` turns this into prototype-space crop coordinates.
+        let tensor_shape = pre.tensor.shape();
+        let inference_shape = (tensor_shape[2] as u32, tensor_shape[3] as u32);
         // Postprocess time runs from output extraction to the postprocess call.
         let speed = || Speed::new(t_inf - t_pre, t_post - t_inf, now_ms() - t_post);
 
@@ -693,11 +696,12 @@ impl YoloPipeline {
     /// The ONNX path reads the same fact off its session; this is the LiteRT equivalent,
     /// which only the JS engine can see.
     ///
-    /// Expects NCHW `[N, 3, H, W]`, what `ai_edge_torch` emits. Any other rank or layout
-    /// (a channels-last `[N, H, W, 3]`, a dynamic axis) is ignored, leaving the metadata
-    /// size in place.
+    /// Expects NCHW `[N, 3, H, W]`, what `ai_edge_torch` emits, with the signed dimensions
+    /// the engine reports. Any other rank or layout (a channels-last `[N, H, W, 3]`) and any
+    /// non-positive axis, which is how a dynamic dimension is reported, is ignored and leaves
+    /// the metadata size in place.
     #[wasm_bindgen(js_name = setInputShape)]
-    pub fn set_input_shape(&mut self, shape: Vec<u32>) {
+    pub fn set_input_shape(&mut self, shape: Vec<i32>) {
         if let [_, 3, h, w] = shape[..]
             && h > 0
             && w > 0

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -33,7 +33,8 @@ use wasm_bindgen::prelude::*;
 use ultralytics_inference::metadata::ModelMetadata;
 use ultralytics_inference::postprocessing::{postprocess, postprocess_semantic_mask};
 use ultralytics_inference::preprocessing::{
-    PreprocessResult, preprocess_image_center_crop, preprocess_image_with_precision,
+    PreprocessResult, calculate_rect_size, preprocess_image_center_crop,
+    preprocess_image_with_precision,
 };
 use ultralytics_inference::results::Speed;
 use ultralytics_inference::visualizer::color::{Color, Colormap, DepthViz};
@@ -228,6 +229,7 @@ fn preprocess_image(
     imgsz: (usize, usize),
     stride: u32,
     task: Task,
+    rect: bool,
 ) -> Result<(Array3<u8>, PreprocessResult), JsError> {
     let rgb = dynimg.to_rgb8();
     let (w, h) = rgb.dimensions();
@@ -236,7 +238,15 @@ fn preprocess_image(
     let pre = if task == Task::Classify {
         preprocess_image_center_crop(dynimg, imgsz, false)
     } else {
-        preprocess_image_with_precision(dynimg, imgsz, stride, false)
+        // Rectangular inference pads only up to the stride instead of to a square, so a
+        // 16:9 frame skips ~40% of its pixels. Only a model that left its height and width
+        // dynamic can accept the resulting shape; see `YoloModel::rect`.
+        let target = if rect {
+            calculate_rect_size(w, h, imgsz, stride)
+        } else {
+            imgsz
+        };
+        preprocess_image_with_precision(dynimg, target, stride, false)
     };
     Ok((orig_img, pre))
 }
@@ -290,6 +300,9 @@ pub struct YoloModel {
     output_names: Vec<String>,
     /// Network input size as `(height, width)`.
     imgsz: (usize, usize),
+    /// Whether the export left height/width dynamic, so rectangular inference can
+    /// feed a per-frame shape instead of padding every frame to a square.
+    rect: bool,
     /// Active device label (`"webgpu"` or `"cpu"`).
     device: &'static str,
 }
@@ -440,7 +453,24 @@ impl YoloModel {
         metadata: ModelMetadata,
         device: Device,
     ) -> Result<Self, JsError> {
-        let imgsz = metadata.imgsz.unwrap_or((DEFAULT_IMGSZ, DEFAULT_IMGSZ));
+        // The height and width the export pinned, whatever the batch dimension does.
+        // ONNX Runtime rejects every other size, so this outranks the metadata, which can
+        // disagree with the export (a 224 classify model can carry `imgsz: 640`). Matches
+        // the native `YOLOModel::load_with_config` resolution.
+        let fixed_imgsz = session.inputs().first().and_then(|i| match i.dtype() {
+            ValueType::Tensor { shape, .. } if shape.len() == 4 && shape[2] > 0 && shape[3] > 0 =>
+            {
+                #[allow(clippy::cast_sign_loss)]
+                Some((shape[2] as usize, shape[3] as usize))
+            }
+            _ => None,
+        });
+        let imgsz = fixed_imgsz
+            .or(metadata.imgsz)
+            .unwrap_or((DEFAULT_IMGSZ, DEFAULT_IMGSZ));
+        // A pinned height/width can only ever take `imgsz`, so rect applies exactly when
+        // the export left them dynamic - the same invariant as the native `rect_enabled`.
+        let rect = fixed_imgsz.is_none();
         let output_names = session
             .outputs()
             .iter()
@@ -451,6 +481,7 @@ impl YoloModel {
             metadata,
             output_names,
             imgsz,
+            rect,
             device: device.label(),
         })
     }
@@ -491,6 +522,7 @@ impl YoloModel {
             self.imgsz,
             self.metadata.stride,
             self.metadata.task,
+            self.rect,
         )?;
 
         // Resolve the output dtype path before borrowing the session for inference.
@@ -653,6 +685,27 @@ impl YoloPipeline {
         vec![1, 3, self.imgsz.0 as u32, self.imgsz.1 as u32]
     }
 
+    /// Adopt the input shape the engine reports for the compiled model.
+    ///
+    /// Without it the size comes from the metadata, which the graph itself never has to
+    /// agree with, and [`input_shape`](Self::input_shape) is what the caller sizes its
+    /// input tensor from - so a stale `imgsz` would feed the model a tensor it rejects.
+    /// The ONNX path reads the same fact off its session; this is the LiteRT equivalent,
+    /// which only the JS engine can see.
+    ///
+    /// Expects NCHW `[N, 3, H, W]`, what `ai_edge_torch` emits. Any other rank or layout
+    /// (a channels-last `[N, H, W, 3]`, a dynamic axis) is ignored, leaving the metadata
+    /// size in place.
+    #[wasm_bindgen(js_name = setInputShape)]
+    pub fn set_input_shape(&mut self, shape: Vec<u32>) {
+        if let [_, 3, h, w] = shape[..]
+            && h > 0
+            && w > 0
+        {
+            self.imgsz = (h as usize, w as usize);
+        }
+    }
+
     /// Preprocess raw RGBA pixels (e.g. a webcam `ImageData`) into the NCHW f32
     /// input tensor an Ultralytics LiteRT/TFLite model expects, normalized to
     /// `[0, 1]`, the same preprocessing as the ONNX path.
@@ -672,11 +725,14 @@ impl YoloPipeline {
         let t0 = now_ms();
         let dynimg = rgba_to_image(rgba, width, height)?;
 
+        // `rect: false` - the engine allocated its input tensor from `inputShape`, so the
+        // shape has to stay put across frames.
         let (orig_img, pre) = preprocess_image(
             &dynimg,
             self.imgsz,
             self.metadata.stride,
             self.metadata.task,
+            false,
         )?;
         let data = pre
             .tensor

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.31",
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@litertjs/core": "^2.5.0",
+        "@litertjs/core": "^2.5.3",
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
@@ -22,19 +22,19 @@
       }
     },
     "node_modules/@litertjs/core": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@litertjs/core/-/core-2.5.2.tgz",
-      "integrity": "sha512-2O4p5Me8B3KbW9EPU9Xe6iKl2jZ5nZeGxRBvhm5x42Wj7qb3xk2CjibPLA0eSyt2HuELu2hCIZ+7gHZM5cipcw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@litertjs/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-PlGmbMOq9WitX7FO0jhbdJw9GthatsyuCQXjTt/wJZo0FLaw48q4tz8IwqgqCIkviYGr9OFDL1kCnN4nzWoyJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@litertjs/wasm-utils": "^2.0.0"
+        "@litertjs/wasm-utils": "^2.5.3"
       }
     },
     "node_modules/@litertjs/wasm-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@litertjs/wasm-utils/-/wasm-utils-2.5.0.tgz",
-      "integrity": "sha512-zhMAqJRJ3ROi48flZxYx+K2MiMllJVuH7oeumpSIfQMBeOb6JyLV/7ltLbY6E+nERUAfNwzIBqjslWAeXcO6iQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@litertjs/wasm-utils/-/wasm-utils-2.5.3.tgz",
+      "integrity": "sha512-4fJiw6tBQnIs+0jH/OQ16nYOiSl8/+zZnn5h2ul8aTKHi05sVqZW580Tmk78pC2kT39A9OYBVdFawteZ/sI1kQ==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -66,7 +66,7 @@
     }
   },
   "devDependencies": {
-    "@litertjs/core": "^2.5.0",
+    "@litertjs/core": "^2.5.3",
     "typescript": "^5.4.0"
   }
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -715,8 +715,10 @@ export class YOLO {
     const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator);
     // The compiled model outranks the metadata: `pipeline.inputShape` is what sizes the
     // input tensor below, so a stale `imgsz` would build one the model rejects.
+    // Signed on purpose: the engine reports a dynamic axis as a negative number, and wasm
+    // rejects those rather than reading one as a huge unsigned size.
     const shape = backend.inputShape;
-    if (shape) pipeline.setInputShape(new Uint32Array(shape));
+    if (shape) pipeline.setInputShape(new Int32Array(shape));
     return new YOLO(new LiteRtEngine(pipeline, backend));
   }
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -365,6 +365,8 @@ interface LiteRtTensor {
 }
 interface LiteRtCompiledModel {
   run(input: LiteRtTensor | LiteRtTensor[]): Promise<LiteRtTensor[]>;
+  // The compiled model knows its real input shape; the metadata only claims one.
+  getInputDetails?(): readonly { readonly shape: Int32Array | number[] }[];
   delete?(): void;
 }
 interface LiteRtModule {
@@ -430,6 +432,12 @@ class LiteRtBackend {
     private readonly model: LiteRtCompiledModel,
     readonly device: string,
   ) {}
+
+  /** Input shape the compiled model actually expects, when LiteRT reports it. */
+  get inputShape(): number[] | undefined {
+    const shape = this.model.getInputDetails?.()[0]?.shape;
+    return shape && Array.from(shape);
+  }
 
   /** Import LiteRT.js, init its wasm, and compile the model, falling back from
    * WebGPU to wasm (CPU) if the GPU accelerator cannot compile. */
@@ -705,6 +713,10 @@ export class YOLO {
       );
     }
     const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator);
+    // The compiled model outranks the metadata: `pipeline.inputShape` is what sizes the
+    // input tensor below, so a stale `imgsz` would build one the model rejects.
+    const shape = backend.inputShape;
+    if (shape) pipeline.setInputShape(new Uint32Array(shape));
     return new YOLO(new LiteRtEngine(pipeline, backend));
   }
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improved Web inference reliability and efficiency by aligning input dimensions with the compiled model and enabling rectangular inference for dynamic-size exports.

### 📊 Key Changes

- Added rectangular preprocessing for models with dynamic height and width, reducing unnecessary padding for non-square images.
- Detects fixed input dimensions directly from ONNX model sessions instead of relying solely on metadata.
- Tracks whether a model supports rectangular inference and uses the actual tensor shape during postprocessing, improving segmentation mask alignment.
- Added `setInputShape` to the LiteRT pipeline so compiled model dimensions override potentially stale metadata.
- Reads input shape information from LiteRT compiled models when available.
- Updated `@litertjs/core` from `2.5.0` to `2.5.3`.

### 🎯 Purpose & Impact

- 🚀 Reduces wasted computation for widescreen or otherwise non-square images when using dynamic-shape models.
- ✅ Prevents inference failures caused by mismatches between model metadata and the dimensions enforced by ONNX or LiteRT engines.
- 🎯 Improves segmentation accuracy by basing postprocessing on the tensor shape actually sent to the model.
- 🌐 Makes browser inference more robust across fixed-shape and dynamic-shape exports, with graceful fallback when runtime shape details are unavailable.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `web/package-lock.json`
</details>
