### PR TITLE
Order scores with total_cmp so a NaN cannot panic the sort

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -548,13 +548,15 @@ fn extract_detect_boxes(
         return Array2::zeros((0, 6));
     }
 
-    // Top-K Selection & Sort
+    // Top-K Selection & Sort. `total_cmp` keeps a NaN score from panicking, and both of these
+    // need the total order it provides: `select_nth_unstable_by` has unspecified behavior with
+    // an inconsistent comparator.
     let nms_limit = (max_det * 10).min(candidates.len());
     if candidates.len() > nms_limit {
-        candidates.select_nth_unstable_by(nms_limit, |a, b| b.score.partial_cmp(&a.score).unwrap());
+        candidates.select_nth_unstable_by(nms_limit, |a, b| b.score.total_cmp(&a.score));
         candidates.truncate(nms_limit);
     }
-    candidates.sort_unstable_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    candidates.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
 
     // Population of SoA for NMS (small copy, very fast)
     let n = candidates.len();

--- a/src/results.rs
+++ b/src/results.rs
@@ -886,12 +886,13 @@ impl Keypoints {
     }
 }
 
-/// Sort key that ranks NaN below every real probability.
+/// Order two probabilities so that any NaN ranks below every real value, ascending otherwise.
 ///
-/// `f32::total_cmp` orders a positive NaN *above* infinity, so comparing raw values would let
-/// a NaN win the top-1 argmax. This mirrors how the detection head picks its best class score.
-const fn rank(v: f32) -> f32 {
-    if v.is_nan() { f32::NEG_INFINITY } else { v }
+/// `f32::total_cmp` alone would let a positive NaN win the top-1 argmax, since it orders NaN
+/// above infinity. Testing `is_nan` separately rather than substituting a sentinel keeps
+/// `f32::NEG_INFINITY` a distinct, orderable input.
+fn cmp_prob(a: f32, b: f32) -> std::cmp::Ordering {
+    b.is_nan().cmp(&a.is_nan()).then_with(|| a.total_cmp(&b))
 }
 
 /// Classification probabilities.
@@ -928,7 +929,7 @@ impl Probs {
         self.data
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| rank(**a).total_cmp(&rank(**b)))
+            .max_by(|(_, a), (_, b)| cmp_prob(**a, **b))
             .map_or(0, |(i, _)| i)
     }
     /// Get the indices of the top-5 classes.
@@ -953,7 +954,7 @@ impl Probs {
     #[must_use]
     pub fn top_k(&self, k: usize) -> Vec<usize> {
         let mut indices: Vec<usize> = (0..self.data.len()).collect();
-        indices.sort_by(|&a, &b| rank(self.data[b]).total_cmp(&rank(self.data[a])));
+        indices.sort_by(|&a, &b| cmp_prob(self.data[b], self.data[a]));
         indices.truncate(k);
         indices
     }
@@ -1334,10 +1335,20 @@ mod tests {
     #[test]
     fn test_probs_with_nan_does_not_panic() {
         let probs = Probs::new(array![0.1, f32::NAN, 0.7, 0.05]);
-        assert_eq!(probs.top1(), 2, "NaN sorts below a real probability");
+        assert_eq!(probs.top1(), 2, "NaN ranks below a real probability");
         assert!((probs.top1conf() - 0.7).abs() < 1e-6);
-        assert_eq!(probs.top_k(4).len(), 4);
+        assert_eq!(probs.top_k(4), vec![2, 0, 3, 1], "the NaN class sorts last");
         assert_eq!(probs.top5conf().len(), 4);
+
+        // Negative infinity is a real value, so it must still outrank a NaN. A sentinel-based
+        // ranking would tie these two and hand the argmax to the NaN.
+        let probs = Probs::new(array![f32::NEG_INFINITY, f32::NAN]);
+        assert_eq!(probs.top1(), 0);
+        assert_eq!(probs.top_k(2), vec![0, 1]);
+
+        // All-NaN input still has to return an in-range index rather than panicking.
+        let probs = Probs::new(array![f32::NAN, f32::NAN]);
+        assert!(probs.top1() < 2);
     }
 
     #[test]

--- a/src/results.rs
+++ b/src/results.rs
@@ -886,6 +886,14 @@ impl Keypoints {
     }
 }
 
+/// Sort key that ranks NaN below every real probability.
+///
+/// `f32::total_cmp` orders a positive NaN *above* infinity, so comparing raw values would let
+/// a NaN win the top-1 argmax. This mirrors how the detection head picks its best class score.
+const fn rank(v: f32) -> f32 {
+    if v.is_nan() { f32::NEG_INFINITY } else { v }
+}
+
 /// Classification probabilities.
 ///
 /// Stores class probabilities with convenience methods for top predictions.
@@ -915,16 +923,12 @@ impl Probs {
     /// # Returns
     ///
     /// * The class ID with the highest probability.
-    ///
-    /// # Panics
-    ///
-    /// Panics if valid comparison cannot be made (e.g. NaN) in `max_by`.
     #[must_use]
     pub fn top1(&self) -> usize {
         self.data
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .max_by(|(_, a), (_, b)| rank(**a).total_cmp(&rank(**b)))
             .map_or(0, |(i, _)| i)
     }
     /// Get the indices of the top-5 classes.
@@ -949,11 +953,7 @@ impl Probs {
     #[must_use]
     pub fn top_k(&self, k: usize) -> Vec<usize> {
         let mut indices: Vec<usize> = (0..self.data.len()).collect();
-        indices.sort_by(|&a, &b| {
-            self.data[b]
-                .partial_cmp(&self.data[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        indices.sort_by(|&a, &b| rank(self.data[b]).total_cmp(&rank(self.data[a])));
         indices.truncate(k);
         indices
     }
@@ -1327,6 +1327,17 @@ mod tests {
         assert!((probs.top1conf() - 0.7).abs() < 1e-6);
         let c5 = probs.top5conf();
         assert!((c5[0] - 0.7).abs() < 1e-6);
+    }
+
+    /// A NaN probability used to panic in `top1`, and with it `top1conf`, `top5conf`, and
+    /// `summary`. `total_cmp` orders NaN instead, so the real class still wins.
+    #[test]
+    fn test_probs_with_nan_does_not_panic() {
+        let probs = Probs::new(array![0.1, f32::NAN, 0.7, 0.05]);
+        assert_eq!(probs.top1(), 2, "NaN sorts below a real probability");
+        assert!((probs.top1conf() - 0.7).abs() < 1e-6);
+        assert_eq!(probs.top_k(4).len(), 4);
+        assert_eq!(probs.top5conf().len(), 4);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,9 +120,10 @@ fn nms_by_class<T>(
         return vec![];
     }
 
-    // Sort by score (descending)
+    // Sort by score (descending). `total_cmp` keeps a NaN score from panicking and gives the
+    // sort a total order, which `sort_by` requires.
     let mut indices: Vec<usize> = (0..boxes.len()).collect();
-    indices.sort_by(|&a, &b| boxes[b].1.partial_cmp(&boxes[a].1).unwrap());
+    indices.sort_by(|&a, &b| boxes[b].1.total_cmp(&boxes[a].1));
 
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
@@ -160,10 +161,6 @@ fn nms_by_class<T>(
 /// # Returns
 ///
 /// Indices of boxes to keep
-///
-/// # Panics
-///
-/// Panics if `partial_cmp` fails for floating point comparisons (e.g. NaN).
 #[must_use]
 pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Vec<usize> {
     nms_by_class(boxes, iou_threshold, calculate_iou)
@@ -183,10 +180,6 @@ pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Ve
 /// # Returns
 ///
 /// Indices of boxes to keep
-///
-/// # Panics
-///
-/// Panics if `partial_cmp` fails for floating point comparisons (e.g. NaN).
 #[must_use]
 pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f32) -> Vec<usize> {
     nms_by_class(boxes, iou_threshold, calculate_probiou)
@@ -319,6 +312,13 @@ mod tests {
         ];
         let keep = nms_per_class(&boxes, 0.5);
         assert_eq!(keep, vec![0]);
+
+        // A NaN score used to panic in the sort comparator.
+        let boxes = vec![
+            ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
+            ([100.0, 100.0, 110.0, 110.0], 0.9, 0),
+        ];
+        assert_eq!(nms_per_class(&boxes, 0.5).len(), 2);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,10 +120,17 @@ fn nms_by_class<T>(
         return vec![];
     }
 
-    // Sort by score (descending). `total_cmp` keeps a NaN score from panicking and gives the
-    // sort a total order, which `sort_by` requires.
+    // Sort by score (descending), with any NaN last. `total_cmp` alone would rank a positive
+    // NaN above every finite score, letting it suppress a valid overlapping box of the same
+    // class; testing `is_nan` first processes every real score before the NaNs.
     let mut indices: Vec<usize> = (0..boxes.len()).collect();
-    indices.sort_by(|&a, &b| boxes[b].1.total_cmp(&boxes[a].1));
+    indices.sort_by(|&a, &b| {
+        boxes[a]
+            .1
+            .is_nan()
+            .cmp(&boxes[b].1.is_nan())
+            .then_with(|| boxes[b].1.total_cmp(&boxes[a].1))
+    });
 
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
@@ -319,6 +326,14 @@ mod tests {
             ([100.0, 100.0, 110.0, 110.0], 0.9, 0),
         ];
         assert_eq!(nms_per_class(&boxes, 0.5).len(), 2);
+
+        // A NaN-scored box overlapping a valid one of the same class must not outrank it and
+        // suppress it: the real detection is processed first and survives.
+        let boxes = vec![
+            ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
+            ([1.0, 1.0, 11.0, 11.0], 0.9, 0),
+        ];
+        assert_eq!(nms_per_class(&boxes, 0.5), vec![1]);
     }
 
     #[test]


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Makes detection, classification, and NMS processing robust against `NaN` confidence scores without panics or incorrect ranking.

### 📊 Key Changes

- Replaced unsafe floating-point comparisons with total ordering in detection box selection and sorting.
- Added consistent probability ranking that places `NaN` values below all real probabilities.
- Updated standard and rotated NMS to process valid scores before `NaN` scores.
- Removed outdated documentation stating that `NaN` inputs could cause panics.
- Added tests covering `NaN`, negative infinity, overlapping detections, and all-`NaN` classification inputs.

### 🎯 Purpose & Impact

- ✅ Prevents inference crashes when model outputs contain `NaN` values.
- 🎯 Ensures valid detections and class probabilities are ranked ahead of invalid scores.
- 🚫 Prevents `NaN`-scored boxes from incorrectly suppressing valid overlapping detections during NMS.
- 🔒 Improves reliability for downstream methods such as `top1`, `top_k`, confidence accessors, and result summaries.