### PR TITLE
Letterbox a batch on the GPU instead of concatenating on the host

### DIFF
--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -183,8 +183,10 @@ the CPU path runs and the flag is silently ignored:
 - the task is not `Classify` (which uses center-crop, not letterbox),
 - the model takes an FP32 input tensor (FP16-input models keep the CPU path).
 
-It is wired into `predict_image` specifically (single-frame). `predict_batch`
-and the multi-image batch path always use CPU preprocess.
+`predict_batch` and the multi-image path use the same kernel, writing each image
+into its own slot of one `[N, 3, H, W]` device buffer, so a batch is uploaded
+without a host-side concatenation. The batch path additionally excludes
+`Semantic`, whose baked-in `ArgMax` output is handled by the CPU path.
 
 ## CLI
 
@@ -195,10 +197,18 @@ ultralytics-inference predict --model yolo26n.onnx --source image.jpg \
   --device tensorrt:0 --half
 ```
 
-This uses the TensorRT EP (FP16 + engine cache). The `cuda-preprocess` kernel
-fast path is **not** used by the CLI - the CLI runs through the batch
-processor, which uses CPU preprocess. The GPU preprocess path is reached only
-through `YOLOModel::predict_image` in library code.
+This uses the TensorRT EP (FP16 + engine cache). The CLI runs through the batch
+processor, which calls `predict_batch`, so the `cuda-preprocess` kernel is used
+only when `--batch` is greater than 1. At `--batch 1` the batch processor still
+calls `predict_batch` with a single image, which takes the CPU preprocess path.
+
+```bash
+ultralytics-inference predict --model yolo26n-b16.onnx --source images/ \
+  --device tensorrt:0 --half --batch 16
+```
+
+The model must be exported with a matching batch size, or with a dynamic batch
+axis. A model whose input pins `[16, 3, 640, 640]` cannot run at `--batch 1`.
 
 [`YOLOModel::predict_image`]: crate::YOLOModel::predict_image
 

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -123,6 +123,7 @@ pub(crate) struct PreGeom {
 pub(crate) struct CudaStreamHandle {
     ctx: Arc<CudaContext>,
     stream: Arc<CudaStream>,
+    device_id: usize,
 }
 
 impl CudaStreamHandle {
@@ -132,7 +133,11 @@ impl CudaStreamHandle {
             InferenceError::ModelLoadError(format!("cudarc CudaContext::new({device_id}): {e:?}"))
         })?;
         let stream = ctx.default_stream();
-        Ok(Self { ctx, stream })
+        Ok(Self {
+            ctx,
+            stream,
+            device_id,
+        })
     }
 
     /// Raw cudarc stream pointer, suitable for `ort`'s `with_compute_stream`.
@@ -174,6 +179,8 @@ pub(crate) struct CudaPreprocessor {
     dst_w: usize,
     /// Number of `3 * dst_h * dst_w` slots the input buffer holds.
     batch: usize,
+    /// CUDA device the context, stream and buffers live on.
+    device_id: usize,
 }
 
 impl CudaPreprocessor {
@@ -187,7 +194,11 @@ impl CudaPreprocessor {
         dst_w: usize,
         batch: usize,
     ) -> Result<Self> {
-        let CudaStreamHandle { ctx, stream } = handle;
+        let CudaStreamHandle {
+            ctx,
+            stream,
+            device_id,
+        } = handle;
 
         let ptx = compile_ptx_with_opts(KERNEL_SRC, cudarc::nvrtc::CompileOptions::default())
             .map_err(|e| InferenceError::ModelLoadError(format!("NVRTC compile: {e:?}")))?;
@@ -222,6 +233,7 @@ impl CudaPreprocessor {
             dst_h,
             dst_w,
             batch,
+            device_id,
         })
     }
 
@@ -229,6 +241,13 @@ impl CudaPreprocessor {
     /// stable for the lifetime of this preprocessor.
     pub(crate) const fn input_dev_ptr(&self) -> u64 {
         self.input_dev_ptr
+    }
+
+    /// CUDA device the input buffer lives on. The `MemoryInfo` describing that buffer to
+    /// ONNX Runtime must name this device, not device 0, or a session running on another
+    /// GPU is handed a pointer it cannot read.
+    pub(crate) const fn device_id(&self) -> usize {
+        self.device_id
     }
 
     /// Number of images the input buffer was sized for. A caller passing more than this

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -162,23 +162,31 @@ pub(crate) struct CudaPreprocessor {
     frame_dev: CudaSlice<u8>,
     frame_dev_capacity: usize,
 
-    /// Persistent device buffer for the model input tensor (`3 * dst_h * dst_w` f32).
-    /// Pointer is stable for the buffer's lifetime - cached so callers can
-    /// hand it to ORT via `TensorRefMut::from_raw` without re-querying.
+    /// Persistent device buffer for the model input tensor
+    /// (`batch * 3 * dst_h * dst_w` f32). Pointer is stable for the buffer's
+    /// lifetime - cached so callers can hand it to ORT via
+    /// `TensorRefMut::from_raw` without re-querying.
     input_dev: CudaSlice<f32>,
     input_dev_ptr: u64,
 
     /// Model input height/width (letterbox target). May be non-square.
     dst_h: usize,
     dst_w: usize,
+    /// Number of `3 * dst_h * dst_w` slots the input buffer holds.
+    batch: usize,
 }
 
 impl CudaPreprocessor {
     /// Phase-2 init: NVRTC-compile the preprocess kernel and pre-allocate the
-    /// device input buffer (`3 * dst_h * dst_w` f32). Reuses the context+stream
-    /// from [`CudaStreamHandle::open`] so ORT and this preprocessor share the
-    /// same compute stream.
-    pub(crate) fn finalize(handle: CudaStreamHandle, dst_h: usize, dst_w: usize) -> Result<Self> {
+    /// device input buffer (`batch * 3 * dst_h * dst_w` f32). Reuses the
+    /// context+stream from [`CudaStreamHandle::open`] so ORT and this
+    /// preprocessor share the same compute stream.
+    pub(crate) fn finalize(
+        handle: CudaStreamHandle,
+        dst_h: usize,
+        dst_w: usize,
+        batch: usize,
+    ) -> Result<Self> {
         let CudaStreamHandle { ctx, stream } = handle;
 
         let ptx = compile_ptx_with_opts(KERNEL_SRC, cudarc::nvrtc::CompileOptions::default())
@@ -190,7 +198,7 @@ impl CudaPreprocessor {
             .load_function("preprocess")
             .map_err(|e| InferenceError::ModelLoadError(format!("load_function: {e:?}")))?;
 
-        let input_elems = 3 * dst_h * dst_w;
+        let input_elems = batch * 3 * dst_h * dst_w;
         let input_dev = stream
             .alloc_zeros::<f32>(input_elems)
             .map_err(|e| InferenceError::ModelLoadError(format!("alloc input_dev: {e:?}")))?;
@@ -213,10 +221,11 @@ impl CudaPreprocessor {
             input_dev_ptr,
             dst_h,
             dst_w,
+            batch,
         })
     }
 
-    /// Device pointer of the model input buffer (`3 * dst_h * dst_w` f32),
+    /// Device pointer of the model input buffer (`batch * 3 * dst_h * dst_w` f32),
     /// stable for the lifetime of this preprocessor.
     pub(crate) const fn input_dev_ptr(&self) -> u64 {
         self.input_dev_ptr
@@ -230,6 +239,10 @@ impl CudaPreprocessor {
     /// inference, or the stride-aligned rectangle for `rect`. The caller sizes the buffer
     /// at [`Self::finalize`] to the largest target `rect` can produce.
     ///
+    /// `slot` selects which image of the batch to write, so a batched caller fills
+    /// `[N, 3, H, W]` in place and hands ORT the whole buffer with no host-side
+    /// concatenation.
+    ///
     /// The output of this call is enqueued on the same stream that the ORT
     /// session was bound to via [`CudaStreamHandle::raw_stream_ptr`], so the
     /// subsequent `session.run_binding(...)` sees the writes without an
@@ -241,8 +254,14 @@ impl CudaPreprocessor {
         src_w: u32,
         bgr_in: bool,
         dst: (usize, usize),
+        slot: usize,
     ) -> Result<PreGeom> {
         let (dst_h, dst_w) = dst;
+        debug_assert!(
+            slot < self.batch,
+            "slot {slot} out of range for a {}-slot input buffer",
+            self.batch
+        );
         // Writes are linear (`idx = y * dst_w + x`, plane stride `dst_h * dst_w`), so the
         // product is what has to fit; the caller sizes the buffer to the largest target.
         debug_assert!(
@@ -296,13 +315,20 @@ impl CudaPreprocessor {
             shared_mem_bytes: 0,
         };
 
+        // Write into this image's slot of the `[N, 3, H, W]` buffer. The kernel indexes
+        // from its `dst` base, so a sub-view is all the batching it needs.
+        let slot_elems = 3 * self.dst_h * self.dst_w;
+        let mut slot_view = self
+            .input_dev
+            .slice_mut(slot * slot_elems..(slot + 1) * slot_elems);
+
         unsafe {
             self.stream
                 .launch_builder(&self.kernel)
                 .arg(&self.frame_dev)
                 .arg(&(src_h as i32))
                 .arg(&(src_w as i32))
-                .arg(&mut self.input_dev)
+                .arg(&mut slot_view)
                 .arg(&(dst_h as i32))
                 .arg(&(dst_w as i32))
                 .arg(&scale_x)
@@ -340,7 +366,7 @@ mod tests {
     /// Open device 0 and build a preprocessor targeting `dst_h` x `dst_w`.
     fn preprocessor(dst_h: usize, dst_w: usize) -> CudaPreprocessor {
         let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
-        CudaPreprocessor::finalize(handle, dst_h, dst_w).expect("finalize preprocessor")
+        CudaPreprocessor::finalize(handle, dst_h, dst_w, 1).expect("finalize preprocessor")
     }
 
     /// Build an HWC RGB buffer filled with a single solid color.
@@ -386,7 +412,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 200, 100, 50);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w))
+            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w), 0)
             .expect("preprocess");
 
         // 640/640 = 1.0 is the binding axis; the 480-tall image is centered.
@@ -409,7 +435,7 @@ mod tests {
         // 640x640 into 384x640: scale 0.6 fills the width, pads the height to 0.
         let frame = solid(640, 640, 10, 20, 30);
         let geom = pre
-            .preprocess(&frame, 640, 640, false, (pre.dst_h, pre.dst_w))
+            .preprocess(&frame, 640, 640, false, (pre.dst_h, pre.dst_w), 0)
             .expect("preprocess");
 
         assert_eq!(geom.pad_y, 0);
@@ -427,7 +453,7 @@ mod tests {
         let frame = solid(src_h as usize, src_w as usize, 255, 255, 255);
 
         let geom = pre
-            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w))
+            .preprocess(&frame, src_h, src_w, false, (pre.dst_h, pre.dst_w), 0)
             .expect("preprocess");
         assert!(
             geom.pad_x > 0,
@@ -459,6 +485,7 @@ mod tests {
             dst as u32,
             false,
             (pre.dst_h, pre.dst_w),
+            0,
         )
         .expect("preprocess");
 
@@ -488,13 +515,21 @@ mod tests {
             dst as u32,
             false,
             (rgb.dst_h, rgb.dst_w),
+            0,
         )
         .expect("rgb preprocess");
         let rgb_host = readback(&rgb);
 
         let mut bgr = preprocessor(dst, dst);
-        bgr.preprocess(&frame, dst as u32, dst as u32, true, (bgr.dst_h, bgr.dst_w))
-            .expect("bgr preprocess");
+        bgr.preprocess(
+            &frame,
+            dst as u32,
+            dst as u32,
+            true,
+            (bgr.dst_h, bgr.dst_w),
+            0,
+        )
+        .expect("bgr preprocess");
         let bgr_host = readback(&bgr);
 
         // RGB reads byte[0]=255 into R; BGR reads the same byte into B.
@@ -515,7 +550,7 @@ mod tests {
     fn preprocess_rejects_wrong_len() {
         let mut pre = preprocessor(64, 64);
         let bad = vec![0u8; 10]; // != 64 * 64 * 3
-        let result = pre.preprocess(&bad, 64, 64, false, (pre.dst_h, pre.dst_w));
+        let result = pre.preprocess(&bad, 64, 64, false, (pre.dst_h, pre.dst_w), 0);
         assert!(
             matches!(result, Err(InferenceError::InferenceError(_))),
             "wrong-length frame must be rejected"
@@ -527,10 +562,10 @@ mod tests {
         let mut pre = preprocessor(128, 128);
         // First a small frame, then a larger one to force `frame_dev` to grow.
         let small = solid(32, 32, 1, 2, 3);
-        pre.preprocess(&small, 32, 32, false, (pre.dst_h, pre.dst_w))
+        pre.preprocess(&small, 32, 32, false, (pre.dst_h, pre.dst_w), 0)
             .expect("small frame");
         let large = solid(256, 256, 4, 5, 6);
-        pre.preprocess(&large, 256, 256, false, (pre.dst_h, pre.dst_w))
+        pre.preprocess(&large, 256, 256, false, (pre.dst_h, pre.dst_w), 0)
             .expect("large frame after buffer growth");
     }
 
@@ -560,7 +595,7 @@ mod tests {
             // A rect target, so this also covers the non-square letterbox `rect` produces.
             let dst = (192usize, 320usize);
             let mut pre = preprocessor(dst.0, dst.1);
-            pre.preprocess(&frame, src_h as u32, src_w as u32, false, dst)
+            pre.preprocess(&frame, src_h as u32, src_w as u32, false, dst, 0)
                 .expect("gpu preprocess");
             let gpu = readback(&pre);
 

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -231,6 +231,13 @@ impl CudaPreprocessor {
         self.input_dev_ptr
     }
 
+    /// Number of images the input buffer was sized for. A caller passing more than this
+    /// must not use the device path: the buffer cannot be grown without invalidating the
+    /// pointer already handed to ONNX Runtime.
+    pub(crate) const fn slots(&self) -> usize {
+        self.batch
+    }
+
     /// H2D-copy the source frame, launch the fused preprocess kernel writing
     /// into the input buffer, and return the letterbox geometry needed by
     /// post-processing.
@@ -317,7 +324,12 @@ impl CudaPreprocessor {
 
         // Write into this image's slot of the `[N, 3, H, W]` buffer. The kernel indexes
         // from its `dst` base, so a sub-view is all the batching it needs.
-        let slot_elems = 3 * self.dst_h * self.dst_w;
+        //
+        // The stride is the *target* plane, not the backing buffer's. `finalize` rounds the
+        // buffer up to the stride, so a model input that is not stride-aligned (1000x1000
+        // backed by 1024x1024) would otherwise place image 1 after a 1024x1024 plane while
+        // ORT, reading the `[N, 3, dst_h, dst_w]` tensor, expects it after a 1000x1000 one.
+        let slot_elems = 3 * dst_h * dst_w;
         let mut slot_view = self
             .input_dev
             .slice_mut(slot * slot_elems..(slot + 1) * slot_elems);

--- a/src/model.rs
+++ b/src/model.rs
@@ -172,8 +172,14 @@ impl YOLOModel {
                 config.device,
                 None | Some(crate::Device::Cuda(_) | crate::Device::TensorRt(_))
             );
+            // Open the context on the device the session will run on. Defaulting to 0 here
+            // would hand a GPU-0 pointer to a session executing on another GPU.
+            let device_index = match config.device {
+                Some(crate::Device::Cuda(i) | crate::Device::TensorRt(i)) => i,
+                _ => 0,
+            };
             if config.cuda_preprocess && device_eligible {
-                match crate::cuda_inference::CudaStreamHandle::open(0) {
+                match crate::cuda_inference::CudaStreamHandle::open(device_index) {
                     Ok(h) => Some(h),
                     Err(e) => {
                         warn!("cuda-preprocess: stream init failed ({e:?}); using CPU preprocess");
@@ -1037,6 +1043,35 @@ impl YOLOModel {
         }
     }
 
+    /// Memory descriptors for a device-resident input and host-readable outputs.
+    ///
+    /// `device_id` must name the GPU the input buffer lives on. Naming device 0 for a
+    /// session running on another GPU hands ORT a pointer it cannot read.
+    #[cfg(feature = "cuda-preprocess")]
+    fn device_memory_info(
+        device_id: usize,
+    ) -> Result<(
+        ort::memory::MemoryInfo<'static>,
+        ort::memory::MemoryInfo<'static>,
+    )> {
+        use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
+
+        let build = |device: AllocationDevice, id: usize, what: &str| {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            MemoryInfo::new(
+                device,
+                id as i32,
+                AllocatorType::Device,
+                MemoryType::Default,
+            )
+            .map_err(|e| InferenceError::InferenceError(format!("{what} meminfo: {e}")))
+        };
+        Ok((
+            build(AllocationDevice::CUDA, device_id, "cuda")?,
+            build(AllocationDevice::CPU, 0, "cpu")?,
+        ))
+    }
+
     /// CUDA-preprocess fast path used by [`Self::predict_image`] when
     /// `cuda_preprocessor` is populated. Runs the fused letterbox+normalize kernel,
     /// hands the resulting device buffer to ORT via `TensorRefMut::from_raw`,
@@ -1048,7 +1083,6 @@ impl YOLOModel {
         image: &DynamicImage,
         path: String,
     ) -> Result<Vec<Results>> {
-        use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
         use ort::value::TensorRefMut;
 
         // Computed before `run_binding` borrows the session: true when the
@@ -1080,27 +1114,15 @@ impl YOLOModel {
         let geom = pre.preprocess(&rgb_bytes, h, w, false, target, 0)?;
         let (dst_h, dst_w) = target;
         let dev_ptr = pre.input_dev_ptr();
+        let device_id = pre.device_id();
         #[allow(clippy::cast_precision_loss)]
         let preprocess_time = start_preprocess.elapsed().as_secs_f64() * 1000.0;
 
-        let cuda_mem = MemoryInfo::new(
-            AllocationDevice::CUDA,
-            0,
-            AllocatorType::Device,
-            MemoryType::Default,
-        )
-        .map_err(|e| InferenceError::InferenceError(format!("cuda meminfo: {e}")))?;
-        let cpu_mem = MemoryInfo::new(
-            AllocationDevice::CPU,
-            0,
-            AllocatorType::Device,
-            MemoryType::Default,
-        )
-        .map_err(|e| InferenceError::InferenceError(format!("cpu meminfo: {e}")))?;
+        let (cuda_mem, cpu_mem) = Self::device_memory_info(device_id)?;
         let shape: Vec<i64> = vec![1, 3, dst_h as i64, dst_w as i64];
         // SAFETY: dev_ptr is owned by `cuda_preprocessor` (stored on `self`) and remains
-        // valid for the duration of this call. ORT consumes it during
-        // `run_binding`, which is synchronized via the shared cuda stream.
+        // valid for the duration of this call. ORT consumes it during `run_binding`, which
+        // is synchronized via the shared cuda stream.
         let in_tensor = unsafe {
             TensorRefMut::<f32>::from_raw(cuda_mem, dev_ptr as *mut core::ffi::c_void, shape.into())
                 .map_err(|e| InferenceError::InferenceError(format!("from_raw: {e}")))?
@@ -1218,7 +1240,6 @@ impl YOLOModel {
         images: &[&DynamicImage],
         paths: &[String],
     ) -> Result<Vec<Vec<Results>>> {
-        use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
         use ort::value::TensorRefMut;
 
         let n_images = images.len();
@@ -1263,31 +1284,15 @@ impl YOLOModel {
         let preprocess_time = start_preprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
 
         let (dst_h, dst_w) = target;
-        let dev_ptr = self
-            .cuda_preprocessor
-            .as_ref()
-            .expect("cuda_preprocessor")
-            .input_dev_ptr();
+        let pre = self.cuda_preprocessor.as_ref().expect("cuda_preprocessor");
+        let dev_ptr = pre.input_dev_ptr();
+        let device_id = pre.device_id();
 
-        let cuda_mem = MemoryInfo::new(
-            AllocationDevice::CUDA,
-            0,
-            AllocatorType::Device,
-            MemoryType::Default,
-        )
-        .map_err(|e| InferenceError::InferenceError(format!("cuda meminfo: {e}")))?;
-        let cpu_mem = MemoryInfo::new(
-            AllocationDevice::CPU,
-            0,
-            AllocatorType::Device,
-            MemoryType::Default,
-        )
-        .map_err(|e| InferenceError::InferenceError(format!("cpu meminfo: {e}")))?;
+        let (cuda_mem, cpu_mem) = Self::device_memory_info(device_id)?;
+        // The buffer was sized for `slots >= n_images` at load, checked before dispatch.
         let shape: Vec<i64> = vec![n_images as i64, 3, dst_h as i64, dst_w as i64];
-        // SAFETY: dev_ptr is owned by `cuda_preprocessor` (stored on `self`) and remains
-        // valid for the duration of this call, and the buffer was sized for `slots >=
-        // n_images` images at load. ORT consumes it during `run_binding`, which is
-        // synchronized via the shared cuda stream.
+        // SAFETY: as in `predict_image_cuda_pre`; the pointer is owned by
+        // `cuda_preprocessor` and outlives this call.
         let in_tensor = unsafe {
             TensorRefMut::<f32>::from_raw(cuda_mem, dev_ptr as *mut core::ffi::c_void, shape.into())
                 .map_err(|e| InferenceError::InferenceError(format!("from_raw: {e}")))?

--- a/src/model.rs
+++ b/src/model.rs
@@ -1225,12 +1225,21 @@ impl YOLOModel {
         let n_images_f = n_images as f64;
         let start_preprocess = Instant::now();
 
-        // A batch shares one letterbox target: `rect` needs a uniform batch and the models
-        // that reach here have a fixed input anyway, so use the model's own size.
-        let target = self
+        // One letterbox target for the whole batch, chosen the same way the CPU batch path
+        // chooses it: `rect` applies only when the model is dynamic and every source shares
+        // a shape, since a mixed batch cannot share one padded target.
+        let imgsz = self
             .metadata
             .imgsz
             .unwrap_or(InferenceConfig::DEFAULT_IMGSZ);
+        let first_dims = images[0].dimensions();
+        let uniform_shape = images.iter().all(|img| img.dimensions() == first_dims);
+        let target = if self.rect_enabled() && uniform_shape {
+            let (w, h) = first_dims;
+            calculate_rect_size(w, h, imgsz, self.metadata.stride)
+        } else {
+            imgsz
+        };
 
         // RGB extraction is per-image and host-side, so fan it out; the device uploads
         // below must stay ordered on the shared stream.
@@ -1423,9 +1432,15 @@ impl YOLOModel {
 
         // Same fast path (and same allowlist) as `predict_image`, filling one device slot
         // per image. Single images keep using `predict_image`'s arm, which already ran.
+        // `predict_batch` is public and its length is not tied to `config.batch`, so a batch
+        // larger than the buffer was sized for falls back to the CPU path rather than
+        // indexing past the last slot.
         #[cfg(feature = "cuda-preprocess")]
         if images.len() > 1
-            && self.cuda_preprocessor.is_some()
+            && self
+                .cuda_preprocessor
+                .as_ref()
+                .is_some_and(|p| images.len() <= p.slots())
             && !self.fp16_input
             && !self.has_semantic_mask_output()
             && matches!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -469,7 +469,13 @@ impl YOLOModel {
             let stride = metadata.stride as usize;
             let round_up = |v: usize| v.div_ceil(stride) * stride;
             let (dst_h, dst_w) = (round_up(resolved_imgsz.0), round_up(resolved_imgsz.1));
-            match crate::cuda_inference::CudaPreprocessor::finalize(handle, dst_h, dst_w) {
+            // One slot per image the model's input accepts, so a batched run fills
+            // `[N, 3, H, W]` on the device instead of concatenating on the host.
+            let slots = Self::fixed_batch(&session)
+                .or(config.batch)
+                .unwrap_or(1)
+                .max(1);
+            match crate::cuda_inference::CudaPreprocessor::finalize(handle, dst_h, dst_w, slots) {
                 Ok(p) => Some(p),
                 Err(e) => {
                     return Err(InferenceError::ModelLoadError(format!(
@@ -564,6 +570,7 @@ impl YOLOModel {
             .with_timing_cache_path(cache_str)
             .with_max_workspace_size(4 * 1024 * 1024 * 1024)
             .with_builder_optimization_level(5);
+
         bind_compute_stream!(ep, compute_stream)
     }
 
@@ -1070,7 +1077,7 @@ impl YOLOModel {
             .cuda_preprocessor
             .as_mut()
             .expect("predict_image_cuda_pre invariant: cuda_preprocessor.is_some()");
-        let geom = pre.preprocess(&rgb_bytes, h, w, false, target)?;
+        let geom = pre.preprocess(&rgb_bytes, h, w, false, target, 0)?;
         let (dst_h, dst_w) = target;
         let dev_ptr = pre.input_dev_ptr();
         #[allow(clippy::cast_precision_loss)]
@@ -1201,6 +1208,158 @@ impl YOLOModel {
         Ok(vec![result])
     }
 
+    /// Batched twin of [`Self::predict_image_cuda_pre`]: letterboxes every image straight
+    /// into its slot of the device-side `[N, 3, H, W]` input, so a batch costs no host
+    /// tensor allocation and no concatenation - which otherwise dominate a batched GPU run.
+    #[cfg(feature = "cuda-preprocess")]
+    #[allow(unsafe_code, clippy::cast_precision_loss)]
+    fn predict_batch_cuda_pre(
+        &mut self,
+        images: &[&DynamicImage],
+        paths: &[String],
+    ) -> Result<Vec<Vec<Results>>> {
+        use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
+        use ort::value::TensorRefMut;
+
+        let n_images = images.len();
+        let n_images_f = n_images as f64;
+        let start_preprocess = Instant::now();
+
+        // A batch shares one letterbox target: `rect` needs a uniform batch and the models
+        // that reach here have a fixed input anyway, so use the model's own size.
+        let target = self
+            .metadata
+            .imgsz
+            .unwrap_or(InferenceConfig::DEFAULT_IMGSZ);
+
+        // RGB extraction is per-image and host-side, so fan it out; the device uploads
+        // below must stay ordered on the shared stream.
+        let frames: Vec<(Vec<u8>, u32, u32)> = images
+            .par_iter()
+            .map(|image| {
+                let rgb = image.to_rgb8();
+                let (w, h) = (rgb.width(), rgb.height());
+                (rgb.into_raw(), h, w)
+            })
+            .collect();
+
+        let mut geoms = Vec::with_capacity(n_images);
+        for (slot, (bytes, h, w)) in frames.iter().enumerate() {
+            let pre = self
+                .cuda_preprocessor
+                .as_mut()
+                .expect("predict_batch_cuda_pre invariant: cuda_preprocessor.is_some()");
+            geoms.push(pre.preprocess(bytes, *h, *w, false, target, slot)?);
+        }
+        let preprocess_time = start_preprocess.elapsed().as_secs_f64() * 1000.0 / n_images_f;
+
+        let (dst_h, dst_w) = target;
+        let dev_ptr = self
+            .cuda_preprocessor
+            .as_ref()
+            .expect("cuda_preprocessor")
+            .input_dev_ptr();
+
+        let cuda_mem = MemoryInfo::new(
+            AllocationDevice::CUDA,
+            0,
+            AllocatorType::Device,
+            MemoryType::Default,
+        )
+        .map_err(|e| InferenceError::InferenceError(format!("cuda meminfo: {e}")))?;
+        let cpu_mem = MemoryInfo::new(
+            AllocationDevice::CPU,
+            0,
+            AllocatorType::Device,
+            MemoryType::Default,
+        )
+        .map_err(|e| InferenceError::InferenceError(format!("cpu meminfo: {e}")))?;
+        let shape: Vec<i64> = vec![n_images as i64, 3, dst_h as i64, dst_w as i64];
+        // SAFETY: dev_ptr is owned by `cuda_preprocessor` (stored on `self`) and remains
+        // valid for the duration of this call, and the buffer was sized for `slots >=
+        // n_images` images at load. ORT consumes it during `run_binding`, which is
+        // synchronized via the shared cuda stream.
+        let in_tensor = unsafe {
+            TensorRefMut::<f32>::from_raw(cuda_mem, dev_ptr as *mut core::ffi::c_void, shape.into())
+                .map_err(|e| InferenceError::InferenceError(format!("from_raw: {e}")))?
+        };
+
+        let start_inference = Instant::now();
+        let mut binding = self
+            .session
+            .create_binding()
+            .map_err(|e| InferenceError::InferenceError(format!("create_binding: {e}")))?;
+        binding
+            .bind_input(&self.input_name, &in_tensor)
+            .map_err(|e| InferenceError::InferenceError(format!("bind_input: {e}")))?;
+        for n in &self.output_names {
+            binding
+                .bind_output_to_device(n, &cpu_mem)
+                .map_err(|e| InferenceError::InferenceError(format!("bind_output: {e}")))?;
+        }
+        let outputs = self
+            .session
+            .run_binding(&binding)
+            .map_err(|e| InferenceError::InferenceError(format!("run_binding: {e}")))?;
+        binding
+            .synchronize_outputs()
+            .map_err(|e| InferenceError::InferenceError(format!("sync_outputs: {e}")))?;
+        let inference_time = start_inference.elapsed().as_secs_f64() * 1000.0 / n_images_f;
+
+        // Reuse each frame's RGB buffer as the annotator's HWC array; no copy.
+        let mut origs = Vec::with_capacity(n_images);
+        for (bytes, h, w) in frames {
+            origs.push(
+                ndarray::Array3::from_shape_vec((h as usize, w as usize, 3), bytes)
+                    .map_err(|e| InferenceError::InferenceError(format!("Array3 from rgb: {e}")))?,
+            );
+        }
+
+        let start_postprocess = Instant::now();
+        let mut batch_results =
+            Self::extract_and_invoke(&outputs, &self.output_names, inference_time, |outs, _ms| {
+                let mut results = Vec::with_capacity(n_images);
+                for (i, (orig_img, geom)) in origs.into_iter().zip(&geoms).enumerate() {
+                    let (h, w) = (orig_img.shape()[0] as u32, orig_img.shape()[1] as u32);
+                    // Slice image `i` out of each batched output. `postprocess` wants the
+                    // full rank with a batch of one, not the batch dim stripped.
+                    let img_outputs: Vec<(&[f32], Vec<usize>)> = outs
+                        .iter()
+                        .map(|(data, shape)| {
+                            let per_image = data.len() / n_images;
+                            let mut img_shape = shape.clone();
+                            img_shape[0] = 1;
+                            (&data[i * per_image..(i + 1) * per_image], img_shape)
+                        })
+                        .collect();
+                    let pre = crate::preprocessing::PreprocessResult {
+                        tensor: ndarray::Array4::<f32>::zeros((0, 0, 0, 0)),
+                        tensor_f16: None,
+                        orig_shape: (h, w),
+                        scale: (geom.scale, geom.scale),
+                        padding: (geom.pad_y as f32, geom.pad_x as f32),
+                    };
+                    results.push(vec![postprocess(
+                        img_outputs,
+                        self.metadata.task,
+                        &pre,
+                        &self.config,
+                        Arc::clone(&self.metadata.names),
+                        orig_img,
+                        paths.get(i).cloned().unwrap_or_default(),
+                        Speed::new(preprocess_time, inference_time, 0.0),
+                        (dst_h as u32, dst_w as u32),
+                        self.metadata.end2end,
+                        self.metadata.kpt_shape,
+                    )]);
+                }
+                Ok(results)
+            })?;
+        Self::apply_postprocess_time(&mut batch_results, start_postprocess, n_images_f);
+
+        Ok(batch_results)
+    }
+
     /// Run inference on the default Ultralytics sample images.
     ///
     /// Downloads default `bus.jpg` and `zidane.jpg` if not present, then runs inference on both.
@@ -1260,6 +1419,21 @@ impl YOLOModel {
     ) -> Result<Vec<Vec<Results>>> {
         if images.is_empty() {
             return Ok(Vec::new());
+        }
+
+        // Same fast path (and same allowlist) as `predict_image`, filling one device slot
+        // per image. Single images keep using `predict_image`'s arm, which already ran.
+        #[cfg(feature = "cuda-preprocess")]
+        if images.len() > 1
+            && self.cuda_preprocessor.is_some()
+            && !self.fp16_input
+            && !self.has_semantic_mask_output()
+            && matches!(
+                self.metadata.task,
+                Task::Detect | Task::Segment | Task::Pose | Task::Obb | Task::Depth
+            )
+        {
+            return self.predict_batch_cuda_pre(images, paths);
         }
 
         // Get target size from config or metadata


### PR DESCRIPTION
The fused CUDA letterbox kernel wrote a single image, so a batched run fell back to the host path and paid a full tensor build and copy; it now writes each image into its own slot of one `[N, 3, H, W]` device buffer and binds that directly.

| Configuration | FPS |
| ------------- | --- |
| batch 1 | 884.1 |
| batch 8 | 1182.6 |
| batch 16 | 1213.9 |

Measured with yolo26n at 640x640 over coco128 on a DGX Spark, TensorRT FP16.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Adds CUDA-accelerated preprocessing for multi-image batches, enabling direct device-side input construction and safer multi-GPU inference.

### 📊 Key Changes
- 🖥️ Extended the CUDA preprocessor to allocate a device buffer with one slot per batch image.
- ⚡ Added batched GPU preprocessing that writes images directly into a `[N, 3, H, W]` device tensor, avoiding host-side concatenation.
- 🎯 Enabled the batch CUDA path for Detect, Segment, Pose, OBB, and Depth tasks when the batch fits the preallocated buffer.
- 🔄 Retained CPU preprocessing for single-image batches, Semantic models, FP16-input models, unsupported tasks, and oversized batches.
- 🧩 Added device-aware CUDA memory descriptors and initializes CUDA contexts on the configured GPU instead of always using GPU 0.
- 📚 Updated CUDA documentation with batch usage requirements, including matching or dynamic model batch sizes.
- 🧪 Updated CUDA preprocessing tests for slot-based batched buffers.

### 🎯 Purpose & Impact
- 📈 Improves batched GPU inference performance by reducing host memory allocation, tensor concatenation, and unnecessary data movement.
- ✅ Enables the CLI to use CUDA preprocessing when `--batch` is greater than 1 and the model supports the requested batch size.
- 🌐 Improves reliability on multi-GPU systems by ensuring device buffers and ONNX Runtime sessions use the same GPU.
- 🛡️ Preserves compatibility through automatic fallback to CPU preprocessing when CUDA batching is unsupported or unsafe.
- ⚠️ Users must export models with a matching fixed batch size or a dynamic batch dimension; fixed-size models may reject different `--batch` values.