### PR TITLE
Drop the stale git source allowances from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -83,7 +83,3 @@ deny = [
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/pykeio/ort.git"]
-
-[sources.allow-org]
-github = ["ultralytics"]


### PR DESCRIPTION
`Cargo.lock` resolves every dependency from crates.io and contains no git sources, so the `allow-git` entry for the ort repository and the `sources.allow-org` block for ultralytics no longer apply to anything.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed obsolete Git source allowances from `deny.toml` because the current `Cargo.lock` contains no Git-based dependencies.

### 📊 Key Changes
- Deleted the `allow-git` entry for `https://github.com/pykeio/ort.git`.
- Removed the `[sources.allow-org]` configuration that allowed GitHub sources under `ultralytics`.
- Retained the existing crates.io registry configuration and warnings for unknown registries and Git sources.

### 🎯 Purpose & Impact
- Dependency source validation no longer permits the unused `ort` Git repository or Ultralytics GitHub sources.
- No user-facing change.