### PR TITLE
Release 0.0.34 with GPU batch letterbox, preprocessing hardening, and DGX Spark docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.33"
+version = "0.0.34"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.33 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -235,7 +235,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.33 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -332,7 +332,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.33"
+ultralytics-inference = "0.0.34"
 ```
 
 ```toml
@@ -548,7 +548,7 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.33", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.34", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,7 +214,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.33 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -234,7 +234,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.33 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -331,7 +331,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.33"
+ultralytics-inference = "0.0.34"
 ```
 
 ```toml
@@ -544,7 +544,7 @@ cargo build --release --features "cuda,tensorrt"
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.33", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.34", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.33"
+version = "0.0.34"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -35,9 +35,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.33", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.34", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.33", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.34", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -67,7 +67,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.33", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.34", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Bumps the Ultralytics inference packages from `0.0.33` to `0.0.34` across Rust, WebAssembly, and browser distributions.

### 📊 Key Changes

- Updated the core Rust crate version to `0.0.34`.
- Updated the WebAssembly bindings crate to `0.0.34`.
- Updated the browser package `@ultralytics/yolo` to `0.0.34`.
- Refreshed English and Chinese documentation examples to reference the new release.
- Updated CUDA, TensorRT, CoreML, and XNNPACK dependency examples to use `0.0.34`.
- Regenerated dependency lockfiles, including `Cargo.lock` and `web/package-lock.json`.

### 🎯 Purpose & Impact

- 📦 Publishes a consistent version across all inference package targets.
- 🧩 Ensures users copying installation instructions receive the latest release.
- 🌐 Keeps Rust, WebAssembly, and browser integrations aligned.
- ✅ This is primarily a release and documentation update; no functional inference or model behavior changes are shown in the diff.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
