### PR TITLE
Count finished results instead of keeping every frame in memory

### DIFF
--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -190,9 +190,7 @@ pub fn run_prediction(args: &PredictArgs) {
         process::exit(1);
     }
 
-    // Process each image/frame. Only the count is needed, for the speed averages below; keeping
-    // the results would retain every frame's original image for the whole run, which a video or
-    // an endless webcam source cannot afford.
+    // Only the count is used below; keeping the results would pin every frame's image.
     let mut result_count = 0usize;
     let mut total_preprocess = 0.0;
     let mut total_inference = 0.0;

--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -190,8 +190,10 @@ pub fn run_prediction(args: &PredictArgs) {
         process::exit(1);
     }
 
-    // Process each image/frame
-    let mut all_results: Vec<(String, Results)> = Vec::new();
+    // Process each image/frame. Only the count is needed, for the speed averages below; keeping
+    // the results would retain every frame's original image for the whole run, which a video or
+    // an endless webcam source cannot afford.
+    let mut result_count = 0usize;
     let mut total_preprocess = 0.0;
     let mut total_inference = 0.0;
     let mut total_postprocess = 0.0;
@@ -350,7 +352,7 @@ pub fn run_prediction(args: &PredictArgs) {
                         total_preprocess += result.speed.preprocess.unwrap_or(0.0);
                         total_inference += result.speed.inference.unwrap_or(0.0);
                         total_postprocess += result.speed.postprocess.unwrap_or(0.0);
-                        all_results.push((image_path.clone(), result));
+                        result_count += 1;
                     }
                 }
             },
@@ -383,7 +385,7 @@ pub fn run_prediction(args: &PredictArgs) {
     }
 
     // Print speed summary with inference tensor shape (after letterboxing)
-    let num_results = all_results.len().max(1) as f64;
+    let num_results = result_count.max(1) as f64;
     verbose!(
         "Speed: {:.1}ms preprocess, {:.1}ms inference, {:.1}ms postprocess per image at shape ({}, 3, {}, {})",
         total_preprocess / num_results,


### PR DESCRIPTION
The CLI kept every frame's results for the whole run but only ever used the count, so memory grew with the length of the source. I used a test video has 341 frame 1080p clip and peak memory drops from 2.31 GB to 0.26 GB with yolo26n and from 6.55 GB to 0.60 GB with yolo26n-seg, and a webcam or RTSP source no longer runs out of memory and keep system safer.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The prediction CLI now counts processed results instead of retaining every frame’s results, reducing memory growth during long-running inference.

### 📊 Key Changes
- Replaced the `all_results` vector, which stored each image path and `Results` object, with a `result_count` counter.
- Incremented the counter for each processed result while preserving preprocessing, inference, and postprocessing timing totals.
- Updated the speed summary to calculate averages from `result_count`, retaining the existing fallback for zero results.

### 🎯 Purpose & Impact
- Processed frame results and their associated images are no longer kept in memory after use, preventing memory usage from growing with the source length.
- The CLI’s reported speed averages continue to use the number of processed results.