### PR TITLE
Guard the classify center crop against a zero-extent source

### DIFF
--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -686,6 +686,19 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     #[allow(clippy::cast_possible_truncation)]
     let (target_h, target_w) = (target_size.0 as u32, target_size.1 as u32);
 
+    // A zero-extent source has no pixels to sample, and the cover scale below divides by
+    // each extent: `target / 0` is infinite, which makes the resized extents garbage and
+    // asks the allocator for terabytes. Mirror the letterbox path and hand back a frame of
+    // the padding colour.
+    if src_w == 0 || src_h == 0 || target_w == 0 || target_h == 0 {
+        let blank = RgbImage::from_pixel(
+            target_w.max(1),
+            target_h.max(1),
+            image::Rgb(LETTERBOX_COLOR),
+        );
+        return (blank, (1.0, 1.0));
+    }
+
     // Calculate scale to "cover" the target area
     // scale = max(target_w / src_w, target_h / src_h)
     #[allow(clippy::cast_precision_loss)]

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -689,7 +689,7 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     // A zero-extent source has no pixels to sample, and the cover scale below divides by
     // each extent: `target / 0` is infinite, which makes the resized extents garbage and
     // asks the allocator for terabytes. Mirror the letterbox path and hand back a frame of
-    // the padding colour.
+    // the padding color.
     if src_w == 0 || src_h == 0 || target_w == 0 || target_h == 0 {
         let blank = RgbImage::from_pixel(
             target_w.max(1),

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -686,11 +686,8 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     #[allow(clippy::cast_possible_truncation)]
     let (target_h, target_w) = (target_size.0 as u32, target_size.1 as u32);
 
-    // A zero-extent source has no pixels to sample, and the cover scale below divides by
-    // each source extent: `target / 0` is infinite, which makes the resized extents garbage
-    // and asks the allocator for terabytes. Mirror the letterbox path and hand back a frame
-    // of the padding color at the requested target, leaving the target dimensions alone so
-    // a zero target still yields a zero-extent tensor as it does there.
+    // The cover scale below divides by each source extent, so `target / 0` is infinite: the
+    // resized extents come out garbage and the allocator is asked for terabytes.
     if src_w == 0 || src_h == 0 {
         let blank = RgbImage::from_pixel(target_w, target_h, image::Rgb(LETTERBOX_COLOR));
         return (blank, (1.0, 1.0));

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -614,6 +614,10 @@ pub const fn clip_coords(coords: &[f32; 4], shape: (u32, u32)) -> [f32; 4] {
 ///
 /// Resizes the image so the shortest side matches `target_size`, then center crops.
 ///
+/// A zero-width or zero-height source yields a `target_size` frame of the letterbox
+/// padding color, matching [`preprocess_image`]. `target_size` is returned as requested,
+/// so a zero target yields a zero-extent tensor there too.
+///
 /// # Arguments
 ///
 /// * `image` - Input image.
@@ -664,6 +668,10 @@ pub fn preprocess_image_center_crop(
 ///
 /// Resizes the image such that the shortest side equals the target dimension,
 /// maintaining aspect ratio, then crops the center `target_size`.
+///
+/// A zero-extent source short-circuits to a `target_size` frame of the padding color: the
+/// cover scale divides by each source extent, so `target / 0` would otherwise drive the
+/// resized extents to infinity and request an unbounded allocation.
 ///
 /// # Arguments
 ///

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -225,10 +225,6 @@ pub fn preprocess_image_with_precision(
     build_preprocess_result(image, target_size, geom, scale, orig_shape, half)
 }
 
-// ================================================================================================
-// Public API Functions
-// ================================================================================================
-
 /// Get or compute the X coordinate LUT for bilinear interpolation.
 ///
 /// Uses 11-bit fixed-point weights matching `OpenCV`'s `INTER_LINEAR` coordinate mapping:
@@ -668,10 +664,6 @@ pub fn preprocess_image_center_crop(
 ///
 /// Resizes the image such that the shortest side equals the target dimension,
 /// maintaining aspect ratio, then crops the center `target_size`.
-///
-/// A zero-extent source short-circuits to a `target_size` frame of the padding color: the
-/// cover scale divides by each source extent, so `target / 0` would otherwise drive the
-/// resized extents to infinity and request an unbounded allocation.
 ///
 /// # Arguments
 ///

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -687,15 +687,12 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     let (target_h, target_w) = (target_size.0 as u32, target_size.1 as u32);
 
     // A zero-extent source has no pixels to sample, and the cover scale below divides by
-    // each extent: `target / 0` is infinite, which makes the resized extents garbage and
-    // asks the allocator for terabytes. Mirror the letterbox path and hand back a frame of
-    // the padding color.
-    if src_w == 0 || src_h == 0 || target_w == 0 || target_h == 0 {
-        let blank = RgbImage::from_pixel(
-            target_w.max(1),
-            target_h.max(1),
-            image::Rgb(LETTERBOX_COLOR),
-        );
+    // each source extent: `target / 0` is infinite, which makes the resized extents garbage
+    // and asks the allocator for terabytes. Mirror the letterbox path and hand back a frame
+    // of the padding color at the requested target, leaving the target dimensions alone so
+    // a zero target still yields a zero-extent tensor as it does there.
+    if src_w == 0 || src_h == 0 {
+        let blank = RgbImage::from_pixel(target_w, target_h, image::Rgb(LETTERBOX_COLOR));
         return (blank, (1.0, 1.0));
     }
 


### PR DESCRIPTION
A zero-width or zero-height image makes the cover scale divide by zero, so the resized extents become garbage and the allocator is asked for terabytes, aborting the process. The letterbox path already returns the padding color for this case; the classify center crop did not.

The requested `target_size` is passed through unchanged, so a zero target still yields a zero-extent tensor exactly as `preprocess_image` does.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛡️ Prevents preprocessing crashes and excessive memory allocation when center-cropping zero-width or zero-height images.

### 📊 Key Changes
- Added an early check in `center_crop_image` for images with zero width or height.
- Returns a target-sized image filled with the standard letterbox padding color for invalid source dimensions.
- Preserves the requested target size and returns a neutral scale of `(1.0, 1.0)`.
- Updated documentation to describe zero-dimension input behavior.
- Removed an outdated public API section separator comment.

### 🎯 Purpose & Impact
- 🚫 Prevents division-by-zero behavior and invalid resize calculations.
- 💾 Avoids potentially requesting extremely large memory allocations for malformed inputs.
- ✅ Makes center-crop behavior consistent with the existing `preprocess_image` handling.
- 🔧 Improves preprocessing robustness for edge cases without affecting normal image inputs.