### PR TITLE
Warm up at the batch size the model input pins

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -768,6 +768,19 @@ impl YOLOModel {
             )
     }
 
+    /// Batch size the export pinned on the model input, or `None` when it is dynamic.
+    /// Authoritative over a configured batch, the way the pinned height/width is.
+    fn fixed_batch(session: &Session) -> Option<usize> {
+        match session.inputs().first()?.dtype() {
+            ValueType::Tensor { shape, .. } if shape.len() == 4 && shape[0] > 0 =>
+            {
+                #[allow(clippy::cast_sign_loss)]
+                Some(shape[0] as usize)
+            }
+            _ => None,
+        }
+    }
+
     /// Maximum allowed image dimension to prevent OOM during warmup.
     const MAX_IMGSZ: usize = 8192;
 
@@ -798,11 +811,18 @@ impl YOLOModel {
             )));
         }
 
+        // Match whatever the export pinned on the batch axis, exactly as the height and
+        // width are matched above: a `[8, 3, 640, 640]` model rejects a batch-1 warmup and
+        // would fail the whole `load`. A dynamic batch takes the configured size.
+        let batch =
+            Self::fixed_batch(&self.session).unwrap_or_else(|| self.config.batch.unwrap_or(1));
+
         let warmup_result = Self::run_warmup(
             &mut self.session,
             &self.input_name,
             self.fp16_input,
             target_size,
+            batch,
         );
 
         if let Err(e) = warmup_result {
@@ -1538,17 +1558,18 @@ impl YOLOModel {
         input_name: &str,
         fp16_input: bool,
         size: (usize, usize),
+        batch: usize,
     ) -> Result<()> {
         let (h, w) = size;
         if fp16_input {
-            let dummy = ndarray::Array4::<f16>::zeros((1, 3, h, w));
+            let dummy = ndarray::Array4::<f16>::zeros((batch, 3, h, w));
             let cont = dummy.as_standard_layout();
             let tensor = TensorRef::from_array_view(&cont).map_err(|e| {
                 InferenceError::InferenceError(format!("Failed to create FP16 input tensor: {e}"))
             })?;
             Self::run_timed(session, ort::inputs![input_name => tensor])?;
         } else {
-            let dummy = ndarray::Array4::<f32>::zeros((1, 3, h, w));
+            let dummy = ndarray::Array4::<f32>::zeros((batch, 3, h, w));
             let cont = dummy.as_standard_layout();
             let tensor = TensorRef::from_array_view(cont.view()).map_err(|e| {
                 InferenceError::InferenceError(format!("Failed to create input tensor: {e}"))


### PR DESCRIPTION
`load_with_config` always runs a warmup pass, and that pass shaped its dummy input with a batch of 1, so loading any model whose input pins a larger batch failed with `Got: 1 Expected: 8` before the caller could do anything.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔥 Fixes model warmup to respect fixed batch sizes defined by exported model inputs.

### 📊 Key Changes

- Added detection of fixed batch dimensions from the model’s input tensor shape.
- Warmup now uses the exported batch size when it is fixed, such as batch 8.
- Dynamic-batch models continue using the configured batch size, defaulting to 1.
- Updated FP16 and FP32 warmup tensors to allocate the correct batch dimension.

### 🎯 Purpose & Impact

- ✅ Prevents model loading failures when exported models require a specific batch size.
- 🚀 Improves compatibility with fixed-batch ONNX and inference models.
- 🔄 Preserves existing behavior for models with dynamic batch dimensions.
- 💾 Ensures warmup inputs match the model’s expected shape, reducing avoidable initialization errors.