### PR TITLE
Make the CUDA guide links absolute so they work on docs.rs and GitHub

### DIFF
--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -8,7 +8,7 @@
 | `tensorrt`        | ORT TensorRT EP (FP16, engine cache, opt-level 5)   | NVIDIA GPU with TensorRT installed; 2–3× faster than `cuda`                                      |
 | `cuda-preprocess` | GPU-side preprocess + zero-copy device input to TRT | maximum throughput; `YOLOModel::predict_image` transparently uses a fused CUDA preprocess kernel |
 
-`cuda-preprocess` implies `cuda` + `tensorrt`. When it's compiled in, no API change is required - `YOLOModel::predict_image` automatically routes through the GPU preprocess path on CUDA/TensorRT devices. Opt out per-model with [`InferenceConfig::with_cuda_preprocess(false)`](crate::InferenceConfig::with_cuda_preprocess).
+`cuda-preprocess` implies `cuda` + `tensorrt`. When it's compiled in, no API change is required - `YOLOModel::predict_image` automatically routes through the GPU preprocess path on CUDA/TensorRT devices. Opt out per-model with [`InferenceConfig::with_cuda_preprocess(false)`](https://docs.rs/ultralytics-inference/latest/ultralytics_inference/inference/struct.InferenceConfig.html#method.with_cuda_preprocess).
 
 ## Requirements
 
@@ -214,12 +214,12 @@ axis. A model whose input pins `[16, 3, 640, 640]` cannot run at `--batch 1`.
 
 ## Troubleshooting
 
-| Symptom                                                                    | Fix                                                                                                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).                                                    |
-| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.                                                 |
-| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                                                          |
-| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                                                           |
-| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.                                                   |
-| CUDA EP fails to load on a CUDA 12 system                                  | The downloaded binaries are CUDA 13 and no CUDA 12 build is published. Compile ONNX Runtime for CUDA 12 and link it with `ORT_LIB_PATH`. |
-| `no builds available that satisfy the requested feature set` on aarch64    | Only a CPU distribution is published for `aarch64-unknown-linux-gnu`. Link a GPU ONNX Runtime yourself, see [DGX.md](DGX.md).            |
+| Symptom                                                                    | Fix                                                                                                                                                                                   |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ``cudarc-* build script failed: `nvcc --version` failed``                  | Set `PATH` to include the toolkit's `bin/`, or set `CUDARC_CUDA_VERSION` (see above).                                                                                                 |
+| `libcudart.so.13: cannot open shared object file`                          | Toolkit not installed or not on `ld.so` path. Verify `ldconfig -p \| grep libcudart.so`.                                                                                              |
+| `libnvinfer.so.10: cannot open shared object file`                         | TensorRT not installed. Required for `tensorrt` and `cuda-preprocess` features.                                                                                                       |
+| TRT engine build is slow on first run                                      | Expected - engines are cached under `.trt_cache/`. Subsequent runs reuse them.                                                                                                        |
+| Build hits `Must specify one of the following features: [cuda-13020, ...]` | Your environment has neither `nvcc` on `PATH` nor `CUDARC_CUDA_VERSION` set. Pick one.                                                                                                |
+| CUDA EP fails to load on a CUDA 12 system                                  | The downloaded binaries are CUDA 13 and no CUDA 12 build is published. Compile ONNX Runtime for CUDA 12 and link it with `ORT_LIB_PATH`.                                              |
+| `no builds available that satisfy the requested feature set` on aarch64    | Only a CPU distribution is published for `aarch64-unknown-linux-gnu`. Link a GPU ONNX Runtime yourself, see [DGX.md](https://github.com/ultralytics/inference/blob/main/docs/DGX.md). |


### PR DESCRIPTION
`docs/CUDA.md` is rendered both on GitHub and, via `include_str!`, as `crate::cuda_guide` on docs.rs. The intra-doc link resolved only on docs.rs and the `DGX.md` link only on GitHub, so each was broken in one of the two. Absolute URLs work in both.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔗 Updated CUDA documentation links to use reliable, fully qualified destinations.

### 📊 Key Changes

- Replaced the relative Rust API link for `InferenceConfig::with_cuda_preprocess(false)` with its canonical [docs.rs API documentation](https://docs.rs/ultralytics-inference/latest/ultralytics_inference/inference/struct.InferenceConfig.html#method.with_cuda_preprocess).
- Updated the `DGX.md` troubleshooting link to point directly to the [GitHub documentation file](https://github.com/ultralytics/inference/blob/main/docs/DGX.md).
- Adjusted troubleshooting table spacing for improved Markdown formatting and readability.

### 🎯 Purpose & Impact

- ✅ Makes CUDA setup and troubleshooting documentation links more dependable across different viewing environments.
- 🧭 Helps users quickly find the API reference and DGX guidance they need.
- 📖 Improves documentation consistency without changing CUDA functionality or user-facing APIs.