### PR TITLE
Delete the success and section log macros that nothing calls

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -43,33 +43,12 @@ macro_rules! error {
     }
 }
 
-/// Macro for success messages.
-#[macro_export]
-macro_rules! success {
-    ($($arg:tt)*) => {
-        use colored::Colorize;
-        println!("{} {}", "SUCCESS ✅".green().bold(), format!($($arg)*));
-    }
-}
-
 /// Macro for verbose messages.
 #[macro_export]
 macro_rules! verbose {
     ($($arg:tt)*) => {
         if $crate::logging::is_verbose() {
             println!("{}", format!($($arg)*));
-        }
-    }
-}
-
-/// Macro for section headers.
-#[macro_export]
-macro_rules! section {
-    ($($arg:tt)*) => {
-        use colored::Colorize;
-        if $crate::logging::is_verbose() {
-            println!();
-            println!("{}", format!($($arg)*).cyan().bold());
         }
     }
 }


### PR DESCRIPTION
Neither macro has a single call site in `src`, `crates`, `examples`, `tests`, the READMEs, or `docs`; `info!`, `warn!`, `error!`, and `verbose!` are the ones actually in use. Both are `#[macro_export]`ed, so they are reachable as `ultralytics_inference::success!` and `ultralytics_inference::section!` by downstream crates even though nothing here uses them.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed the unused exported `success!` and `section!` logging macros from `src/logging.rs` to eliminate unreferenced API surface.

### 📊 Key Changes
- Deleted the `success!` macro, which printed bold green success messages.
- Deleted the `section!` macro, which conditionally printed bold cyan section headers in verbose mode.
- Retained the actively used `info!`, `warn!`, `error!`, and `verbose!` logging macros.

### 🎯 Purpose & Impact
- Downstream crates can no longer use `ultralytics_inference::success!` or `ultralytics_inference::section!`.
- No behavior changes for the repository’s existing call sites, since neither macro had any usages.