### PR TITLE
Add an optional CUDA memory limit to InferenceConfig

### DIFF
--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -130,6 +130,13 @@ What to expect and how to avoid surprises:
 > You cannot load a standalone `.engine` file directly (that needs the native
 > TensorRT runtime); the `.trt_cache/` engine is an internal ORT artifact.
 
+### Sharing the GPU with other processes
+
+`InferenceConfig::with_cuda_memory_limit(bytes)` caps the CUDA EP's memory arena so a long-running session cannot take
+the whole card. The cap covers the arena only: the CUDA context and the cuDNN workspaces sit outside it, so YOLO26n at
+640x640 still peaks near 270 MiB under a 64 MiB cap, and 64 MiB is about the floor at which that model loads. Detections
+and speed are unchanged by the cap. A `Device::TensorRt` session ignores the setting, and so does a limit of `0`.
+
 ### `cuda-preprocess` feature
 
 No separate type or API. With the feature compiled in and a CUDA/TensorRT

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -133,9 +133,9 @@ What to expect and how to avoid surprises:
 ### Sharing the GPU with other processes
 
 `InferenceConfig::with_cuda_memory_limit(bytes)` caps the CUDA EP's memory arena so a long-running session cannot take
-the whole card. The cap covers the arena only: the CUDA context and the cuDNN workspaces sit outside it, so YOLO26n at
-640x640 still peaks near 270 MiB under a 64 MiB cap, and 64 MiB is about the floor at which that model loads. Detections
-and speed are unchanged by the cap. A `Device::TensorRt` session ignores the setting, and so does a limit of `0`.
+the whole card. The cap covers the arena only: the CUDA context and the cuDNN workspaces sit outside it, so peak device
+memory stays well above the limit, and a cap the model cannot run in fails the load. Detections and speed are unchanged
+by the cap. A `Device::TensorRt` session ignores the setting, and so does a limit of `0`.
 
 ### `cuda-preprocess` feature
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -492,7 +492,7 @@ impl InferenceConfig {
     /// device can be shared with other processes. Has no effect unless the
     /// crate is built with the `cuda` feature and a CUDA device is selected.
     /// A limit the graph cannot fit in fails the load with an ONNX Runtime arena
-    /// error; 64 MiB is already the floor for `YOLO26n` at 640x640.
+    /// error, so leave the model room to run.
     ///
     /// # Example
     ///

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -157,7 +157,7 @@ pub struct InferenceConfig {
     pub cuda_preprocess: bool,
     /// Upper bound, in bytes, on the CUDA execution provider's memory arena.
     ///
-    /// `None` (default) keeps ONNX Runtime's default behaviour, which grows the
+    /// `None` (default) keeps ONNX Runtime's default behavior, which grows the
     /// arena greedily and can reserve most of the device. Set a value to cap the
     /// allocation so other processes can share the GPU. Only consulted when the
     /// crate is built with the `cuda` feature and a CUDA device is selected.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -157,10 +157,10 @@ pub struct InferenceConfig {
     pub cuda_preprocess: bool,
     /// Upper bound, in bytes, on the CUDA execution provider's memory arena.
     ///
-    /// `None` (default) keeps ONNX Runtime's default behavior, which grows the
-    /// arena greedily and can reserve most of the device. Set a value to cap the
-    /// allocation so other processes can share the GPU. Only consulted when the
-    /// crate is built with the `cuda` feature and a CUDA device is selected.
+    /// `None` (default) lets the arena grow as far as the device allows. Only
+    /// consulted with the `cuda` feature and a CUDA device: a `TensorRT` device
+    /// ignores it, as does a limit of `0`. The cap covers the arena alone, so
+    /// peak device memory stays well above it.
     pub cuda_memory_limit: Option<usize>,
 }
 
@@ -491,6 +491,8 @@ impl InferenceConfig {
     /// Use this to stop ONNX Runtime from reserving most of the GPU so the
     /// device can be shared with other processes. Has no effect unless the
     /// crate is built with the `cuda` feature and a CUDA device is selected.
+    /// A limit the graph cannot fit in fails the load with an ONNX Runtime arena
+    /// error; 64 MiB is already the floor for `YOLO26n` at 640x640.
     ///
     /// # Example
     ///

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -155,6 +155,13 @@ pub struct InferenceConfig {
     /// default). In every other configuration the value is ignored and the
     /// standard CPU preprocess path runs.
     pub cuda_preprocess: bool,
+    /// Upper bound, in bytes, on the CUDA execution provider's memory arena.
+    ///
+    /// `None` (default) keeps ONNX Runtime's default behaviour, which grows the
+    /// arena greedily and can reserve most of the device. Set a value to cap the
+    /// allocation so other processes can share the GPU. Only consulted when the
+    /// crate is built with the `cuda` feature and a CUDA device is selected.
+    pub cuda_memory_limit: Option<usize>,
 }
 
 impl Default for InferenceConfig {
@@ -174,6 +181,7 @@ impl Default for InferenceConfig {
             rect: Self::DEFAULT_RECT,
             classes: None,
             cuda_preprocess: Self::DEFAULT_CUDA_PREPROCESS,
+            cuda_memory_limit: None,
         }
     }
 }
@@ -477,6 +485,30 @@ impl InferenceConfig {
     pub fn keep_class(&self, class_id: usize) -> bool {
         self.classes.as_ref().is_none_or(|c| c.contains(&class_id))
     }
+
+    /// Cap the CUDA execution provider's memory arena at `limit` bytes.
+    ///
+    /// Use this to stop ONNX Runtime from reserving most of the GPU so the
+    /// device can be shared with other processes. Has no effect unless the
+    /// crate is built with the `cuda` feature and a CUDA device is selected.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use ultralytics_inference::InferenceConfig;
+    ///
+    /// // Limit the CUDA arena to 2 GiB.
+    /// let config = InferenceConfig::new().with_cuda_memory_limit(2 * 1024 * 1024 * 1024);
+    /// ```
+    ///
+    /// # Returns
+    ///
+    /// * The modified `InferenceConfig`.
+    #[must_use]
+    pub const fn with_cuda_memory_limit(mut self, limit: usize) -> Self {
+        self.cuda_memory_limit = Some(limit);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -529,7 +561,8 @@ mod tests {
             .with_device(crate::Device::Cpu)
             .with_save(false)
             .with_save_frames(true)
-            .with_rect(false);
+            .with_rect(false)
+            .with_cuda_memory_limit(2 * 1024 * 1024 * 1024);
 
         assert_eq!(config.batch, Some(4));
         assert_eq!(config.quantize, Some(Quantization::Fp16));
@@ -538,6 +571,7 @@ mod tests {
         assert!(!config.save);
         assert!(config.save_frames);
         assert!(!config.rect);
+        assert_eq!(config.cuda_memory_limit, Some(2 * 1024 * 1024 * 1024));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -571,8 +571,9 @@ impl YOLOModel {
     /// for the `cuda-preprocess` fast path; see [`bind_compute_stream`].
     ///
     /// `mem_limit` (when `Some`) caps the EP's memory arena at that many bytes
-    /// and switches it to a non-greedy extend strategy, so the GPU can be shared
-    /// with other processes.
+    /// so the GPU can be shared with other processes. The default extend strategy
+    /// stays: pairing the cap with `SameAsRequested` measured 14-33% *more* peak
+    /// device memory on the `YOLO26n` models.
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
     fn build_cuda_ep(
@@ -585,9 +586,7 @@ impl YOLOModel {
             .with_tf32(true);
 
         if let Some(size) = mem_limit {
-            ep = ep
-                .with_memory_limit(size)
-                .with_arena_extend_strategy(ort::ep::ArenaExtendStrategy::SameAsRequested);
+            ep = ep.with_memory_limit(size);
         }
 
         bind_compute_stream!(ep, compute_stream)

--- a/src/model.rs
+++ b/src/model.rs
@@ -585,7 +585,7 @@ impl YOLOModel {
             .with_device_id(device_id)
             .with_tf32(true);
 
-        if let Some(size) = mem_limit {
+        if let Some(size) = mem_limit.filter(|&size| size > 0) {
             ep = ep.with_memory_limit(size);
         }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -230,7 +230,7 @@ impl YOLOModel {
                 crate::Device::Cpu => {}
                 #[cfg(feature = "cuda")]
                 crate::Device::Cuda(i) => eps.push((
-                    Self::build_cuda_ep(*i as i32, cuda_pre_stream_ptr),
+                    Self::build_cuda_ep(*i as i32, cuda_pre_stream_ptr, config.cuda_memory_limit),
                     "CUDAExecutionProvider",
                 )),
                 #[cfg(feature = "coreml")]
@@ -293,7 +293,7 @@ impl YOLOModel {
 
             #[cfg(feature = "cuda")]
             eps.push((
-                Self::build_cuda_ep(0, cuda_pre_stream_ptr),
+                Self::build_cuda_ep(0, cuda_pre_stream_ptr, config.cuda_memory_limit),
                 "CUDAExecutionProvider",
             ));
 
@@ -569,15 +569,27 @@ impl YOLOModel {
     ///
     /// `compute_stream` (when `Some`) binds the EP to an external cudarc stream
     /// for the `cuda-preprocess` fast path; see [`bind_compute_stream`].
+    ///
+    /// `mem_limit` (when `Some`) caps the EP's memory arena at that many bytes
+    /// and switches it to a non-greedy extend strategy, so the GPU can be shared
+    /// with other processes.
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
     fn build_cuda_ep(
         device_id: i32,
         compute_stream: Option<*mut ()>,
+        mem_limit: Option<usize>,
     ) -> ort::ep::ExecutionProviderDispatch {
-        let ep = ort::ep::CUDA::default()
+        let mut ep = ort::ep::CUDA::default()
             .with_device_id(device_id)
             .with_tf32(true);
+
+        if let Some(size) = mem_limit {
+            ep = ep
+                .with_memory_limit(size)
+                .with_arena_extend_strategy(ort::ep::ArenaExtendStrategy::SameAsRequested);
+        }
+
         bind_compute_stream!(ep, compute_stream)
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -571,9 +571,9 @@ impl YOLOModel {
     /// for the `cuda-preprocess` fast path; see [`bind_compute_stream`].
     ///
     /// `mem_limit` (when `Some`) caps the EP's memory arena at that many bytes
-    /// so the GPU can be shared with other processes. The default extend strategy
-    /// stays: pairing the cap with `SameAsRequested` measured 14-33% *more* peak
-    /// device memory on the `YOLO26n` models.
+    /// so the GPU can be shared with other processes. The arena keeps ONNX
+    /// Runtime's default extend strategy, which reuses its chunks better than
+    /// an exact-size one and so peaks lower under the same cap.
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
     fn build_cuda_ep(


### PR DESCRIPTION
Allows processes to share the gpu as the ort has greedy default strategies. 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:



For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->
    I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an optional cap on the CUDA execution provider's memory arena to `InferenceConfig`, so a session can be kept from taking the whole card and other processes can share the GPU.

### 📊 Key Changes
- Adds `cuda_memory_limit: Option<usize>` with a default of `None`.
- Adds the `with_cuda_memory_limit` builder method and coverage in the configuration test.
- Passes the configured limit through CUDA execution-provider creation for selected CUDA devices.
- Applies the cap on top of ONNX Runtime's default arena extend strategy. Pairing the cap with `SameAsRequested` was measured to raise peak device memory by 14 to 33 percent on the YOLO26n models, so the default strategy is kept.
- Treats a limit of `0` as no limit rather than passing zero to ONNX Runtime.

### 🎯 Purpose & Impact
When set, the arena cannot grow past the cap. The cap covers the arena only, so the CUDA context and the cuDNN workspaces stay outside it and peak device memory sits above the limit, and a cap too small for the model fails the load. A `TensorRT` device ignores the setting. Unset is the default and leaves CPU, CUDA, and every other provider exactly as before, verified across detect, segment, classify, pose, obb, semantic, and depth on CPU, CUDA, and TensorRT with matching results and no speed change.
