### PR TITLE
Drop comments that restate the code they sit above

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -98,7 +98,6 @@ pub fn load_image(path: &str) -> image::ImageResult<DynamicImage> {
             }
         }
     }
-    // Fallback
     image::open(path)
 }
 /// Return the local path to `font`, downloading it from the Ultralytics asset CDN if absent.
@@ -122,7 +121,6 @@ pub fn check_font(font: &str) -> Option<PathBuf> {
         return None;
     }
 
-    // Download font
     let url = format!("{ASSETS_URL}/{font_name}");
     println!("Downloading {url} to {}", font_path.display());
 
@@ -206,7 +204,6 @@ pub fn annotate_image_with(
         "Arial.ttf"
     };
 
-    // Load font
     let font_path = check_font(font_name);
     let font_data = font_path.and_then(|path| {
         let mut file = File::open(path).ok()?;
@@ -219,7 +216,6 @@ pub fn annotate_image_with(
         .as_ref()
         .and_then(|data| FontRef::try_from_slice(data).ok());
 
-    // Draw all annotations using helpers
     draw_semantic_mask(&mut img, result);
     draw_detection(&mut img, result, font.as_ref());
     draw_pose(&mut img, result, None, None, None);
@@ -699,33 +695,20 @@ fn rect_intersect(r1: &Rect, r2: &Rect) -> bool {
 ///
 /// * `img` - The image to draw on
 /// * `result` - The inference results containing keypoints
-/// * `skeleton` - Optional custom skeleton structure (pairs of keypoint indices).
-///                If `None`, uses the default human pose skeleton from `SKELETON`.
-/// * `limb_colors` - Optional custom color indices for limbs.
-///                   If `None`, uses the default from `LIMB_COLOR_INDICES`.
-/// * `kpt_colors` - Optional custom color indices for keypoints.
-///                  If `None`, uses the default from `KPT_COLOR_INDICES`.
+/// * `skeleton` - Pairs of keypoint indices; `None` uses the human pose `SKELETON`.
+/// * `limb_colors` - Color indices for limbs; `None` uses `LIMB_COLOR_INDICES`.
+/// * `kpt_colors` - Color indices for keypoints; `None` uses `KPT_COLOR_INDICES`.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// // Use default human pose configuration
+/// // All `None` draws the default human pose.
 /// draw_pose(&mut img, result, None, None, None);
 ///
-/// // Use custom skeleton for animals
-/// const ANIMAL_SKELETON: [[usize; 2]; 10] = [...];
-/// const ANIMAL_LIMB_COLORS: [usize; 10] = [0, 0, 9, 9, ...];
-/// const ANIMAL_KPT_COLORS: [usize; 15] = [16, 16, 0, 0, ...];
-/// draw_pose(
-///     &mut img,
-///     result,
-///     Some(&ANIMAL_SKELETON),
-///     Some(&ANIMAL_LIMB_COLORS),
-///     Some(&ANIMAL_KPT_COLORS),
-/// );
+/// // Or supply a custom skeleton, for animal keypoints say.
+/// draw_pose(&mut img, result, Some(&SKELETON), Some(&LIMBS), Some(&KPTS));
 /// ```
 #[allow(
-    clippy::doc_overindented_list_items,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_precision_loss,

--- a/src/io.rs
+++ b/src/io.rs
@@ -16,8 +16,8 @@ static INIT: Once = Once::new();
 
 /// Initialize global video logging configuration.
 ///
-/// ensuring `video-rs` is initialized and `FFmpeg` logs are silenced
-/// (only errors are shown). safe to call multiple times.
+/// Ensures `video-rs` is initialized and `FFmpeg` logs are silenced (only errors
+/// are shown). Safe to call multiple times.
 #[allow(clippy::missing_const_for_fn)]
 pub fn init_logging() {
     #[cfg(feature = "video")]
@@ -92,7 +92,6 @@ impl VideoWriter {
     pub fn new<P: AsRef<Path>>(path: P, width: usize, height: usize, fps: f32) -> Result<Self> {
         let output_path = path.as_ref().to_path_buf();
 
-        // Ensure parent directory exists
         if let Some(parent) = output_path.parent() {
             ensure_dir(parent)?;
         }
@@ -102,7 +101,6 @@ impl VideoWriter {
             InferenceError::VideoError(format!("Failed to create video encoder: {e}"))
         })?;
 
-        // Calculate frame duration
         // video-rs uses a rational time base.
         // We can approximate by converting seconds to Time.
         let seconds_per_frame = 1.0 / f64::from(fps);
@@ -156,6 +154,7 @@ impl VideoWriter {
     ///
     /// Calling this explicitly is optional as `drop` will also clean up,
     /// but this allows catching errors.
+    ///
     /// # Errors
     ///
     /// Returns an error if the encoder fails to finish.
@@ -229,7 +228,6 @@ impl SaveResults {
         if save_as_video {
             #[cfg(feature = "video")]
             {
-                // Video saving logic
                 if self.video_writer.is_none() {
                     let filename = Path::new(&meta.path)
                         .file_name()
@@ -248,7 +246,6 @@ impl SaveResults {
                     let height = annotated.height() as usize;
                     let fps = meta.fps.unwrap_or(30.0);
 
-                    // Ensure directory exists
                     if let Some(parent) = save_path.parent() {
                         ensure_dir(parent)?;
                     }
@@ -261,7 +258,6 @@ impl SaveResults {
                 }
             }
         } else {
-            // Image saving logic
             let (save_dir, filename) = if is_video {
                 // For video sources, create a subfolder: {video_name}_frames/
                 let video_stem = Path::new(&meta.path)
@@ -283,7 +279,6 @@ impl SaveResults {
 
             let save_path = save_dir.join(filename);
 
-            // Ensure directory exists
             ensure_dir(&save_dir)?;
 
             annotated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,6 @@
 #[doc = include_str!("../docs/CUDA.md")]
 pub mod cuda_guide {}
 
-// Modules
 #[cfg(feature = "annotate")]
 pub mod annotate;
 pub mod device;
@@ -411,22 +410,17 @@ pub mod results;
 pub mod task;
 pub mod utils;
 
-// Re-export main types for convenience
 pub use device::Device;
 pub use error::{InferenceError, Result};
 pub use inference::InferenceConfig;
+pub use metadata::ModelMetadata;
 #[cfg(not(target_arch = "wasm32"))]
 pub use model::YOLOModel;
+pub use preprocessing::{PreprocessResult, preprocess_image, preprocess_image_with_precision};
 pub use results::{Boxes, DepthMap, Keypoints, Masks, Obb, Probs, Results, SemanticMask, Speed};
 #[cfg(not(target_arch = "wasm32"))]
 pub use source::{Source, SourceIterator, SourceMeta};
 pub use task::Task;
-
-// Re-export metadata for advanced use
-pub use metadata::ModelMetadata;
-
-// Re-export preprocessing utilities
-pub use preprocessing::{PreprocessResult, preprocess_image, preprocess_image_with_precision};
 
 /// Library version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Removes section banners in the crate root and comments that repeat the line below them, and reflows the `draw_pose` doc so the `doc_overindented_list_items` allow is no longer needed. Also fixes a lowercase sentence and a missing blank line before an `# Errors` heading in `io.rs`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Streamlines Rust documentation and comments while organizing public API re-exports without changing inference behavior.

### 📊 Key Changes

- Removed redundant inline comments across annotation, video I/O, saving, and library modules.
- Simplified and clarified `draw_pose` documentation, including custom skeleton usage examples.
- Improved formatting and wording in `init_logging` and `VideoWriter::finish` documentation.
- Reorganized public re-exports in `lib.rs`, keeping metadata and preprocessing utilities clearly exposed.
- No functional changes were made to image annotation, video writing, inference, or result saving.

### 🎯 Purpose & Impact

- 📖 Makes the codebase cleaner and easier to read and maintain.
- 🧭 Improves API documentation for developers using pose annotation helpers.
- 📦 Preserves convenient access to key public types and preprocessing functions.
- ✅ Low-risk update with no expected impact on existing inference results or runtime behavior.