### PR TITLE
Release 0.0.40 with correct batched GPU results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,7 +2674,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.39"
+version = "0.0.40"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.39 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.40 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -234,7 +234,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.39 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.40 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -335,7 +335,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.39"
+ultralytics-inference = "0.0.40"
 ```
 
 ```toml
@@ -551,7 +551,7 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.39", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.40", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,7 +213,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.39 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.40 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -233,7 +233,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.39 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.40 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -334,7 +334,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.39"
+ultralytics-inference = "0.0.40"
 ```
 
 ```toml
@@ -547,7 +547,7 @@ cargo build --release --features "cuda,tensorrt"
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.39", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.40", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.39"
+version = "0.0.40"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -35,9 +35,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.39", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.40", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.39", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.40", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -67,7 +67,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.39", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.40", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -132,7 +132,13 @@ impl CudaStreamHandle {
         let ctx = CudaContext::new(device_id).map_err(|e| {
             InferenceError::ModelLoadError(format!("cudarc CudaContext::new({device_id}): {e:?}"))
         })?;
-        let stream = ctx.default_stream();
+        // A real (non-blocking) stream, never `default_stream()`: that one carries a NULL
+        // `CUstream`, and ORT reads a null `user_compute_stream` as "none given" and runs
+        // the session on a stream of its own. The preprocess kernels would then be
+        // unordered against inference, which reads the input buffer before they land.
+        let stream = ctx.new_stream().map_err(|e| {
+            InferenceError::ModelLoadError(format!("cudarc new_stream({device_id}): {e:?}"))
+        })?;
         Ok(Self {
             ctx,
             stream,

--- a/src/cuda_inference.rs
+++ b/src/cuda_inference.rs
@@ -425,10 +425,14 @@ mod tests {
     #[test]
     fn stream_handle_open() {
         let handle = CudaStreamHandle::open(0).expect("open CUDA device 0");
-        // cudarc hands back CUDA's default stream, whose raw pointer is null by
-        // design, so only assert that the accessor is callable (it feeds ort's
-        // with_compute_stream) rather than that it is non-null.
-        let _ = handle.raw_stream_ptr();
+        // This pointer is what `with_compute_stream` hands ORT. A null one (which is what
+        // `default_stream()` would give) reads as "no stream supplied", so ORT runs the
+        // session on its own stream and the preprocess kernels stop being ordered against
+        // inference. Assert it is real, or that regression passes unnoticed.
+        assert!(
+            !handle.raw_stream_ptr().is_null(),
+            "the preprocess stream must be a real stream, not CUDA's null default"
+        );
     }
 
     #[test]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The preprocess kernels ran on CUDA's default stream, which is a null handle, so ONNX Runtime ignored it and used its own stream instead. Nothing kept the two in order, so a batched GPU run could read the image buffer before it was filled and return no detections in about 3 of 10 runs now it is 10 of 10 runs now and using a real stream fixes that with no change in speed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Release 0.0.40 replaces CUDA’s null default stream with a real non-blocking stream so preprocessing and ONNX Runtime inference are correctly ordered during batched GPU execution.

### 📊 Key Changes
- `CudaStreamHandle` now creates a dedicated CUDA stream with `ctx.new_stream()` instead of using `ctx.default_stream()`.
- ONNX Runtime receives a non-null compute stream, keeping CUDA preprocessing ordered with inference.
- The CUDA stream test now asserts that the raw stream pointer is non-null.
- Rust, web, and documented dependency versions were updated from 0.0.39 to 0.0.40.

### 🎯 Purpose & Impact
- Batched CUDA inference no longer submits inference against an independently scheduled ONNX Runtime stream that can read the input buffer before preprocessing completes.
- The change targets correct GPU result synchronization without a documented speed change.
- Version 0.0.40 is reflected in the Rust crate, web package, lock files, and usage documentation.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
