### PR TITLE
Harden Rust CI cache boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          cache-targets: false
+          prefix-key: v1-rust
           key: xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
@@ -110,6 +112,8 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          cache-targets: false
+          prefix-key: v1-rust
           # Key on ffmpeg version so each container gets its own cache
           key: ffmpeg-${{ matrix.ffmpeg_version }}
 
@@ -152,6 +156,8 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          cache-targets: false
+          prefix-key: v1-rust
           key: ffmpeg-${{ env.FFMPEG_VERSION }}-xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
@@ -199,6 +205,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-targets: false
+          prefix-key: v1-rust
 
       - name: Ensure toolchain
         run: rustup show
@@ -224,6 +233,8 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          cache-targets: false
+          prefix-key: v1-rust
           key: wasm
 
       - name: Ensure toolchain
@@ -277,6 +288,9 @@ jobs:
       # Nightly toolchain version in rustc -V already gives this job a unique cache key
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-targets: false
+          prefix-key: v1-rust
 
       - name: Ensure toolchain
         run: rustup show

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
           key: xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
@@ -113,7 +112,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
           # Key on ffmpeg version so each container gets its own cache
           key: ffmpeg-${{ matrix.ffmpeg_version }}
 
@@ -157,7 +155,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
           key: ffmpeg-${{ env.FFMPEG_VERSION }}-xcode-${{ env.XCODE_VER }}
 
       - name: Ensure toolchain
@@ -207,7 +204,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
 
       - name: Ensure toolchain
         run: rustup show
@@ -234,7 +230,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
           key: wasm
 
       - name: Ensure toolchain
@@ -290,7 +285,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-targets: false
-          prefix-key: v1-rust
 
       - name: Ensure toolchain
         run: rustup show


### PR DESCRIPTION
## Summary

- cache Cargo dependencies without persisting compiler outputs between runners
- clear the existing Rust cache archives so stale target artifacts cannot be restored
- apply the same cache boundary to every Rust job in CI

## Why

Scheduled run 32316367496 restored a 430 MB Rust cache, then Cargo reported a disk I/O error in its cache metadata and failed to read/write dep-info and fingerprint files under target. The same commit and toolchain passed the previous day. Reusing disposable target state across ephemeral runners makes CI correctness depend on archived compiler artifacts.

This keeps network-facing dependency caching while every job builds into a fresh target directory. It does not retry or suppress build failures. The 20 existing v0-rust cache entries were deleted by exact ID; FFmpeg, CodeQL, and other repository caches were preserved.

## Validation

- actionlint -ignore SC2010 .github/workflows/ci.yml
- npx prettier@3.8.5 --print-width 120 --check .github/workflows/ci.yml
- YAML parse
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated all Rust CI caches to preserve Cargo dependencies while excluding compiler output directories, preventing stale `target` artifacts from being restored between runners.

### 📊 Key Changes
- Set `cache-targets: false` for every `Swatinem/rust-cache` step in `.github/workflows/ci.yml`.
- Applied the cache boundary across Xcode, FFmpeg, WASM, nightly, and other Rust CI jobs.
- Retained existing cache keys for dependency caching while excluding Rust build targets from archived cache data.
- Removed the existing 20 `v0-rust` cache archives; unrelated FFmpeg, CodeQL, and repository caches were preserved.

### 🎯 Purpose & Impact
- Rust jobs now build with a fresh `target` directory on each runner while continuing to reuse cached Cargo dependencies.
- This reduces the risk of stale or corrupted compiler artifacts causing CI failures; no retry or failure-suppression behavior was added.