### PR TITLE
Describe the shipped result types instead of calling them future placeholders

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@
 //! - [`Probs`] - Classification probabilities with `top1()`, `top5()`, `top1conf()`, `top5conf()` methods
 //! - [`Obb`] - Oriented bounding boxes with `xyxyxyxy()`, `xywhr()`, `conf()`, `cls()` methods
 //! - [`SemanticMask`] - Per-pixel class map with `class_ids()`, `classes_present()` methods
-//! - [`DepthMap`] - Per-pixel depth map with `min_depth()`, `max_depth()`, `colorize()` methods
+//! - [`DepthMap`] - Per-pixel depth map with `min_depth()`, `max_depth()`, `colorize(colormap, viz)` methods
 //! - [`Speed`] - Per-stage timings with a `total()` method
 //!
 //! ## Module Overview

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,9 @@
 //! - [`Keypoints`] - Pose keypoints with `xy()`, `xyn()`, `conf()` methods
 //! - [`Probs`] - Classification probabilities with `top1()`, `top5()`, `top1conf()`, `top5conf()` methods
 //! - [`Obb`] - Oriented bounding boxes with `xyxyxyxy()`, `xywhr()`, `conf()`, `cls()` methods
+//! - [`SemanticMask`] - Per-pixel class map with `class_ids()`, `classes_present()` methods
+//! - [`DepthMap`] - Per-pixel depth map with `min_depth()`, `max_depth()`, `colorize()` methods
+//! - [`Speed`] - Per-stage timings with a `total()` method
 //!
 //! ## Module Overview
 //!

--- a/src/results.rs
+++ b/src/results.rs
@@ -735,9 +735,9 @@ impl Boxes {
     }
 }
 
-/// Segmentation masks.
+/// Per-instance segmentation masks produced by the `segment` task.
 ///
-/// Placeholder for future segmentation support.
+/// Holds the raw mask tensor. Polygon `xy`/`xyn` contours are not derived.
 #[derive(Debug, Clone)]
 pub struct Masks {
     /// Raw mask data with shape (N, H, W).
@@ -786,9 +786,10 @@ impl Masks {
     // contour properties are not derived yet.
 }
 
-/// Pose keypoints.
+/// Skeletal keypoints produced by the `pose` task, one set per detected object.
 ///
-/// Placeholder for future pose estimation support.
+/// Carries visibility scores only when the model exports three channels per keypoint;
+/// [`conf`](Self::conf) returns `None` otherwise.
 #[derive(Debug, Clone)]
 pub struct Keypoints {
     /// Raw keypoint data with shape (N, K, 2) or (N, K, 3) if confidence included.
@@ -979,9 +980,10 @@ impl Probs {
     }
 }
 
-/// Oriented bounding boxes.
+/// Rotated bounding boxes produced by the `obb` task.
 ///
-/// Placeholder for future OBB support.
+/// Boxes are stored as `xywhr`; [`xyxyxyxy`](Self::xyxyxyxy) expands them to corner points
+/// and [`xyxy`](Self::xyxy) gives the enclosing axis-aligned box.
 #[derive(Debug, Clone)]
 pub struct Obb {
     /// Raw OBB data with shape (N, 7) containing [x, y, w, h, rotation, conf, cls].


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Expands Rust API documentation for inference result types, including semantic segmentation, depth estimation, speed metrics, masks, keypoints, and oriented bounding boxes.

### 📊 Key Changes
- Added `SemanticMask`, `DepthMap`, and `Speed` to the public API overview, documenting their primary methods.
- Clarified that `Masks` contains raw per-instance segmentation tensors and does not derive polygon contours.
- Updated `Keypoints` documentation to describe supported tensor shapes and optional visibility confidence scores.
- Updated `Obb` documentation to explain rotated box storage and conversion to corner points or enclosing axis-aligned boxes.
- Replaced placeholder descriptions with task-specific documentation for segmentation, pose, and OBB inference results.

### 🎯 Purpose & Impact
- 🧭 Makes the Rust inference API easier to discover and understand for developers.
- ✅ Sets clearer expectations about which result data and helper methods are currently available.
- ⚠️ Documents existing limitations, such as the lack of derived mask contours and optional keypoint confidence values.
- 🚀 Improves generated API documentation without changing inference behavior.