### PR TITLE
Document cuda-preprocess in the library feature table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@
 //! | `video` | Video file decoding/encoding (requires `FFmpeg`) |
 //! | `cuda` | NVIDIA CUDA acceleration |
 //! | `tensorrt` | NVIDIA `TensorRT` optimization |
+//! | `cuda-preprocess` | GPU preprocessing with zero-copy `TensorRT` input |
 //! | `coreml` | Apple `CoreML` (macOS/iOS) |
 //! | `openvino` | Intel `OpenVINO` |
 //! | `onednn` | Intel oneDNN |


### PR DESCRIPTION
The `cuda-preprocess` feature is listed in `Cargo.toml`, `README.md`, and `README.zh-CN.md`, but was missing from the feature table in the crate docs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the crate documentation feature table to include the existing `cuda-preprocess` feature and describe its GPU preprocessing capability.

### 📊 Key Changes
- Added `cuda-preprocess` to the feature table in `src/lib.rs`.
- Documented it as providing GPU preprocessing with zero-copy `TensorRT` input.
- No code or feature configuration was changed.

### 🎯 Purpose & Impact
- The crate documentation now matches the feature listings already present in `Cargo.toml`, `README.md`, and `README.zh-CN.md`.
- No user-facing behavior change.