### PR TITLE
Speed up FP16 model promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.37"
+version = "0.0.38"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.37"
+version = "0.0.38"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/src/model.rs
+++ b/src/model.rs
@@ -366,8 +366,27 @@ impl YOLOModel {
         }
         // CPU is the default - no warning needed when no accelerators are registered
 
+        let promotion_start = Instant::now();
+        let promoted_model = if config.quantize == Some(Quantization::Fp32)
+            && provider_name == "CPUExecutionProvider"
+        {
+            crate::onnx::promote_fp16_to_fp32(&std::fs::read(path)?)?
+        } else {
+            None
+        };
+        if promoted_model.is_some() {
+            crate::info!(
+                "Promoted ONNX model to FP32 in {:.1?}",
+                promotion_start.elapsed()
+            );
+        }
+        let optimization_level = if promoted_model.is_some() {
+            ort::session::builder::GraphOptimizationLevel::Level2
+        } else {
+            ort::session::builder::GraphOptimizationLevel::Level3
+        };
         session_builder = session_builder
-            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+            .with_optimization_level(optimization_level)
             .map_err(|e| {
                 InferenceError::ModelLoadError(format!("Failed to set optimization level: {e}"))
             })?
@@ -384,20 +403,6 @@ impl YOLOModel {
                 InferenceError::ModelLoadError(format!("Failed to enable memory pattern: {e}"))
             })?;
 
-        let promotion_start = Instant::now();
-        let promoted_model = if config.quantize == Some(Quantization::Fp32)
-            && provider_name == "CPUExecutionProvider"
-        {
-            crate::onnx::promote_fp16_to_fp32(&std::fs::read(path)?)?
-        } else {
-            None
-        };
-        if promoted_model.is_some() {
-            crate::info!(
-                "Promoted ONNX model to FP32 in {:.1?}",
-                promotion_start.elapsed()
-            );
-        }
         let session = match promoted_model.as_deref() {
             Some(model) => session_builder.commit_from_memory(model),
             None => session_builder.commit_from_file(path),

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 use half::f16;
+use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut};
 
 use crate::{InferenceError, Result};
 
@@ -169,9 +170,21 @@ fn rewrite_tensor(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> R
                 if !data.len().is_multiple_of(2) {
                     return Err(model_error("ONNX FP16 tensor has an invalid byte length"));
                 }
-                for value in data.as_chunks::<2>().0 {
-                    let bits = u16::from_le_bytes([value[0], value[1]]);
-                    output.extend_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
+                if data.len() >= 1 << 20 {
+                    let start = output.len();
+                    output.resize(start + data.len() * 2, 0);
+                    output[start..]
+                        .par_chunks_exact_mut(4)
+                        .zip(data.par_chunks_exact(2))
+                        .for_each(|(output, value)| {
+                            let bits = u16::from_le_bytes([value[0], value[1]]);
+                            output.copy_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
+                        });
+                } else {
+                    for value in data.as_chunks::<2>().0 {
+                        let bits = u16::from_le_bytes([value[0], value[1]]);
+                        output.extend_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
+                    }
                 }
                 Ok(())
             })?,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- use ONNX Runtime Level2 graph optimization for promoted CPU FP32 sessions while retaining Level3 for every existing native and accelerator path
- parallelize conversion of FP16 raw-weight tensors larger than 1 MiB into the existing output buffer
- release the optimized path as Rust and npm patch version `0.0.38`

## YOLO26x optimization benchmark

Same 106.6 MiB FP16 model, `quantize=32`, one-CPU x86_64 Linux container:

| | Before | After |
|---|---:|---:|
| Process wall time | 12.06 s | 7.00–7.06 s |
| First inference | 5.60 s | 3.15–3.16 s |
| FP16→FP32 rewrite | 247 ms | 197–208 ms |

On Apple M5, process wall time improved from 0.62 s to 0.44–0.48 s and inference from 199–213 ms to 155–169 ms. YOLO26n inference improved from 9.1–9.6 ms to 7.6–8.5 ms. All runs returned the same four-person, one-bus result.

## Native FP32 comparison

Production-shaped Cloud Run benchmark: Gen2, one vCPU, 2 GiB, 10 independent cold processes per candidate, with 500 measured warm YOLO26x predictions and 1,000 measured warm YOLO26n predictions per candidate.

| Model | Ultralytics FP32 ONNX | Stored FP16 → runtime FP32 | Difference |
|---|---:|---:|---:|
| YOLO26n | 117.6 ms | 122.6 ms | 4.3% slower |
| YOLO26x | 3207.7 ms | 3146.8 ms | 1.9% faster |

The promoted path was effectively tied warm before this optimization while keeping the stored artifact approximately half-sized.

## Validation

- `cargo test --no-default-features --features annotate` — 205 unit tests, 10 integration tests, and 19 doctests passed
- `cargo clippy --all-targets --no-default-features --features annotate -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

FP16-to-FP32 model promotion on CPU now loads faster by parallelizing large tensor conversion and using ONNX Runtime Level2 optimization, while other execution paths retain Level3 optimization.

### 📊 Key Changes

- Large FP16 raw-weight tensors at least 1 MiB are converted into the output buffer in parallel with Rayon; smaller tensors retain sequential conversion.
- CPU sessions promoted from stored FP16 to runtime FP32 use ONNX Runtime `Level2` graph optimization.
- Native FP32 sessions and all non-CPU or non-promoted paths continue to use `Level3` optimization.
- Rust, WebAssembly, and npm packages were incremented from version `0.0.37` to `0.0.38`.

### 🎯 Purpose & Impact

- Reduces FP16 promotion and initial model-load time for CPU inference, with the PR reporting YOLO26x process time decreasing from about 12.06 seconds to 7.00–7.06 seconds in its benchmark.
- Keeps the stored FP16 model artifact while converting it to FP32 at runtime for the affected CPU path.
- Changes the optimization level only for promoted CPU sessions; existing native and accelerator execution paths retain their previous Level3 setting.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
