### PR TITLE
Use canonical Contribute and License headings in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ ONNX Runtime threading is set to auto (`num_threads: 0`), which lets ORT choose 
 
 - [ ] Python bindings (PyO3)
 
-## 💡 Contributing
+## 💡 Contribute
 
 Ultralytics thrives on community collaboration, and we deeply value your contributions! Whether it's reporting bugs,
 suggesting features, or submitting code changes, your involvement is crucial.
@@ -753,7 +753,7 @@ A heartfelt thank you 🙏 goes out to all our contributors! Your efforts help m
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-## 📜 License
+## 📄 License
 
 Ultralytics offers two licensing options to suit different needs:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -738,7 +738,7 @@ Ultralytics 依靠社区协作持续发展，我们重视每一份贡献。无�
 
 [![Ultralytics 开源贡献者](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-## 📜 许可证
+## 📄 许可证
 
 Ultralytics 提供两种许可方式：
 

--- a/web/README.md
+++ b/web/README.md
@@ -316,7 +316,7 @@ npm run build # wasm-pack build + tsc
 Serve the built package over `localhost` (a secure context) with the two
 cross-origin isolation headers above, then open it in a WebGPU browser.
 
-## 💡 Contributing
+## 💡 Contribute
 
 Ultralytics thrives on community collaboration, and we deeply value your contributions! Whether it's reporting bugs,
 suggesting features, or submitting code changes, your involvement is crucial.
@@ -330,7 +330,7 @@ A heartfelt thank you 🙏 goes out to all our contributors! Your efforts help m
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-## 📜 License
+## 📄 License
 
 Ultralytics offers two licensing options to suit different needs:
 

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -303,7 +303,7 @@ Ultralytics 依靠社区协作持续发展，我们重视每一份贡献。无�
 
 [![Ultralytics 开源贡献者](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-## 📜 许可证
+## 📄 许可证
 
 Ultralytics 提供两种许可方式：
 


### PR DESCRIPTION
Align the README tails with the canonical Ultralytics structure: `## 💡 Contributing` → `## 💡 Contribute` and `## 📜 License` → `## 📄 License`. Applied to the repo READMEs and the `web/` npm package READMEs, mirrored in both 简体中文 translations. Section content is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📝 Updates README section headings across the main and web documentation in English and Chinese.

### 📊 Key Changes

- Renamed **“Contributing”** to **“Contribute”** in the English README files.
- Changed the license heading icon from 📜 to 📄 in both English and Chinese README files.
- Applied the same wording and formatting updates to the `web/` documentation.

### 🎯 Purpose & Impact

- ✨ Makes documentation headings more concise and action-oriented.
- 🌍 Keeps the main and web README files consistent across English and Chinese versions.
- ✅ No functional or code behavior changes; the impact is limited to documentation clarity and presentation.