### PR TITLE
Remove the ArmNN feature, deleted from ONNX Runtime upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,6 @@ qnn = ["ort/qnn"]       # Qualcomm
 # Additional accelerators
 xnnpack = ["ort/xnnpack"]
 acl = ["ort/acl"]           # ARM Compute Library
-armnn = ["ort/armnn"]       # ARM NN
 tvm = ["ort/tvm"]           # Apache TVM
 migraphx = ["ort/migraphx"] # AMD MIGraphX
 rknpu = ["ort/rknpu"]       # Rockchip NPU

--- a/README.md
+++ b/README.md
@@ -578,7 +578,6 @@ Default features (enabled unless `--no-default-features` is passed): `annotate`,
 | `qnn`             | Qualcomm Neural Networks                                                                              |
 | `xnnpack`         | XNNPACK (cross-platform)                                                                              |
 | `acl`             | ARM Compute Library                                                                                   |
-| `armnn`           | ARM NN                                                                                                |
 | `tvm`             | Apache TVM                                                                                            |
 | `rknpu`           | Rockchip NPU                                                                                          |
 | `cann`            | Huawei CANN                                                                                           |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -574,7 +574,6 @@ ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 | `qnn`             | Qualcomm Neural Networks                                                                 |
 | `xnnpack`         | XNNPACK（跨平台）                                                                        |
 | `acl`             | ARM Compute Library                                                                      |
-| `armnn`           | ARM NN                                                                                   |
 | `tvm`             | Apache TVM                                                                               |
 | `rknpu`           | Rockchip NPU                                                                             |
 | `cann`            | Huawei CANN                                                                              |

--- a/docs/DGX.md
+++ b/docs/DGX.md
@@ -100,7 +100,7 @@ The prebuilt wheel above covers the CUDA and TensorRT providers, which is what t
 features need. Building ONNX Runtime yourself is only worth it when you need something the wheel
 does not contain, for example:
 
-- an execution provider it was not built with, such as `xnnpack`, `acl` or `armnn`,
+- an execution provider it was not built with, such as `xnnpack` or `acl`,
 - a CUDA version other than the one it targets (13.0 here),
 - a newer ONNX Runtime than the published wheels.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,6 @@
 //! | `qnn` | Qualcomm Neural Networks |
 //! | `xnnpack` | XNNPACK (cross-platform) |
 //! | `acl` | ARM Compute Library |
-//! | `armnn` | ARM NN |
 //! | `tvm` | Apache TVM |
 //! | `rknpu` | Rockchip NPU |
 //! | `cann` | Huawei CANN |


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Removes the deprecated ARM NN execution provider feature from the inference library and its documentation.

### 📊 Key Changes

- Deleted the `armnn` Cargo feature and its connection to ONNX Runtime.
- Removed ARM NN from the supported execution-provider lists in:
  - `README.md`
  - `README.zh-CN.md`
  - Rust library documentation in `src/lib.rs`
- Updated DGX build guidance to no longer reference ARM NN as a supported custom provider.

### 🎯 Purpose & Impact

- 🧹 Keeps configuration and documentation aligned with the currently supported execution providers.
- ⚙️ Prevents users from attempting to enable an unavailable or unsupported ARM NN backend.
- 📚 Improves clarity for developers building the inference library, while leaving other providers such as XNNPACK and ARM Compute Library unaffected.