### PR TITLE
Add release title to publish Slack notification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,8 +164,19 @@ jobs:
     needs: [check, build, publish, sbom]
     if: always() && needs.check.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Get release title
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
+        run: |
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.build.result == 'success' && needs.publish.result == 'success' && needs.sbom.result == 'success'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
@@ -173,7 +184,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.build.result != 'success' || needs.publish.result != 'success' || needs.sbom.result != 'success'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0


### PR DESCRIPTION
## Summary

Aligns the publish Slack notification with the org standard in `ultralytics/ultralytics`: adds the "Get release title" step (`gh release view` with PR numbers substituted into Slack links) so the success message posts the release title instead of the bare tag, with the tag as fallback. The notify job gains `contents: read` (previously `{}`) so the release lookup is authorized.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves successful release notifications by displaying the GitHub release title and linking referenced PRs in Slack. ✨

### 📊 Key Changes
- Grants the publishing workflow read-only repository contents permission to query release metadata.
- Adds a step to retrieve the release title using the GitHub CLI.
- Converts PR references such as `#123` in release titles into clickable GitHub PR links.
- Updates Slack success notifications to show the release title, with the tag as a fallback.

### 🎯 Purpose & Impact
- Makes Slack release notifications more informative and easier to understand at a glance. 📣
- Lets users quickly identify and open the PRs associated with a release.
- Preserves existing release and workflow links while maintaining least-privilege read-only permissions.
- Failure notifications remain unchanged.