### PR TITLE
Skip unreadable inputs instead of abandoning the rest of the source

### DIFF
--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -358,18 +358,24 @@ pub fn run_prediction(args: &PredictArgs) {
             },
         );
 
-        // Main thread: consume frames from channel and run inference
+        // Main thread: consume frames from channel and run inference. One unreadable file must
+        // not abandon the rest of the source, so skip it and carry on like Ultralytics does.
+        let mut skipped = 0usize;
         for item in receiver {
             let (img, meta) = match item {
                 Ok(val) => val,
                 Err(e) => {
                     error!("Error reading source: {e}");
-                    break;
+                    skipped += 1;
+                    continue;
                 }
             };
             batch_processor.add(img, meta.path.clone(), meta);
         }
         batch_processor.flush();
+        if skipped > 0 {
+            warn!("Skipped {skipped} unreadable input(s) in the source");
+        }
     }
 
     if let Some(saver) = result_saver


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved prediction resilience by skipping unreadable inputs instead of stopping the entire source.

### 📊 Key Changes

- Continues processing when an image or input file cannot be read.
- Tracks the number of skipped inputs during prediction.
- Logs a warning after processing when one or more inputs were skipped.
- Preserves final batch processing by still calling `flush()`.

### 🎯 Purpose & Impact

- 🚀 Prevents a single corrupted or inaccessible file from interrupting inference for the remaining inputs.
- ✅ Makes CLI prediction behavior more consistent with Ultralytics workflows.
- 📈 Improves reliability for large or mixed-quality datasets.
- ⚠️ Clearly informs users how many inputs were skipped.