### PR TITLE
Promote FP16 ONNX models for FP32 inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onnx-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2646a116e96c9ca9ed8e595464acbbf69139048623e952acfbe1d04d2e097b81"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2679,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2689,6 +2695,7 @@ dependencies = [
  "lru",
  "minifb",
  "ndarray",
+ "onnx-rs",
  "ort",
  "rayon",
  "serial_test",
@@ -2700,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.36"
+version = "0.0.37"
 edition = "2024"
 rust-version = "1.89"
 authors = [
@@ -134,6 +134,7 @@ ureq = "^3.3.0"
 dirs = "^6.0"
 rayon = "^1.12"
 clap = { version = "^4.6.1", features = ["derive"] }
+onnx-rs = "^0.1.2"
 # rayon-backed parallelism for ndarray and fast_image_resize, native only.
 ndarray = { version = "^0.17", features = ["rayon"] }
 fast_image_resize = { version = "^6.0", features = ["image", "rayon"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ ureq = "^3.3.0"
 dirs = "^6.0"
 rayon = "^1.12"
 clap = { version = "^4.6.1", features = ["derive"] }
-onnx-rs = "^0.1.2"
+onnx-rs = { version = "^0.1.2", optional = true }
 # rayon-backed parallelism for ndarray and fast_image_resize, native only.
 ndarray = { version = "^0.17", features = ["rayon"] }
 fast_image_resize = { version = "^6.0", features = ["image", "rayon"] }
@@ -151,6 +151,7 @@ video = ["video-rs"]
 
 # Image annotation support (for --save feature in CLI)
 annotate = ["imageproc", "ab_glyph"]
+fp16-to-fp32 = ["dep:onnx-rs"]
 
 # NVIDIA GPU acceleration
 cuda = ["ort/cuda"]
@@ -187,7 +188,7 @@ nvidia = ["cuda", "tensorrt"]
 amd = ["rocm", "migraphx"]
 intel = ["openvino", "onednn"]
 mobile = ["nnapi", "coreml", "qnn"]
-all = ["annotate", "visualize", "video"]
+all = ["annotate", "visualize", "video", "fp16-to-fp32"]
 
 [dev-dependencies]
 # Testing dependencies

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ cargo install ultralytics-inference --no-default-features
 # Enable video support
 cargo install ultralytics-inference --features video
 
+# Enable FP16 ONNX to FP32 promotion
+cargo install ultralytics-inference --features fp16-to-fp32
+
 # Enable multiple accelerators
 cargo install ultralytics-inference --features "cuda,tensorrt"
 ```
@@ -568,6 +571,7 @@ Default features (enabled unless `--no-default-features` is passed): `annotate`,
 | `annotate`        | Image annotation for `--save` (default)                                                               |
 | `visualize`       | Real-time window display for `--show` (default)                                                       |
 | `video`           | Video file decoding/encoding (requires FFmpeg)                                                        |
+| `fp16-to-fp32`    | In-memory FP16 ONNX to FP32 promotion for CPU inference                                               |
 | `cuda`            | NVIDIA CUDA support                                                                                   |
 | `tensorrt`        | NVIDIA TensorRT optimization                                                                          |
 | `cuda-preprocess` | GPU preprocessing + zero-copy TensorRT input (needs CUDA toolkit; see [`docs/CUDA.md`](docs/CUDA.md)) |
@@ -590,7 +594,7 @@ Default features (enabled unless `--no-default-features` is passed): `annotate`,
 | `amd`             | Convenience: ROCm + MIGraphX                                                                          |
 | `intel`           | Convenience: OpenVINO + oneDNN                                                                        |
 | `mobile`          | Convenience: NNAPI + CoreML + QNN                                                                     |
-| `all`             | Convenience: annotate + visualize + video                                                             |
+| `all`             | Convenience: annotate + visualize + video + fp16-to-fp32                                              |
 
 ## 🌐 Browser / WebGPU (WASM)
 
@@ -653,12 +657,13 @@ One of the key benefits of this library is a Rust/ONNX Runtime stack with no PyT
 | `imageproc` | Drawing boxes and shapes       |
 | `ab_glyph`  | Text rendering (embedded font) |
 
-### Optional Dependencies (for Video & Visualization)
+### Optional Dependencies (for Video, Visualization & ONNX Conversion)
 
-| Crate      | Purpose                            |
-| ---------- | ---------------------------------- |
-| `minifb`   | Window creation and buffer display |
-| `video-rs` | Video decoding/encoding (ffmpeg)   |
+| Crate      | Purpose                                     |
+| ---------- | ------------------------------------------- |
+| `minifb`   | Window creation and buffer display          |
+| `video-rs` | Video decoding/encoding (ffmpeg)            |
+| `onnx-rs`  | FP16 ONNX to FP32 graph conversion (opt-in) |
 
 ### Video Support (FFmpeg)
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 The legacy `--half` flag remains accepted for backward compatibility, maps to `--quantize 16`, and emits the same deprecation warning as Ultralytics Python. An explicit `--quantize` value wins.
 
-For CPU inference, `--quantize 32` promotes an FP16 ONNX graph to FP32 in memory during model loading. The original compact FP16 file remains unchanged, while ONNX Runtime executes the promoted graph with its optimized FP32 CPU kernels.
+For CPU inference, `--quantize 32` promotes an Ultralytics-exported FP16 ONNX graph to FP32 in memory during model loading. The original compact FP16 file remains unchanged, while ONNX Runtime executes the promoted graph with its optimized FP32 CPU kernels.
 
 **Task and Model Resolution:**
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.36 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.37 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -234,7 +234,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.36 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.37 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -286,6 +286,8 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 The legacy `--half` flag remains accepted for backward compatibility, maps to `--quantize 16`, and emits the same deprecation warning as Ultralytics Python. An explicit `--quantize` value wins.
 
+For CPU inference, `--quantize 32` promotes an FP16 ONNX graph to FP32 in memory during model loading. The original compact FP16 file remains unchanged, while ONNX Runtime executes the promoted graph with its optimized FP32 CPU kernels.
+
 **Task and Model Resolution:**
 
 | Invocation                                        | Model used             | Notes                                                               |
@@ -333,7 +335,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.36"
+ultralytics-inference = "0.0.37"
 ```
 
 ```toml
@@ -549,7 +551,7 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.36", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.37", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 The legacy `--half` flag remains accepted for backward compatibility, maps to `--quantize 16`, and emits the same deprecation warning as Ultralytics Python. An explicit `--quantize` value wins.
 
-For CPU inference, `--quantize 32` promotes an Ultralytics-exported FP16 ONNX graph to FP32 in memory during model loading. The original compact FP16 file remains unchanged, while ONNX Runtime executes the promoted graph with its optimized FP32 CPU kernels.
+For CPU inference, enable the `fp16-to-fp32` Cargo feature and use `--quantize 32` to promote an Ultralytics-exported FP16 ONNX graph to FP32 in memory during model loading. The original compact FP16 file remains unchanged, while ONNX Runtime executes the promoted graph with its optimized FP32 CPU kernels.
 
 **Task and Model Resolution:**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -285,7 +285,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 旧版 `--half` 标志仍可向后兼容，会映射为 `--quantize 16`，并发出与 Ultralytics Python 相同的弃用警告。显式的 `--quantize` 值优先。
 
-进行 CPU 推理时，`--quantize 32` 会在模型加载期间于内存中将 FP16 ONNX 图提升为 FP32。原始的紧凑 FP16 文件保持不变，而 ONNX Runtime 会使用其优化的 FP32 CPU 内核执行提升后的图。
+进行 CPU 推理时，`--quantize 32` 会在模型加载期间于内存中将 Ultralytics 导出的 FP16 ONNX 图提升为 FP32。原始的紧凑 FP16 文件保持不变，而 ONNX Runtime 会使用其优化的 FP32 CPU 内核执行提升后的图。
 
 **任务和模型解析：**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,7 +213,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.36 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.37 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -233,7 +233,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.36 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.37 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -285,6 +285,8 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 旧版 `--half` 标志仍可向后兼容，会映射为 `--quantize 16`，并发出与 Ultralytics Python 相同的弃用警告。显式的 `--quantize` 值优先。
 
+进行 CPU 推理时，`--quantize 32` 会在模型加载期间于内存中将 FP16 ONNX 图提升为 FP32。原始的紧凑 FP16 文件保持不变，而 ONNX Runtime 会使用其优化的 FP32 CPU 内核执行提升后的图。
+
 **任务和模型解析：**
 
 | 调用方式                                          | 使用模型               | 说明                                                    |
@@ -332,7 +334,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.36"
+ultralytics-inference = "0.0.37"
 ```
 
 ```toml
@@ -545,7 +547,7 @@ cargo build --release --features "cuda,tensorrt"
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.36", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.37", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,6 +100,9 @@ cargo install ultralytics-inference --no-default-features
 # 启用视频支持
 cargo install ultralytics-inference --features video
 
+# 启用 FP16 ONNX 到 FP32 提升
+cargo install ultralytics-inference --features fp16-to-fp32
+
 # 启用多个加速后端
 cargo install ultralytics-inference --features "cuda,tensorrt"
 ```
@@ -564,6 +567,7 @@ ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 | `annotate`        | 为 `--save` 提供图片标注（默认）                                                         |
 | `visualize`       | 为 `--show` 提供实时窗口显示（默认）                                                     |
 | `video`           | 视频文件解码/编码（需要 FFmpeg）                                                         |
+| `fp16-to-fp32`    | 在内存中将 FP16 ONNX 提升为 FP32，以便进行 CPU 推理                                      |
 | `cuda`            | NVIDIA CUDA 支持                                                                         |
 | `tensorrt`        | NVIDIA TensorRT 优化                                                                     |
 | `cuda-preprocess` | GPU 预处理 + TensorRT 零拷贝输入（需要 CUDA toolkit；见 [`docs/CUDA.md`](docs/CUDA.md)） |
@@ -586,7 +590,7 @@ ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 | `amd`             | 便捷组合：ROCm + MIGraphX                                                                |
 | `intel`           | 便捷组合：OpenVINO + oneDNN                                                              |
 | `mobile`          | 便捷组合：NNAPI + CoreML + QNN                                                           |
-| `all`             | 便捷组合：annotate + visualize + video                                                   |
+| `all`             | 便捷组合：annotate + visualize + video + fp16-to-fp32                                    |
 
 ## 🌐 浏览器 / WebGPU（WASM）
 
@@ -639,12 +643,13 @@ JS/TS 封装与构建说明见 [`web/`](web/README.md)。需要支持 WebGPU 的
 | `imageproc` | 绘制框和形状 |
 | `ab_glyph`  | 文本渲染字体 |
 
-### 可选依赖（用于视频和可视化）
+### 可选依赖（用于视频、可视化和 ONNX 转换）
 
-| Crate      | 用途                    |
-| ---------- | ----------------------- |
-| `minifb`   | 窗口创建和缓冲区显示    |
-| `video-rs` | 视频解码/编码（ffmpeg） |
+| Crate      | 用途                                 |
+| ---------- | ------------------------------------ |
+| `minifb`   | 窗口创建和缓冲区显示                 |
+| `video-rs` | 视频解码/编码（ffmpeg）              |
+| `onnx-rs`  | FP16 ONNX 到 FP32 图转换（选择启用） |
 
 ### 视频支持（FFmpeg）
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -285,7 +285,7 @@ ultralytics-inference predict --model <model.onnx> --source <source>
 
 旧版 `--half` 标志仍可向后兼容，会映射为 `--quantize 16`，并发出与 Ultralytics Python 相同的弃用警告。显式的 `--quantize` 值优先。
 
-进行 CPU 推理时，`--quantize 32` 会在模型加载期间于内存中将 Ultralytics 导出的 FP16 ONNX 图提升为 FP32。原始的紧凑 FP16 文件保持不变，而 ONNX Runtime 会使用其优化的 FP32 CPU 内核执行提升后的图。
+进行 CPU 推理时，请启用 `fp16-to-fp32` Cargo 功能并使用 `--quantize 32`，以便在模型加载期间于内存中将 Ultralytics 导出的 FP16 ONNX 图提升为 FP32。原始的紧凑 FP16 文件保持不变，而 ONNX Runtime 会使用其优化的 FP32 CPU 内核执行提升后的图。
 
 **任务和模型解析：**
 

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.36"
+version = "0.0.37"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -35,9 +35,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.36", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.37", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.36", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.37", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -67,7 +67,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.36", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.37", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -318,8 +318,8 @@ impl InferenceConfig {
     /// Set the requested inference precision.
     ///
     /// The accepted schemes match the Python package's `quantize` argument.
-    /// Loading an FP16 ONNX model with [`Quantization::Fp32`] promotes its graph
-    /// to FP32 in memory while leaving the source file unchanged.
+    /// Loading an Ultralytics-exported FP16 ONNX model with [`Quantization::Fp32`]
+    /// promotes its graph to FP32 in memory while leaving the source file unchanged.
     ///
     /// # Returns
     ///

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -318,8 +318,9 @@ impl InferenceConfig {
     /// Set the requested inference precision.
     ///
     /// The accepted schemes match the Python package's `quantize` argument.
-    /// Loading an Ultralytics-exported FP16 ONNX model with [`Quantization::Fp32`]
-    /// promotes its graph to FP32 in memory while leaving the source file unchanged.
+    /// With the `fp16-to-fp32` feature, loading an Ultralytics-exported FP16 ONNX
+    /// model with [`Quantization::Fp32`] promotes its graph to FP32 in memory while
+    /// leaving the source file unchanged.
     ///
     /// # Returns
     ///

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -318,8 +318,8 @@ impl InferenceConfig {
     /// Set the requested inference precision.
     ///
     /// The accepted schemes match the Python package's `quantize` argument.
-    /// For ONNX models, the exported graph determines which precisions the
-    /// execution provider can use.
+    /// Loading an FP16 ONNX model with [`Quantization::Fp32`] promotes its graph
+    /// to FP32 in memory while leaving the source file unchanged.
     ///
     /// # Returns
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@
 //!
 //! Add `quantize=16` for an FP16 ONNX, or `quantize=8` for INT8 (which also
 //! needs a calibration dataset via `data=`). Requires Ultralytics >= 8.4.
+//! Loading an FP16 ONNX with `quantize=32` promotes the graph to FP32 in memory
+//! without changing the compact source file.
 //!
 //! The task is auto-detected from ONNX metadata:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,8 +175,9 @@
 //!
 //! Add `quantize=16` for an FP16 ONNX, or `quantize=8` for INT8 (which also
 //! needs a calibration dataset via `data=`). Requires Ultralytics >= 8.4.
-//! Loading an Ultralytics-exported FP16 ONNX with `quantize=32` promotes the graph
-//! to FP32 in memory without changing the compact source file.
+//! With the `fp16-to-fp32` feature, loading an Ultralytics-exported FP16 ONNX with
+//! `quantize=32` promotes the graph to FP32 in memory without changing the compact
+//! source file.
 //!
 //! The task is auto-detected from ONNX metadata:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,8 +175,8 @@
 //!
 //! Add `quantize=16` for an FP16 ONNX, or `quantize=8` for INT8 (which also
 //! needs a calibration dataset via `data=`). Requires Ultralytics >= 8.4.
-//! Loading an FP16 ONNX with `quantize=32` promotes the graph to FP32 in memory
-//! without changing the compact source file.
+//! Loading an Ultralytics-exported FP16 ONNX with `quantize=32` promotes the graph
+//! to FP32 in memory without changing the compact source file.
 //!
 //! The task is auto-detected from ONNX metadata:
 //!

--- a/src/model.rs
+++ b/src/model.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use half::f16;
 use image::{DynamicImage, GenericImageView};
 use ndarray::Array3;
+use onnx_rs::ast::{DataType, Graph, OpType, TensorProto, TypeValue};
 // `model` is native-only, so rayon is used directly rather than via `crate::parallel`
 // (which exists to give the wasm-shared pipeline sequential shims).
 use ort::session::Session;
@@ -52,6 +53,110 @@ macro_rules! bind_compute_stream {
             None => $ep.build(),
         }
     };
+}
+
+fn promote_fp16_to_fp32(model_bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let mut model = onnx_rs::parse(model_bytes).map_err(|e| {
+        InferenceError::ModelLoadError(format!(
+            "Failed to decode ONNX model for FP32 inference: {e}"
+        ))
+    })?;
+    let graph = model.graph.as_mut().ok_or_else(|| {
+        InferenceError::ModelLoadError("ONNX model has no inference graph".to_string())
+    })?;
+    let promoted = promote_graph(graph)?;
+    if !promoted {
+        return Ok(None);
+    }
+    Ok(Some(onnx_rs::encode(&model)))
+}
+
+fn promote_graph(graph: &mut Graph<'_>) -> Result<bool> {
+    let mut promoted = false;
+    for tensor in &mut graph.initializer {
+        promoted |= promote_tensor(tensor)?;
+    }
+    for value in graph
+        .input
+        .iter_mut()
+        .chain(&mut graph.output)
+        .chain(&mut graph.value_info)
+    {
+        if let Some(type_) = value.r#type.as_mut()
+            && let Some(TypeValue::Tensor(tensor)) = &mut type_.value
+        {
+            promoted |= promote_element_type(&mut tensor.elem_type);
+        }
+    }
+    for node in &mut graph.node {
+        for attribute in &mut node.attribute {
+            if node.op_type == OpType::Cast
+                && attribute.name == "to"
+                && attribute.i == DataType::Float16 as i64
+            {
+                attribute.i = DataType::Float as i64;
+                promoted = true;
+            }
+            if let Some(tensor) = attribute.t.as_mut() {
+                promoted |= promote_tensor(tensor)?;
+            }
+            for tensor in &mut attribute.tensors {
+                promoted |= promote_tensor(tensor)?;
+            }
+        }
+    }
+    Ok(promoted)
+}
+
+fn promote_tensor(tensor: &mut TensorProto<'_>) -> Result<bool> {
+    if tensor.data_type() != DataType::Float16 {
+        return Ok(false);
+    }
+    if !tensor.external_data().is_empty() {
+        return Err(InferenceError::ModelLoadError(
+            "FP32 inference does not support ONNX FP16 external tensor data".to_string(),
+        ));
+    }
+    let values = if let Some(raw_data) = tensor.as_raw() {
+        if !raw_data.len().is_multiple_of(2) {
+            return Err(InferenceError::ModelLoadError(format!(
+                "FP16 tensor '{}' has an invalid byte length",
+                tensor.name()
+            )));
+        }
+        raw_data
+            .chunks_exact(2)
+            .map(|bytes| f16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]])).to_f32())
+            .collect()
+    } else if let Some(int32_data) = tensor.as_i32() {
+        int32_data
+            .iter()
+            .map(|bits| {
+                let bytes = bits.to_le_bytes();
+                f16::from_bits(u16::from_le_bytes([bytes[0], bytes[1]])).to_f32()
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut promoted = TensorProto::from_f32(tensor.name(), tensor.dims().to_vec(), values)
+        .with_doc_string(tensor.doc_string())
+        .with_data_location(tensor.data_location())
+        .with_metadata_props(tensor.metadata_props().to_vec());
+    if let Some(segment) = tensor.segment() {
+        promoted = promoted.with_segment(segment.clone());
+    }
+    *tensor = promoted;
+    Ok(true)
+}
+
+const fn promote_element_type(element_type: &mut DataType) -> bool {
+    if matches!(*element_type, DataType::Float16) {
+        *element_type = DataType::Float;
+        true
+    } else {
+        false
+    }
 }
 
 /// YOLO model for inference.
@@ -366,7 +471,7 @@ impl YOLOModel {
         }
         // CPU is the default - no warning needed when no accelerators are registered
 
-        let session = session_builder
+        session_builder = session_builder
             .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
             .map_err(|e| {
                 InferenceError::ModelLoadError(format!("Failed to set optimization level: {e}"))
@@ -382,9 +487,18 @@ impl YOLOModel {
             .with_memory_pattern(true)
             .map_err(|e| {
                 InferenceError::ModelLoadError(format!("Failed to enable memory pattern: {e}"))
-            })?
-            .commit_from_file(path)
-            .map_err(|e| InferenceError::ModelLoadError(format!("Failed to load model: {e}")))?;
+            })?;
+
+        let promoted_model = if config.quantize == Some(Quantization::Fp32) {
+            promote_fp16_to_fp32(&std::fs::read(path)?)?
+        } else {
+            None
+        };
+        let session = match promoted_model.as_deref() {
+            Some(bytes) => session_builder.commit_from_memory(bytes),
+            None => session_builder.commit_from_file(path),
+        }
+        .map_err(|e| InferenceError::ModelLoadError(format!("Failed to load model: {e}")))?;
 
         // Extract metadata from model
         let metadata = Self::extract_metadata(&session)?;
@@ -449,7 +563,9 @@ impl YOLOModel {
             }
         };
 
-        let quantize = if provider_name == "TensorRTExecutionProvider" {
+        let quantize = if promoted_model.is_some() {
+            Some(Quantization::Fp32)
+        } else if provider_name == "TensorRTExecutionProvider" {
             Some(if config.quantize == Some(Quantization::Fp16) {
                 Quantization::Fp16
             } else {
@@ -2068,8 +2184,70 @@ fn shape_to_usize(shape: &[i64]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use onnx_rs::ast::{
+        Attribute, AttributeType, Model, Node, TensorTypeProto, TypeProto, ValueInfo,
+    };
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_promote_fp16_onnx_graph_to_fp32() {
+        let data = [f16::from_f32(1.5), f16::from_f32(-2.0)]
+            .into_iter()
+            .flat_map(|value| value.to_bits().to_le_bytes())
+            .collect::<Vec<_>>();
+        let model = Model {
+            graph: Some(Graph {
+                initializer: vec![TensorProto::from_raw(
+                    "weight",
+                    vec![2],
+                    DataType::Float16,
+                    &data,
+                )],
+                value_info: vec![ValueInfo {
+                    name: "hidden",
+                    r#type: Some(TypeProto {
+                        value: Some(TypeValue::Tensor(TensorTypeProto {
+                            elem_type: DataType::Float16,
+                            shape: None,
+                        })),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                node: vec![Node {
+                    op_type: OpType::Cast,
+                    attribute: vec![Attribute {
+                        name: "to",
+                        r#type: AttributeType::Int,
+                        i: DataType::Float16 as i64,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let promoted = promote_fp16_to_fp32(&onnx_rs::encode(&model))
+            .unwrap()
+            .unwrap();
+        let model = onnx_rs::parse(&promoted).unwrap();
+        let graph = model.graph.as_ref().unwrap();
+        let initializer = &graph.initializer[0];
+        assert_eq!(initializer.data_type(), DataType::Float);
+        assert_eq!(&*initializer.as_f32().unwrap(), [1.5, -2.0]);
+        assert_eq!(
+            graph.value_info[0].r#type.as_ref().unwrap().value,
+            Some(TypeValue::Tensor(TensorTypeProto {
+                elem_type: DataType::Float,
+                shape: None
+            }))
+        );
+        assert_eq!(graph.node[0].attribute[0].i, DataType::Float as i64);
+        assert!(promote_fp16_to_fp32(&promoted).unwrap().is_none());
+    }
 
     #[test]
     fn test_model_not_found() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use half::f16;
 use image::{DynamicImage, GenericImageView};
 use ndarray::Array3;
+#[cfg(feature = "fp16-to-fp32")]
 use onnx_rs::ast::{DataType, Graph, OpType, TensorProto, TypeValue};
 // `model` is native-only, so rayon is used directly rather than via `crate::parallel`
 // (which exists to give the wasm-shared pipeline sequential shims).
@@ -55,6 +56,7 @@ macro_rules! bind_compute_stream {
     };
 }
 
+#[cfg(feature = "fp16-to-fp32")]
 fn promote_fp16_to_fp32(model_bytes: &[u8]) -> Result<Option<Vec<u8>>> {
     let mut model = onnx_rs::parse(model_bytes).map_err(|e| {
         InferenceError::ModelLoadError(format!(
@@ -71,6 +73,7 @@ fn promote_fp16_to_fp32(model_bytes: &[u8]) -> Result<Option<Vec<u8>>> {
     Ok(Some(onnx_rs::encode(&model)))
 }
 
+#[cfg(feature = "fp16-to-fp32")]
 fn promote_graph(graph: &mut Graph<'_>) -> Result<bool> {
     let mut promoted = false;
     for tensor in &mut graph.initializer {
@@ -108,6 +111,7 @@ fn promote_graph(graph: &mut Graph<'_>) -> Result<bool> {
     Ok(promoted)
 }
 
+#[cfg(feature = "fp16-to-fp32")]
 fn promote_tensor(tensor: &mut TensorProto<'_>) -> Result<bool> {
     if tensor.data_type() != DataType::Float16 {
         return Ok(false);
@@ -150,6 +154,7 @@ fn promote_tensor(tensor: &mut TensorProto<'_>) -> Result<bool> {
     Ok(true)
 }
 
+#[cfg(feature = "fp16-to-fp32")]
 const fn promote_element_type(element_type: &mut DataType) -> bool {
     if matches!(*element_type, DataType::Float16) {
         *element_type = DataType::Float;
@@ -489,11 +494,14 @@ impl YOLOModel {
                 InferenceError::ModelLoadError(format!("Failed to enable memory pattern: {e}"))
             })?;
 
+        #[cfg(feature = "fp16-to-fp32")]
         let promoted_model = if config.quantize == Some(Quantization::Fp32) {
             promote_fp16_to_fp32(&std::fs::read(path)?)?
         } else {
             None
         };
+        #[cfg(not(feature = "fp16-to-fp32"))]
+        let promoted_model: Option<Vec<u8>> = None;
         let session = match promoted_model.as_deref() {
             Some(bytes) => session_builder.commit_from_memory(bytes),
             None => session_builder.commit_from_file(path),
@@ -502,6 +510,14 @@ impl YOLOModel {
 
         // Extract metadata from model
         let metadata = Self::extract_metadata(&session)?;
+        #[cfg(not(feature = "fp16-to-fp32"))]
+        if config.quantize == Some(Quantization::Fp32)
+            && metadata.quantize == Some(Quantization::Fp16)
+        {
+            return Err(InferenceError::FeatureNotEnabled(
+                "enable 'fp16-to-fp32' to run an FP16 ONNX model with quantize=32".to_string(),
+            ));
+        }
 
         // Get input/output names and detect input type
         let input_info = session.inputs().first();
@@ -2184,12 +2200,14 @@ fn shape_to_usize(shape: &[i64]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "fp16-to-fp32")]
     use onnx_rs::ast::{
         Attribute, AttributeType, Model, Node, TensorTypeProto, TypeProto, ValueInfo,
     };
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    #[cfg(feature = "fp16-to-fp32")]
     #[test]
     fn test_promote_fp16_onnx_graph_to_fp32() {
         let data = [f16::from_f32(1.5), f16::from_f32(-2.0)]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- promote FP16 ONNX weights, constants, type annotations, and cast targets to FP32 in memory when `quantize=32`
- keep the compact FP16 model file unchanged and include conversion in model load time
- expose conversion through the opt-in `fp16-to-fp32` feature so default consumers gain no active dependencies
- use one zero-transitive-dependency ONNX codec when enabled and bump the package patch version to 0.0.37

## Validation

- default build dependency tree contains neither `onnx-rs` nor `protobuf`
- `cargo fmt --all -- --check`
- strict clippy and full tests both with and without `fp16-to-fp32`
- default: 203 unit, 10 integration, and 19 doctests passed
- feature enabled: 204 unit, 10 integration, and 19 doctests passed
- wasm32 core build and WebGPU/npm package CI
- real Ultralytics YOLO26n FP16 ONNX export loaded with `--quantize 32`, ran as FP32 on CPU, and produced the expected 4-person/1-bus detections
- feature-disabled FP16 + `quantize=32` returns a clear `FeatureNotEnabled` error

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added opt-in in-memory promotion of FP16 ONNX models to FP32 during model loading when `quantize=32`, while preserving the original model file and keeping the default build free of conversion dependencies.

### 📊 Key Changes
- Added the `fp16-to-fp32` Cargo feature, backed by the optional `onnx-rs` dependency; the feature is also included in `all`.
- Updated `YOLOModel` loading to convert FP16 initializers, tensor type annotations, embedded attribute tensors, and `Cast` targets to FP32, then load the converted graph from memory.
- Added a clear `FeatureNotEnabled` error when FP16 ONNX models are requested with `quantize=32` without the feature enabled.
- Documented the new feature and CPU workflow in the English and Chinese READMEs, and updated package versions to `0.0.37`.
- Added unit coverage for FP16 tensor, metadata, and cast-target promotion.

### 🎯 Purpose & Impact
- Consumers that enable `fp16-to-fp32` can load Ultralytics-exported FP16 ONNX models with `quantize=32` for FP32 inference without modifying the compact source file.
- Default consumers retain the existing dependency set and behavior; requesting this conversion without the feature now produces an explicit error.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
