### PR TITLE
Report cpu when WebGPU is requested but no adapter exists

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -149,31 +149,15 @@ export interface LoadOptions {
 }
 
 /**
- * Resolve the device string passed to wasm. `"cpu"` is honored as-is; every
- * other choice requires a real WebGPU adapter, so `YOLO.device` reports what
- * actually ran.
- *
- * `"webgpu"` is verified rather than trusted: `navigator.gpu` can exist while
- * `requestAdapter()` still resolves to `null` (Chrome on Linux without its
- * Vulkan backend, for one). Returning `"webgpu"` there would make `YOLO.device`
- * claim the GPU ran while the engine quietly executed on CPU — a ~100x
- * slowdown with nothing on screen to explain it.
+ * Resolve the device string passed to wasm. `"cpu"` is honored as-is; anything else
+ * needs a real adapter, since `navigator.gpu` can exist while `requestAdapter()`
+ * still returns `null` — so `YOLO.device` reports what actually ran.
  */
 async function resolveDevice(pref?: "auto" | "webgpu" | "cpu"): Promise<string> {
   if (pref === "cpu") return "cpu";
   const gpu = (navigator as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
-  let adapter: unknown = null;
-  if (gpu) {
-    try {
-      adapter = await gpu.requestAdapter();
-    } catch {
-      adapter = null;
-    }
-  }
-  if (adapter) return "webgpu";
-  if (pref === "webgpu") {
-    console.warn("[@ultralytics/yolo] WebGPU requested but no adapter is available; running on CPU.");
-  }
+  if (await gpu?.requestAdapter().catch(() => null)) return "webgpu";
+  if (pref === "webgpu") console.warn("[@ultralytics/yolo] WebGPU requested but no adapter found; running on CPU.");
   return "cpu";
 }
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -149,18 +149,32 @@ export interface LoadOptions {
 }
 
 /**
- * Resolve the device string passed to wasm. An explicit choice is honored;
- * `"auto"` feature-detects a WebGPU adapter and otherwise falls back to CPU.
+ * Resolve the device string passed to wasm. `"cpu"` is honored as-is; every
+ * other choice requires a real WebGPU adapter, so `YOLO.device` reports what
+ * actually ran.
+ *
+ * `"webgpu"` is verified rather than trusted: `navigator.gpu` can exist while
+ * `requestAdapter()` still resolves to `null` (Chrome on Linux without its
+ * Vulkan backend, for one). Returning `"webgpu"` there would make `YOLO.device`
+ * claim the GPU ran while the engine quietly executed on CPU — a ~100x
+ * slowdown with nothing on screen to explain it.
  */
 async function resolveDevice(pref?: "auto" | "webgpu" | "cpu"): Promise<string> {
-  if (pref === "cpu" || pref === "webgpu") return pref;
+  if (pref === "cpu") return "cpu";
   const gpu = (navigator as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
-  if (!gpu) return "cpu";
-  try {
-    return (await gpu.requestAdapter()) ? "webgpu" : "cpu";
-  } catch {
-    return "cpu";
+  let adapter: unknown = null;
+  if (gpu) {
+    try {
+      adapter = await gpu.requestAdapter();
+    } catch {
+      adapter = null;
+    }
   }
+  if (adapter) return "webgpu";
+  if (pref === "webgpu") {
+    console.warn("[@ultralytics/yolo] WebGPU requested but no adapter is available; running on CPU.");
+  }
+  return "cpu";
 }
 
 /** Ultralytics model assets release (ONNX exports of yolo26 / yolo11 / yolov8). */


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved WebGPU device detection to accurately report the device actually used by the inference runtime. ⚙️

### 📊 Key Changes

- `"cpu"` requests continue to use the CPU directly.
- `"auto"` and `"webgpu"` now verify that a usable WebGPU adapter is available.
- Falls back to CPU when `requestAdapter()` fails or returns no adapter.
- Adds a warning when WebGPU is explicitly requested but unavailable.
- Removes the previous behavior that trusted the presence of `navigator.gpu` alone.

### 🎯 Purpose & Impact

- ✅ Prevents incorrect WebGPU status reporting when browser support exists but no adapter is available.
- 🖥️ Ensures `YOLO.device` reflects the device actually used for inference.
- 🛡️ Maintains reliable CPU fallback behavior across unsupported or restricted environments.
- 🔔 Gives developers clear feedback when a requested WebGPU device cannot be used.