### PR TITLE
Release 0.0.35 with faster OpenVINO model loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.34"
+version = "0.0.35"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.35 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -235,7 +235,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.35 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -332,7 +332,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.34"
+ultralytics-inference = "0.0.35"
 ```
 
 ```toml
@@ -548,7 +548,7 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.34", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.35", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,7 +214,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.35 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -234,7 +234,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.34 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.35 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -331,7 +331,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.34"
+ultralytics-inference = "0.0.35"
 ```
 
 ```toml
@@ -544,7 +544,7 @@ cargo build --release --features "cuda,tensorrt"
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.34", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.35", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.34"
+version = "0.0.35"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -35,9 +35,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.34", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.35", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.34", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.35", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -67,7 +67,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.34", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.35", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/src/io.rs
+++ b/src/io.rs
@@ -52,15 +52,28 @@ pub(crate) fn ensure_dir(path: &Path) -> Result<()> {
 ///
 /// Probes with a real file, since permission bits miss ownership, ACLs and read-only mounts.
 /// Execution providers fail model loading on a cache path they cannot write, rather than skip it.
+///
+/// `create_new` never truncates and never follows a symlink, so a name clash leaves the existing
+/// file untouched and only the probe this call created is removed.
 #[cfg(any(feature = "openvino", feature = "tensorrt", feature = "coreml"))]
 pub(crate) fn is_writable_dir(path: &Path) -> bool {
     if ensure_dir(path).is_err() {
         return false;
     }
-    let probe = path.join(format!(".write-probe-{}", std::process::id()));
-    let writable = std::fs::File::create(&probe).is_ok();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
+    let probe = path.join(format!(".write-probe-{}-{nonce}", std::process::id()));
+    if std::fs::File::options()
+        .create_new(true)
+        .write(true)
+        .open(&probe)
+        .is_err()
+    {
+        return false;
+    }
     let _ = std::fs::remove_file(&probe);
-    writable
+    true
 }
 
 /// Return the next available run directory, e.g. `runs/detect/predict`, then `predict2`, `predict3`, ...
@@ -321,6 +334,36 @@ impl SaveResults {
 mod tests {
     use super::*;
     use crate::source::SourceMeta;
+
+    /// Truncation safety itself is guaranteed by `create_new`; what is asserted here is the
+    /// observable contract the execution providers rely on, including the read-only case that
+    /// otherwise turns into a model load failure.
+    #[cfg(any(feature = "openvino", feature = "tensorrt", feature = "coreml"))]
+    #[test]
+    fn test_is_writable_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("cache");
+
+        // Creates the directory, reports writable, and leaves no probe behind.
+        assert!(is_writable_dir(&dir));
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 0);
+
+        // Existing contents survive untouched.
+        let existing = dir.join("model.blob");
+        std::fs::write(&existing, b"precious").unwrap();
+        assert!(is_writable_dir(&dir));
+        assert_eq!(std::fs::read(&existing).unwrap(), b"precious");
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+
+        // An existing but read-only directory reports false rather than being handed to a provider.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+            assert!(!is_writable_dir(&dir));
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
 
     #[test]
     fn test_ensure_dir_creates_nested() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -48,6 +48,21 @@ pub(crate) fn ensure_dir(path: &Path) -> Result<()> {
     })
 }
 
+/// Create `path` if needed and report whether a file can actually be written into it.
+///
+/// Probes with a real file, since permission bits miss ownership, ACLs and read-only mounts.
+/// Execution providers fail model loading on a cache path they cannot write, rather than skip it.
+#[cfg(any(feature = "openvino", feature = "tensorrt", feature = "coreml"))]
+pub(crate) fn is_writable_dir(path: &Path) -> bool {
+    if ensure_dir(path).is_err() {
+        return false;
+    }
+    let probe = path.join(format!(".write-probe-{}", std::process::id()));
+    let writable = std::fs::File::create(&probe).is_ok();
+    let _ = std::fs::remove_file(&probe);
+    writable
+}
+
 /// Return the next available run directory, e.g. `runs/detect/predict`, then `predict2`, `predict3`, ...
 #[must_use]
 pub fn find_next_run_dir(base: &str, prefix: &str) -> String {

--- a/src/model.rs
+++ b/src/model.rs
@@ -565,17 +565,19 @@ impl YOLOModel {
         let parent = model_path.parent().unwrap_or_else(|| Path::new("."));
         let suffix = if fp16 { "fp16" } else { "fp32" };
         let cache_dir = parent.join(".trt_cache").join(format!("{stem}_{suffix}"));
-        let _ = std::fs::create_dir_all(&cache_dir);
-        let cache_str = cache_dir.to_string_lossy().into_owned();
-        let ep = ort::ep::TensorRT::default()
+        let mut ep = ort::ep::TensorRT::default()
             .with_device_id(device_id)
             .with_fp16(fp16)
-            .with_engine_cache(true)
-            .with_engine_cache_path(cache_str.clone())
-            .with_timing_cache(true)
-            .with_timing_cache_path(cache_str)
             .with_max_workspace_size(4 * 1024 * 1024 * 1024)
             .with_builder_optimization_level(5);
+        if crate::io::is_writable_dir(&cache_dir) {
+            let cache_str = cache_dir.to_string_lossy().into_owned();
+            ep = ep
+                .with_engine_cache(true)
+                .with_engine_cache_path(cache_str.clone())
+                .with_timing_cache(true)
+                .with_timing_cache_path(cache_str);
+        }
 
         bind_compute_stream!(ep, compute_stream)
     }
@@ -626,7 +628,7 @@ impl YOLOModel {
                 .join("ultralytics-inference")
                 .join("coreml")
                 .join(format!("{stem}_{hash:016x}_{ort_build:016x}_mlprogram"));
-            if std::fs::create_dir_all(&cache_dir).is_ok() {
+            if crate::io::is_writable_dir(&cache_dir) {
                 ep = ep.with_model_cache_dir(cache_dir.to_string_lossy());
             }
         }
@@ -642,8 +644,8 @@ impl YOLOModel {
     /// those knobs was measured to be a no-op at best and a regression on hybrid CPUs at worst.
     ///
     /// `device_type` is `None` when no device was requested, leaving the choice to `OpenVINO`.
-    /// The cache is only passed once its directory exists, since `OpenVINO` fails compilation on a
-    /// `CACHE_DIR` it cannot open, which would break models in read-only directories.
+    /// The cache is only passed once its directory is writable, since the GPU plugin fails
+    /// compilation on a `CACHE_DIR` it cannot write.
     #[cfg(feature = "openvino")]
     fn build_openvino_ep(
         model_path: &Path,
@@ -660,7 +662,7 @@ impl YOLOModel {
         if let Some(device_type) = device_type {
             ep = ep.with_device_type(device_type);
         }
-        if std::fs::create_dir_all(&cache_dir).is_ok() {
+        if crate::io::is_writable_dir(&cache_dir) {
             ep = ep.with_cache_dir(cache_dir.to_string_lossy());
         }
         ep.build()

--- a/src/model.rs
+++ b/src/model.rs
@@ -265,7 +265,7 @@ impl YOLOModel {
                         _ => "CPU",
                     };
                     eps.push((
-                        Self::build_openvino_ep(path, dt),
+                        Self::build_openvino_ep(path, Some(dt)),
                         "OpenVINOExecutionProvider",
                     ));
                 }
@@ -312,7 +312,7 @@ impl YOLOModel {
 
             #[cfg(feature = "openvino")]
             eps.push((
-                ort::ep::OpenVINO::default().build(),
+                Self::build_openvino_ep(path, None),
                 "OpenVINOExecutionProvider",
             ));
 
@@ -640,24 +640,27 @@ impl YOLOModel {
     /// `OpenVINO`'s defaults, which already pick the optimal low-latency configuration for a
     /// single-stream batch-1 workload (GPU runs FP16, one stream, auto thread scheduling). Forcing
     /// those knobs was measured to be a no-op at best and a regression on hybrid CPUs at worst.
+    ///
+    /// `device_type` is `None` when no device was requested, which leaves the choice to
+    /// `OpenVINO`'s own default. The cache still applies in that case, under a `_default` suffix.
     #[cfg(feature = "openvino")]
     fn build_openvino_ep(
         model_path: &Path,
-        device_type: &str,
+        device_type: Option<&str>,
     ) -> ort::ep::ExecutionProviderDispatch {
         let stem = model_path
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("model");
         let parent = model_path.parent().unwrap_or_else(|| Path::new("."));
-        let cache_dir = parent
-            .join(".ov_cache")
-            .join(format!("{stem}_{}", device_type.to_ascii_lowercase()));
+        let suffix = device_type.map_or_else(|| "default".to_owned(), str::to_ascii_lowercase);
+        let cache_dir = parent.join(".ov_cache").join(format!("{stem}_{suffix}"));
         let _ = std::fs::create_dir_all(&cache_dir);
-        ort::ep::OpenVINO::default()
-            .with_device_type(device_type)
-            .with_cache_dir(cache_dir.to_string_lossy())
-            .build()
+        let mut ep = ort::ep::OpenVINO::default();
+        if let Some(device_type) = device_type {
+            ep = ep.with_device_type(device_type);
+        }
+        ep.with_cache_dir(cache_dir.to_string_lossy()).build()
     }
 
     /// Distribute the elapsed wall time since `start` evenly across every result in the

--- a/src/model.rs
+++ b/src/model.rs
@@ -641,8 +641,9 @@ impl YOLOModel {
     /// single-stream batch-1 workload (GPU runs FP16, one stream, auto thread scheduling). Forcing
     /// those knobs was measured to be a no-op at best and a regression on hybrid CPUs at worst.
     ///
-    /// `device_type` is `None` when no device was requested, which leaves the choice to
-    /// `OpenVINO`'s own default. The cache still applies in that case, under a `_default` suffix.
+    /// `device_type` is `None` when no device was requested, leaving the choice to `OpenVINO`.
+    /// The cache is only passed once its directory exists, since `OpenVINO` fails compilation on a
+    /// `CACHE_DIR` it cannot open, which would break models in read-only directories.
     #[cfg(feature = "openvino")]
     fn build_openvino_ep(
         model_path: &Path,
@@ -655,12 +656,14 @@ impl YOLOModel {
         let parent = model_path.parent().unwrap_or_else(|| Path::new("."));
         let suffix = device_type.map_or_else(|| "default".to_owned(), str::to_ascii_lowercase);
         let cache_dir = parent.join(".ov_cache").join(format!("{stem}_{suffix}"));
-        let _ = std::fs::create_dir_all(&cache_dir);
         let mut ep = ort::ep::OpenVINO::default();
         if let Some(device_type) = device_type {
             ep = ep.with_device_type(device_type);
         }
-        ep.with_cache_dir(cache_dir.to_string_lossy()).build()
+        if std::fs::create_dir_all(&cache_dir).is_ok() {
+            ep = ep.with_cache_dir(cache_dir.to_string_lossy());
+        }
+        ep.build()
     }
 
     /// Distribute the elapsed wall time since `start` evenly across every result in the

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The default device path registered a bare OpenVINO EP, so it recompiled the model on every process start while TensorRT and CoreML both got their caches there. Measured on an Intel iGPU host with an OpenVINO enabled ONNX Runtime, default path, caches warm: 690/692/704ms before, 537/540/539ms after, so roughly 155ms off every run.

The cache directory is only passed to OpenVINO once it exists, since OpenVINO fails compilation on a CACHE_DIR it cannot open. That also fixes models loaded from read-only directories with intel:cpu and intel:gpu, which failed before this PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Released version 0.0.35 with writable-cache detection and persistent caching for OpenVINO, while applying the same safety check to TensorRT and CoreML cache paths.

### 📊 Key Changes
- The default OpenVINO execution-provider path now uses a `.ov_cache` directory and only configures it when the directory is writable.
- Explicit OpenVINO device paths retain their device selection and use device-specific cache directories when writable.
- TensorRT and CoreML caches are now configured only after a real file-write probe succeeds.
- Added `is_writable_dir()` and tests covering directory creation, probe cleanup, preservation of existing files, and read-only directories.
- Bumped the Rust package, web package, and documented dependency versions from 0.0.34 to 0.0.35.

### 🎯 Purpose & Impact
- OpenVINO models on the default path can reuse compiled model caches between process starts, reducing the measured startup time by roughly 155 ms with warm caches.
- Models in read-only directories using `intel:cpu` or `intel:gpu` no longer receive an unusable OpenVINO cache path.
- TensorRT and CoreML avoid being given cache directories that cannot accept writes.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
