### PR TITLE
Document depth as a supported LiteRT.js task

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -299,7 +299,7 @@ Notes:
   If you load an end2end `.tflite` anyway, the backend auto-switches it to wasm
   (slower) and logs a warning rather than returning empty results.
 
-- **Tasks**: detect, segment, pose, obb, classify, and semantic are all supported.
+- **Tasks**: detect, segment, pose, obb, classify, semantic, and depth are all supported.
 - **Cross-origin isolation**: LiteRT's threaded wasm wants `SharedArrayBuffer`,
   so serve with `Cross-Origin-Opener-Policy: same-origin` and
   `Cross-Origin-Embedder-Policy: require-corp`.

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -274,7 +274,7 @@ wasm 默认从 jsDelivr CDN 加载；向 `YOLO.load` 传入 `litertWasmUrl: "/li
 
   如果仍然加载了 end2end 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
 
-- **支持的任务**：detect、segment、pose、obb、classify 和 semantic 均已支持。
+- **支持的任务**：detect、segment、pose、obb、classify、semantic 和 depth 均已支持。
 - **跨源隔离**：LiteRT 的多线程 wasm 需要 `SharedArrayBuffer`，因此请以
   `Cross-Origin-Opener-Policy: same-origin` 和 `Cross-Origin-Embedder-Policy: require-corp`
   提供服务。


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Updated web inference documentation to include depth estimation as a supported task.

### 📊 Key Changes
- Added **depth** to the supported task lists in:
  - `web/README.md`
  - `web/README.zh-CN.md`
- Kept the English and Simplified Chinese documentation aligned.

### 🎯 Purpose & Impact
- ✅ Informs users that web inference supports depth models alongside detection, segmentation, pose, OBB, classification, and semantic tasks.
- 🌐 Improves documentation accuracy for both English- and Chinese-speaking users.
- 🚀 Helps users discover and adopt depth estimation capabilities in the web inference package.