### PR TITLE
Add Task::has_depth to complete the task capability helpers

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -126,6 +126,12 @@ impl Task {
     pub const fn has_semantic_mask(&self) -> bool {
         matches!(self, Self::Semantic)
     }
+
+    /// Returns `true` only for the `Depth` task, which outputs a per-pixel depth map.
+    #[must_use]
+    pub const fn has_depth(&self) -> bool {
+        matches!(self, Self::Depth)
+    }
 }
 
 impl fmt::Display for Task {
@@ -211,6 +217,9 @@ mod tests {
         assert!(Task::Obb.has_obb());
         assert!(Task::Semantic.has_semantic_mask());
         assert!(!Task::Detect.has_semantic_mask());
+        assert!(Task::Depth.has_depth());
+        assert!(!Task::Semantic.has_depth());
+        assert!(!Task::Depth.has_semantic_mask());
     }
 
     #[test]


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds a helper method to identify depth-estimation tasks in the Rust inference API. 🧭

### 📊 Key Changes

- Introduced `Task::has_depth()`, which returns `true` only for `Task::Depth`.
- Added unit tests covering depth and semantic-mask task detection.
- Preserved existing task behavior and APIs.

### 🎯 Purpose & Impact

- Makes it easier for downstream code to detect tasks that produce per-pixel depth maps. 📐
- Improves task-type handling and validation in Rust inference workflows.
- Provides test coverage to prevent incorrect task classification. ✅