### PR TITLE
Speed up FP16 promotion by reserving protobuf length prefixes

### DIFF
--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -9,6 +9,17 @@ const FLOAT: u64 = 1;
 const FLOAT16: u64 = 10;
 const LENGTH_DELIMITED: u8 = 2;
 const MAX_VARINT_BYTES: usize = 10;
+/// Tensors below this widen on one thread: the rayon fan-out costs more than
+/// splitting a small tensor saves.
+const MIN_PARALLEL_BYTES: usize = 1 << 20;
+
+/// Upper bound on the bytes a promoted rewrite of `length` input bytes produces.
+/// FP16 `raw_data` doubles, and an `int32_data` varint as short as one byte widens
+/// to four raw bytes, so four times the input plus the added `raw_data` header
+/// covers every rewrite this module performs.
+const fn promoted_bound(length: usize) -> usize {
+    length.saturating_mul(4).saturating_add(32)
+}
 
 pub fn promote_fp16_to_fp32(model: &[u8]) -> Result<Option<Vec<u8>>> {
     let mut output = Vec::with_capacity(model.len().saturating_mul(2));
@@ -26,21 +37,13 @@ fn rewrite_model(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> Re
         match field.number {
             7 => {
                 graph = true;
-                write_message(output, field.number, |output| {
-                    rewrite_graph(field.message()?, output, promoted)
-                })?;
+                field.rewrite(output, |src, dst| rewrite_graph(src, dst, promoted))?;
             }
-            20 => write_message(output, field.number, |output| {
-                rewrite_training_info(field.message()?, output, promoted)
-            })?,
-            25 => write_message(output, field.number, |output| {
-                rewrite_function(field.message()?, output, promoted)
-            })?,
+            20 => field.rewrite(output, |src, dst| rewrite_training_info(src, dst, promoted))?,
+            25 => field.rewrite(output, |src, dst| rewrite_function(src, dst, promoted))?,
             14 if find_bytes(field.message()?, 1)? == Some(b"quantize".as_slice()) => {
                 quantize = true;
-                write_message(output, field.number, |output| {
-                    rewrite_metadata_quantize(field.message()?, output)
-                })?;
+                field.rewrite(output, rewrite_metadata_quantize)?;
             }
             _ => output.extend_from_slice(field.encoded),
         }
@@ -49,7 +52,7 @@ fn rewrite_model(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> Re
         return Err(model_error("ONNX model has no inference graph"));
     }
     if *promoted != initial_promoted && !quantize {
-        write_message(output, 14, |output| {
+        write_message(output, 14, 32, |output| {
             write_bytes_field(output, 1, b"quantize")?;
             write_bytes_field(output, 2, b"32")
         })?;
@@ -73,18 +76,10 @@ fn rewrite_graph(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> Re
     for field in Fields::new(input) {
         let field = field?;
         match field.number {
-            1 => write_message(output, field.number, |output| {
-                rewrite_node(field.message()?, output, promoted)
-            })?,
-            5 => write_message(output, field.number, |output| {
-                rewrite_tensor(field.message()?, output, promoted)
-            })?,
-            15 => write_message(output, field.number, |output| {
-                rewrite_sparse_tensor(field.message()?, output, promoted)
-            })?,
-            11..=13 => write_message(output, field.number, |output| {
-                rewrite_value_info(field.message()?, output, promoted)
-            })?,
+            1 => field.rewrite(output, |src, dst| rewrite_node(src, dst, promoted))?,
+            5 => field.rewrite(output, |src, dst| rewrite_tensor(src, dst, promoted))?,
+            15 => field.rewrite(output, |src, dst| rewrite_sparse_tensor(src, dst, promoted))?,
+            11..=13 => field.rewrite(output, |src, dst| rewrite_value_info(src, dst, promoted))?,
             _ => output.extend_from_slice(field.encoded),
         }
     }
@@ -96,8 +91,8 @@ fn rewrite_node(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> Res
     for field in Fields::new(input) {
         let field = field?;
         if field.number == 5 {
-            write_message(output, field.number, |output| {
-                rewrite_attribute(field.message()?, output, promoted, cast)
+            field.rewrite(output, |src, dst| {
+                rewrite_attribute(src, dst, promoted, cast)
             })?;
         } else {
             output.extend_from_slice(field.encoded);
@@ -120,18 +115,12 @@ fn rewrite_attribute(
                 write_varint_field(output, field.number, FLOAT);
                 *promoted += 1;
             }
-            5 | 10 => write_message(output, field.number, |output| {
-                rewrite_tensor(field.message()?, output, promoted)
-            })?,
-            6 | 11 => write_message(output, field.number, |output| {
-                rewrite_graph(field.message()?, output, promoted)
-            })?,
-            22 | 23 => write_message(output, field.number, |output| {
-                rewrite_sparse_tensor(field.message()?, output, promoted)
-            })?,
-            14 | 15 => write_message(output, field.number, |output| {
-                rewrite_type(field.message()?, output, promoted)
-            })?,
+            5 | 10 => field.rewrite(output, |src, dst| rewrite_tensor(src, dst, promoted))?,
+            6 | 11 => field.rewrite(output, |src, dst| rewrite_graph(src, dst, promoted))?,
+            22 | 23 => {
+                field.rewrite(output, |src, dst| rewrite_sparse_tensor(src, dst, promoted))?;
+            }
+            14 | 15 => field.rewrite(output, |src, dst| rewrite_type(src, dst, promoted))?,
             _ => output.extend_from_slice(field.encoded),
         }
     }
@@ -161,33 +150,19 @@ fn rewrite_tensor(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> R
         match field.number {
             2 => write_varint_field(output, field.number, FLOAT),
             5 if !wrote_int32_data => {
-                write_message(output, 9, |output| rewrite_int32_data(input, output))?;
+                write_message(output, 9, promoted_bound(input.len()), |output| {
+                    rewrite_int32_data(input, output)
+                })?;
                 wrote_int32_data = true;
             }
             5 => {}
-            9 => write_message(output, field.number, |output| {
+            9 => {
                 let data = field.message()?;
-                if !data.len().is_multiple_of(2) {
-                    return Err(model_error("ONNX FP16 tensor has an invalid byte length"));
-                }
-                if data.len() >= 1 << 20 {
-                    let start = output.len();
-                    output.resize(start + data.len() * 2, 0);
-                    output[start..]
-                        .par_chunks_exact_mut(4)
-                        .zip(data.par_chunks_exact(2))
-                        .for_each(|(output, value)| {
-                            let bits = u16::from_le_bytes([value[0], value[1]]);
-                            output.copy_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
-                        });
-                } else {
-                    for value in data.as_chunks::<2>().0 {
-                        let bits = u16::from_le_bytes([value[0], value[1]]);
-                        output.extend_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
-                    }
-                }
-                Ok(())
-            })?,
+                let bound = data.len().saturating_mul(2);
+                write_message(output, field.number, bound, |output| {
+                    write_raw_data(data, output)
+                })?;
+            }
             _ => output.extend_from_slice(field.encoded),
         }
     }
@@ -214,6 +189,33 @@ fn rewrite_int32_data(input: &[u8], output: &mut Vec<u8>) -> Result<()> {
     Ok(())
 }
 
+/// Widen packed FP16 `raw_data` to FP32, in parallel once a tensor is large
+/// enough that splitting it pays for the rayon fan-out.
+/// Widen packed FP16 `raw_data` to FP32, splitting across rayon only once a tensor
+/// is large enough to pay for the fan-out.
+fn write_raw_data(data: &[u8], output: &mut Vec<u8>) -> Result<()> {
+    if !data.len().is_multiple_of(2) {
+        return Err(model_error("ONNX FP16 tensor has an invalid byte length"));
+    }
+    if data.len() >= MIN_PARALLEL_BYTES {
+        let start = output.len();
+        output.resize(start + data.len() * 2, 0);
+        output[start..]
+            .par_chunks_exact_mut(4)
+            .zip(data.par_chunks_exact(2))
+            .for_each(|(output, value)| {
+                let bits = u16::from_le_bytes([value[0], value[1]]);
+                output.copy_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
+            });
+    } else {
+        for value in data.as_chunks::<2>().0 {
+            let bits = u16::from_le_bytes(*value);
+            output.extend_from_slice(&f16::from_bits(bits).to_f32().to_le_bytes());
+        }
+    }
+    Ok(())
+}
+
 fn write_fp16_bits(output: &mut Vec<u8>, bits: u64) -> Result<()> {
     let bits = u16::try_from(bits)
         .map_err(|_| model_error("ONNX FP16 int32_data value exceeds 16 bits"))?;
@@ -225,9 +227,7 @@ fn rewrite_sparse_tensor(input: &[u8], output: &mut Vec<u8>, promoted: &mut usiz
     for field in Fields::new(input) {
         let field = field?;
         if field.number == 1 {
-            write_message(output, field.number, |output| {
-                rewrite_tensor(field.message()?, output, promoted)
-            })?;
+            field.rewrite(output, |src, dst| rewrite_tensor(src, dst, promoted))?;
         } else {
             output.extend_from_slice(field.encoded);
         }
@@ -239,9 +239,7 @@ fn rewrite_value_info(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) 
     for field in Fields::new(input) {
         let field = field?;
         if field.number == 2 {
-            write_message(output, field.number, |output| {
-                rewrite_type(field.message()?, output, promoted)
-            })?;
+            field.rewrite(output, |src, dst| rewrite_type(src, dst, promoted))?;
         } else {
             output.extend_from_slice(field.encoded);
         }
@@ -253,14 +251,12 @@ fn rewrite_type(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) -> Res
     for field in Fields::new(input) {
         let field = field?;
         match field.number {
-            1 | 8 => write_message(output, field.number, |output| {
-                rewrite_tensor_type(field.message()?, output, promoted)
+            1 | 8 => field.rewrite(output, |src, dst| rewrite_tensor_type(src, dst, promoted))?,
+            4 | 9 => field.rewrite(output, |src, dst| {
+                rewrite_nested_type(src, dst, promoted, 1)
             })?,
-            4 | 9 => write_message(output, field.number, |output| {
-                rewrite_nested_type(field.message()?, output, promoted, 1)
-            })?,
-            5 => write_message(output, field.number, |output| {
-                rewrite_nested_type(field.message()?, output, promoted, 2)
+            5 => field.rewrite(output, |src, dst| {
+                rewrite_nested_type(src, dst, promoted, 2)
             })?,
             _ => output.extend_from_slice(field.encoded),
         }
@@ -290,9 +286,7 @@ fn rewrite_nested_type(
     for field in Fields::new(input) {
         let field = field?;
         if field.number == type_field {
-            write_message(output, field.number, |output| {
-                rewrite_type(field.message()?, output, promoted)
-            })?;
+            field.rewrite(output, |src, dst| rewrite_type(src, dst, promoted))?;
         } else {
             output.extend_from_slice(field.encoded);
         }
@@ -304,9 +298,7 @@ fn rewrite_training_info(input: &[u8], output: &mut Vec<u8>, promoted: &mut usiz
     for field in Fields::new(input) {
         let field = field?;
         if matches!(field.number, 1 | 2) {
-            write_message(output, field.number, |output| {
-                rewrite_graph(field.message()?, output, promoted)
-            })?;
+            field.rewrite(output, |src, dst| rewrite_graph(src, dst, promoted))?;
         } else {
             output.extend_from_slice(field.encoded);
         }
@@ -318,65 +310,67 @@ fn rewrite_function(input: &[u8], output: &mut Vec<u8>, promoted: &mut usize) ->
     for field in Fields::new(input) {
         let field = field?;
         match field.number {
-            7 => write_message(output, field.number, |output| {
-                rewrite_node(field.message()?, output, promoted)
+            7 => field.rewrite(output, |src, dst| rewrite_node(src, dst, promoted))?,
+            11 => field.rewrite(output, |src, dst| {
+                rewrite_attribute(src, dst, promoted, false)
             })?,
-            11 => write_message(output, field.number, |output| {
-                rewrite_attribute(field.message()?, output, promoted, false)
-            })?,
-            12 => write_message(output, field.number, |output| {
-                rewrite_value_info(field.message()?, output, promoted)
-            })?,
+            12 => field.rewrite(output, |src, dst| rewrite_value_info(src, dst, promoted))?,
             _ => output.extend_from_slice(field.encoded),
         }
     }
     Ok(())
 }
 
-fn find_varint(input: &[u8], number: u32) -> Result<Option<u64>> {
+fn find_field(input: &[u8], number: u32) -> Result<Option<Field<'_>>> {
     for field in Fields::new(input) {
         let field = field?;
         if field.number == number {
-            return field.varint().map(Some);
+            return Ok(Some(field));
         }
     }
     Ok(None)
+}
+
+fn find_varint(input: &[u8], number: u32) -> Result<Option<u64>> {
+    find_field(input, number)?
+        .map(|field| field.varint())
+        .transpose()
 }
 
 fn find_bytes(input: &[u8], number: u32) -> Result<Option<&[u8]>> {
-    for field in Fields::new(input) {
-        let field = field?;
-        if field.number == number {
-            return field.message().map(Some);
-        }
-    }
-    Ok(None)
+    find_field(input, number)?
+        .map(|field| field.message())
+        .transpose()
 }
 
 fn has_field(input: &[u8], number: u32) -> Result<bool> {
-    for field in Fields::new(input) {
-        if field?.number == number {
-            return Ok(true);
-        }
-    }
-    Ok(false)
+    Ok(find_field(input, number)?.is_some())
 }
 
+/// Write `write`'s output as field `number`, reserving room for the length prefix
+/// up front. `bound` is an upper bound on the payload length: when it predicts the
+/// same varint width as the payload actually needs, which is the common case, the
+/// payload lands in place and nothing has to be shifted.
 fn write_message(
     output: &mut Vec<u8>,
     number: u32,
+    bound: usize,
     write: impl FnOnce(&mut Vec<u8>) -> Result<()>,
 ) -> Result<()> {
     write_varint(output, u64::from(number) << 3 | u64::from(LENGTH_DELIMITED));
+    let mut encoded = [0; MAX_VARINT_BYTES];
+    let reserved = encode_varint(bound as u64, &mut encoded);
     let length = output.len();
-    output.resize(length + MAX_VARINT_BYTES, 0);
+    output.resize(length + reserved, 0);
     let payload = output.len();
     write(output)?;
     let end = output.len();
-    let mut encoded = [0; MAX_VARINT_BYTES];
     let encoded_len = encode_varint((end - payload) as u64, &mut encoded);
-    output.copy_within(payload..end, length + encoded_len);
-    output.truncate(end - (MAX_VARINT_BYTES - encoded_len));
+    if encoded_len != reserved {
+        output.resize(end + encoded_len.saturating_sub(reserved), 0);
+        output.copy_within(payload..end, length + encoded_len);
+        output.truncate(length + encoded_len + (end - payload));
+    }
     output[length..length + encoded_len].copy_from_slice(&encoded[..encoded_len]);
     Ok(())
 }
@@ -387,7 +381,7 @@ fn write_varint_field(output: &mut Vec<u8>, number: u32, value: u64) {
 }
 
 fn write_bytes_field(output: &mut Vec<u8>, number: u32, value: &[u8]) -> Result<()> {
-    write_message(output, number, |output| {
+    write_message(output, number, value.len(), |output| {
         output.extend_from_slice(value);
         Ok(())
     })
@@ -444,6 +438,18 @@ impl<'a> Field<'a> {
         Ok(self.value)
     }
 
+    /// Rewrite this field's message into `output` behind its own length prefix.
+    fn rewrite(
+        &self,
+        output: &mut Vec<u8>,
+        write: impl FnOnce(&'a [u8], &mut Vec<u8>) -> Result<()>,
+    ) -> Result<()> {
+        let input = self.message()?;
+        write_message(output, self.number, promoted_bound(input.len()), |output| {
+            write(input, output)
+        })
+    }
+
     fn varint(&self) -> Result<u64> {
         if self.wire != 0 {
             return Err(model_error("invalid ONNX protobuf field type"));
@@ -474,42 +480,26 @@ impl<'a> Fields<'a> {
             return Err(model_error("invalid ONNX field number"));
         }
         let wire = (key & 7) as u8;
-        let value_start;
-        let end;
-        match wire {
+        let mut value_start = self.position;
+        let length = match wire {
             0 => {
-                value_start = self.position;
                 read_varint(self.input, &mut self.position)?;
-                end = self.position;
+                self.position - value_start
             }
-            1 => {
-                value_start = self.position;
-                end = self
-                    .position
-                    .checked_add(8)
-                    .ok_or_else(|| model_error("invalid ONNX field length"))?;
-                self.position = end;
-            }
+            1 => 8,
+            5 => 4,
             LENGTH_DELIMITED => {
                 let length = usize::try_from(read_varint(self.input, &mut self.position)?)
                     .map_err(|_| model_error("invalid ONNX field length"))?;
                 value_start = self.position;
-                end = self
-                    .position
-                    .checked_add(length)
-                    .ok_or_else(|| model_error("invalid ONNX field length"))?;
-                self.position = end;
-            }
-            5 => {
-                value_start = self.position;
-                end = self
-                    .position
-                    .checked_add(4)
-                    .ok_or_else(|| model_error("invalid ONNX field length"))?;
-                self.position = end;
+                length
             }
             _ => return Err(model_error("unsupported ONNX protobuf wire type")),
-        }
+        };
+        let end = value_start
+            .checked_add(length)
+            .ok_or_else(|| model_error("invalid ONNX field length"))?;
+        self.position = end;
         if end > self.input.len() {
             return Err(model_error("truncated ONNX protobuf"));
         }
@@ -542,7 +532,7 @@ mod tests {
     fn promotes_fp16_tensor_and_preserves_unknown_fields() {
         let mut tensor = Vec::new();
         write_varint_field(&mut tensor, 2, FLOAT16);
-        write_message(&mut tensor, 9, |output| {
+        write_message(&mut tensor, 9, 8, |output| {
             output.extend_from_slice(&f16::from_f32(1.5).to_bits().to_le_bytes());
             output.extend_from_slice(&f16::from_f32(-2.0).to_bits().to_le_bytes());
             Ok(())
@@ -551,13 +541,13 @@ mod tests {
         write_varint_field(&mut tensor, 99, 7);
 
         let mut graph = Vec::new();
-        write_message(&mut graph, 5, |output| {
+        write_message(&mut graph, 5, tensor.len(), |output| {
             output.extend_from_slice(&tensor);
             Ok(())
         })
         .unwrap();
         let mut model = Vec::new();
-        write_message(&mut model, 7, |output| {
+        write_message(&mut model, 7, graph.len(), |output| {
             output.extend_from_slice(&graph);
             Ok(())
         })
@@ -585,20 +575,20 @@ mod tests {
     fn promotes_packed_fp16_int32_data() {
         let mut tensor = Vec::new();
         write_varint_field(&mut tensor, 2, FLOAT16);
-        write_message(&mut tensor, 5, |output| {
+        write_message(&mut tensor, 5, 8, |output| {
             write_varint(output, u64::from(f16::from_f32(1.5).to_bits()));
             write_varint(output, u64::from(f16::from_f32(-2.0).to_bits()));
             Ok(())
         })
         .unwrap();
         let mut graph = Vec::new();
-        write_message(&mut graph, 5, |output| {
+        write_message(&mut graph, 5, tensor.len(), |output| {
             output.extend_from_slice(&tensor);
             Ok(())
         })
         .unwrap();
         let mut model = Vec::new();
-        write_message(&mut model, 7, |output| {
+        write_message(&mut model, 7, graph.len(), |output| {
             output.extend_from_slice(&graph);
             Ok(())
         })

--- a/src/onnx.rs
+++ b/src/onnx.rs
@@ -9,8 +9,6 @@ const FLOAT: u64 = 1;
 const FLOAT16: u64 = 10;
 const LENGTH_DELIMITED: u8 = 2;
 const MAX_VARINT_BYTES: usize = 10;
-/// Tensors below this widen on one thread: the rayon fan-out costs more than
-/// splitting a small tensor saves.
 const MIN_PARALLEL_BYTES: usize = 1 << 20;
 
 /// Upper bound on the bytes a promoted rewrite of `length` input bytes produces.
@@ -347,10 +345,6 @@ fn has_field(input: &[u8], number: u32) -> Result<bool> {
     Ok(find_field(input, number)?.is_some())
 }
 
-/// Write `write`'s output as field `number`, reserving room for the length prefix
-/// up front. `bound` is an upper bound on the payload length: when it predicts the
-/// same varint width as the payload actually needs, which is the common case, the
-/// payload lands in place and nothing has to be shifted.
 fn write_message(
     output: &mut Vec<u8>,
     number: u32,


### PR DESCRIPTION
FP16 to FP32 promotion reserved ten bytes for every protobuf length prefix and then shifted the whole payload back into place, one full buffer memmove per nesting level, about 285 MiB moved for a 95 MiB output. `write_message` now takes an upper bound on the payload and reserves exactly the varint width that bound needs, so the payload almost always lands in place and the shift disappears. Outputs are same for all seven tasks were checked against main on real `half=True` exports with matching annotated results.

| Model            | Before   | After    | Delta  |
| ---------------- | -------- | -------- | ------ |
| detect 4.8 MiB   | 6.70 ms  | 5.80 ms  | -13.4% |
| segment 5.4 MiB  | 7.50 ms  | 6.60 ms  | -12.0% |
| pose 5.9 MiB     | 8.10 ms  | 7.10 ms  | -12.3% |
| classify 5.4 MiB | 8.60 ms  | 6.90 ms  | -19.8% |
| obb 4.9 MiB      | 6.90 ms  | 6.00 ms  | -13.0% |
| semantic 3.0 MiB | 4.30 ms  | 3.80 ms  | -11.6% |
| depth 10.0 MiB   | 15.40 ms | 14.40 ms | -6.5%  |
| detect 47.6 MiB  | 72.40 ms | 66.00 ms | -8.8%  |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
FP16-to-FP32 ONNX promotion now reserves length prefixes using payload-size bounds, reducing unnecessary buffer moves during nested protobuf rewrites.

### 📊 Key Changes
- Updated `write_message` to reserve only the varint width required by an upper-bound payload size, shifting the payload only when the final length needs more space.
- Added `Field::rewrite` and applied it across graph, tensor, node, type, attribute, and related nested-message rewrites.
- Added `promoted_bound` to estimate rewritten message sizes and provide bounds for nested protobuf fields.
- Moved FP16 `raw_data` widening into `write_raw_data`, retaining parallel conversion for tensors at least 1 MiB and sequential conversion for smaller tensors.
- Simplified field lookup and protobuf field-boundary parsing through shared `find_field` logic.

### 🎯 Purpose & Impact
- FP16 promotion avoids the previous full-payload memmove in typical nested messages, with the PR reporting approximately 6.5–19.8% lower conversion times across the listed model tasks and 8.8% for the larger detect model.
- Protobuf length prefixes remain corrected if the actual payload exceeds the reserved varint width.
- No user-facing change to the promotion workflow or serialized model contents is indicated.