### PR TITLE
Make the visualize feature imply annotate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,9 @@ fast_image_resize = { version = "^6.0", features = ["image", "rayon"] }
 [features]
 default = ["annotate", "visualize"]
 
-# Real-time visualization
-visualize = ["minifb"]
+# Real-time visualization. Implies `annotate`: the viewer displays annotated frames,
+# so `annotate_image` must be available.
+visualize = ["minifb", "annotate"]
 
 # Video file support (requires ffmpeg installed on system)
 video = ["video-rs"]


### PR DESCRIPTION
`cargo build --features visualize` without `annotate` fails to compile: the viewer block in `src/cli/predict.rs` calls `annotate_image`, whose import is gated on `annotate`. The default feature set enables both, so only a build that opts out of defaults hits it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the Rust `visualize` feature to automatically include annotation support. 🖼️

### 📊 Key Changes

- Modified the `visualize` feature in `Cargo.toml` to also enable `annotate`.
- Documented that visualization depends on annotations because the viewer displays annotated frames.

### 🎯 Purpose & Impact

- Ensures users enabling `visualize` can access the required `annotate_image` functionality automatically. ✅
- Prevents feature-related build or compilation issues when using the real-time viewer without explicitly enabling `annotate`.
- Simplifies feature configuration while preserving the existing default behavior. 🚀