### PR TITLE
Render the DGX Spark guide on docs.rs

### DIFF
--- a/docs/DGX.md
+++ b/docs/DGX.md
@@ -18,7 +18,7 @@ This is the first thing to know, because the failure looks like a local misconfi
 distribution is published. Building with `--features cuda`, `tensorrt`, `cuda-preprocess` or
 `xnnpack` fails at link time:
 
-```
+```text
 = note: some `extern` functions couldn't be found
 
   !!! The ort-sys crate did not download prebuilt binaries because there are no builds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@
 //! See the [CUDA / `TensorRT` acceleration guide](crate::cuda_guide) for setup,
 //! requirements, and the zero-copy GPU preprocess fast path.
 //!
+//! On aarch64 no GPU build is published; see the [DGX Spark guide](crate::dgx_guide).
+//!
 //! Enable hardware acceleration with Cargo features:
 //!
 //! ```bash
@@ -356,6 +358,11 @@
 //! This project is dual-licensed under [AGPL-3.0](https://github.com/ultralytics/inference/blob/main/LICENSE)
 //! for open-source use or [Ultralytics Enterprise License](https://ultralytics.com/license)
 //! for commercial applications.
+
+/// DGX Spark (aarch64) setup guide rendered from `docs/DGX.md`.
+#[allow(clippy::doc_markdown)]
+#[doc = include_str!("../docs/DGX.md")]
+pub mod dgx_guide {}
 
 /// CUDA / `TensorRT` acceleration guide rendered from `docs/CUDA.md`.
 #[allow(clippy::doc_markdown)]


### PR DESCRIPTION
`docs/DGX.md` was GitHub-only. Tagging its one untagged code fence stops rustdoc compiling a linker error message as a doctest, which is all that stood in the way of including it as `crate::dgx_guide` next to `crate::cuda_guide`. Its links were already absolute, so it renders correctly in both places.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Adds an integrated DGX Spark setup guide to the Rust API documentation and clarifies aarch64 GPU build limitations.

### 📊 Key Changes

- Adds a `dgx_guide` documentation module that renders content from `docs/DGX.md`.
- Links users to the DGX Spark guide when using aarch64 systems without published GPU builds.
- Updates the DGX documentation code block to use the `text` syntax for clearer rendering.

### 🎯 Purpose & Impact

- 🛠️ Makes DGX Spark setup instructions discoverable directly from the generated Rust documentation.
- 🚧 Clearly explains that no aarch64 GPU build is currently published, helping users understand related build failures.
- 📖 Improves documentation consistency and reduces confusion when enabling CUDA, TensorRT, or preprocessing acceleration features.