### PR TITLE
Drop the divider banner from the YOLO26 end-to-end comment

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1268,7 +1268,7 @@ fn postprocess_obb(
     results
 }
 
-// -------- YOLO26 end-to-end (NMS-free) postprocessing --------
+// YOLO26 end-to-end (NMS-free) postprocessing.
 //
 // End-to-end exports bake NMS into the graph and produce a tensor of shape
 // `[B, max_det, 6 + extra]`, where the first 6 columns are always


### PR DESCRIPTION
The dashes around the section label were decoration only. The explanation of the end-to-end tensor layout below it is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Clarifies the comment introducing YOLO26 end-to-end, NMS-free postprocessing.

### 📊 Key Changes

- Simplified the section header comment in `src/postprocessing.rs`.
- Retained documentation describing end-to-end exports and their NMS-free output format.
- No code logic, API, or behavior changes were introduced.

### 🎯 Purpose & Impact

- 📖 Improves readability and consistency in the postprocessing source code.
- ✅ Helps developers quickly understand the YOLO26 end-to-end postprocessing section.
- 🚀 Has no direct impact on inference results, performance, or user-facing functionality.