### PR TITLE
Install Rust CI tools directly with Cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
-        with:
-          tool: wasm-pack
+        run: cargo install wasm-pack --locked
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -290,9 +288,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
-        with:
-          tool: cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
 
       - name: Coverage
         # Exclude code that host-side unit tests cannot exercise: the CUDA kernel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
         run: cargo clippy -p ultralytics-inference-web --target wasm32-unknown-unknown -- -D warnings
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        run: cargo install wasm-pack --locked --force
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -288,7 +288,7 @@ jobs:
         run: rustup show
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --locked --force
 
       - name: Coverage
         # Exclude code that host-side unit tests cannot exercise: the CUDA kernel

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,9 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
-        with:
-          tool: wasm-pack
+        run: cargo install wasm-pack --locked
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --force
+        run: cargo install wasm-pack@0.15.0 --locked --force
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,7 +70,7 @@ jobs:
           key: wasm
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        run: cargo install wasm-pack --locked --force
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## Summary

- replace taiki-e/install-action with direct Cargo installs for cargo-llvm-cov and wasm-pack
- resolve the latest published tools in non-publishing CI while honoring their published lockfiles
- pin wasm-pack only in the OIDC-authorized npm release job

## Why

taiki-e/install-action is a shared installer whose releases track every supported tool, not only the tools used here. It published 21 releases from July 24 through August 23, 2026; only one changed cargo-llvm-cov and none changed wasm-pack. The organization-wide action updater consequently opened 18 install-action PRs in this repository during that period, mostly for unrelated tool manifest changes.

Installing the crates directly removes that noisy intermediary and uses the standard Cargo distribution path. Normal CI intentionally resolves the latest cargo-llvm-cov and wasm-pack releases. The privileged npm publishing job pins wasm-pack 0.15.0 so an unreviewed tool release cannot alter a published artifact. The --force option replaces binaries restored by the Cargo cache; a cold cache does not provide these tools.

## Validation

- git diff --check
- npx prettier@3.8.5 --print-width 120 --check .github/workflows/ci.yml .github/workflows/npm-publish.yml
- cargo install cargo-llvm-cov --locked --force
- cargo install wasm-pack --locked --force
- cargo install wasm-pack@0.15.0 --locked --force
- cargo llvm-cov --version: 0.9.0
- wasm-pack --version: 0.15.0
- hosted CI wasm job passed with direct Cargo installation

Cold local installation took approximately 26 seconds for cargo-llvm-cov and 21 seconds for wasm-pack.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

CI now installs `wasm-pack` and `cargo-llvm-cov` directly with Cargo, while the npm publishing workflow pins `wasm-pack` to version 0.15.0.

### 📊 Key Changes

- Replaced `taiki-e/install-action` with `cargo install wasm-pack --locked --force` in the WebAssembly CI job.
- Replaced `taiki-e/install-action` with `cargo install cargo-llvm-cov --locked --force` in the coverage job.
- Updated the npm publishing workflow to install `wasm-pack@0.15.0` with Cargo.
- Added `--locked` to honor published lockfiles and `--force` to replace binaries restored from the Cargo cache.

### 🎯 Purpose & Impact

- Standard CI resolves the latest published `wasm-pack` and `cargo-llvm-cov` versions directly through Cargo.
- The npm publishing workflow uses the fixed `wasm-pack` 0.15.0 version instead of resolving a newer release.
- Removes these tool installations from the shared `taiki-e/install-action` dependency.