### PR TITLE
Note that FFmpeg 6.1 builds and runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,8 +660,7 @@ One of the key benefits of this library is a Rust/ONNX Runtime stack with no PyT
 
 ### Video Support (FFmpeg)
 
-Video features require FFmpeg installed on your system. CI builds against FFmpeg 7.1 and 8.0;
-FFmpeg 6.1 also builds and runs:
+Video features require FFmpeg (6, 7 or 8) installed on your system:
 
 ```bash
 # macOS

--- a/README.md
+++ b/README.md
@@ -660,7 +660,8 @@ One of the key benefits of this library is a Rust/ONNX Runtime stack with no PyT
 
 ### Video Support (FFmpeg)
 
-Video features require FFmpeg (7 or 8) installed on your system:
+Video features require FFmpeg installed on your system. CI builds against FFmpeg 7.1 and 8.0;
+FFmpeg 6.1 also builds and runs:
 
 ```bash
 # macOS

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -646,7 +646,7 @@ JS/TS 封装与构建说明见 [`web/`](web/README.md)。需要支持 WebGPU 的
 
 ### 视频支持（FFmpeg）
 
-视频 features 需要系统安装 FFmpeg。CI 使用 FFmpeg 7.1 和 8.0 构建；FFmpeg 6.1 也可以构建和运行：
+视频 features 需要系统安装 FFmpeg（6、7 或 8）：
 
 ```bash
 # macOS

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -646,7 +646,7 @@ JS/TS 封装与构建说明见 [`web/`](web/README.md)。需要支持 WebGPU 的
 
 ### 视频支持（FFmpeg）
 
-视频 features 需要系统安装 FFmpeg（7 或 8）：
+视频 features 需要系统安装 FFmpeg。CI 使用 FFmpeg 7.1 和 8.0 构建；FFmpeg 6.1 也可以构建和运行：
 
 ```bash
 # macOS


### PR DESCRIPTION
The READMEs state that the video feature requires FFmpeg 7 or 8. FFmpeg 6.1 also builds and runs, so both now name the versions CI covers and record 6.1 as working.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📹 Expanded video support documentation to include FFmpeg 6.

### 📊 Key Changes

- Updated the English README to list FFmpeg versions 6, 7, and 8 as supported.
- Updated the Chinese README with the same FFmpeg compatibility information.
- No code changes were introduced.

### 🎯 Purpose & Impact

- ✅ Clarifies that users can use FFmpeg 6 for video features, in addition to versions 7 and 8.
- 🛠️ Improves setup guidance and reduces unnecessary upgrade requirements for users with FFmpeg 6 installed.
- 🌍 Keeps installation documentation consistent across English and Chinese versions.