### PR TITLE
Keep running when no display is available

### DIFF
--- a/src/cli/predict.rs
+++ b/src/cli/predict.rs
@@ -52,7 +52,8 @@ pub fn run_prediction(args: &PredictArgs) {
         process::exit(1);
     });
     #[cfg(feature = "visualize")]
-    let show = args.show;
+    #[cfg_attr(not(feature = "visualize"), allow(unused_mut))]
+    let mut show = args.show;
     if model_is_default && verbose {
         warn!("'model' argument is missing. Using default '--model={model_path}'.");
     }
@@ -329,9 +330,18 @@ pub fn run_prediction(args: &PredictArgs) {
                             }
 
                             if viewer.is_none() {
-                                viewer = Some(
-                                    Viewer::new(DISPLAY_NAME, view_width, view_height).unwrap(),
-                                );
+                                // No display (headless, SSH without forwarding) must not kill a
+                                // run whose inference already succeeded: warn once, then carry on
+                                // without the window, like an unreadable input is skipped.
+                                match Viewer::new(DISPLAY_NAME, view_width, view_height) {
+                                    Ok(v) => viewer = Some(v),
+                                    Err(e) => {
+                                        warn!(
+                                            "Cannot open a display window ({e}). Continuing without --show."
+                                        );
+                                        show = false;
+                                    }
+                                }
                             }
 
                             if let Some(ref mut v) = viewer {

--- a/src/visualizer/viewer.rs
+++ b/src/visualizer/viewer.rs
@@ -43,7 +43,7 @@ impl Viewer {
                 ..WindowOptions::default()
             },
         )
-        .map_err(|e| InferenceError::VisualizerError(format!("Failed to create window: {e}")))?;
+        .map_err(|e| InferenceError::VisualizerError(format!("{e:?}")))?;
 
         // Limit update rate
         window.set_target_fps(60);


### PR DESCRIPTION
Opening the viewer window used unwrap, so predict --show aborted the whole run over SSH or on a headless machine even though inference had already finished. It now warns once and carries on without the window, and the warning names the real cause because minifb's Display drops it while Debug keeps it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `predict --show` to handle display initialization failures gracefully by warning once and continuing inference without opening a viewer window.

### 📊 Key Changes
- Replaced the `Viewer::new(...).unwrap()` call in `src/cli/predict.rs` with error handling.
- Sets `show` to `false` after a viewer creation failure, preventing further display attempts.
- Logs a warning containing the underlying display error and states that prediction continues without `--show`.
- Changed `src/visualizer/viewer.rs` to preserve the detailed minifb error using debug formatting.

### 🎯 Purpose & Impact
- On headless systems or SSH sessions without display forwarding, prediction no longer aborts when `--show` cannot create a window; it continues without visualization.