### PR TITLE
Delete public model and task helpers that nothing calls

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1734,97 +1734,6 @@ impl YOLOModel {
         )
     }
 
-    /// Run inference on a raw array.
-    ///
-    /// # Arguments
-    ///
-    /// * `image` - HWC u8 array.
-    /// * `path` - Optional identifier.
-    ///
-    /// # Returns
-    ///
-    /// Vector of Results.
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    pub fn predict_array(&mut self, image: &Array3<u8>, path: String) -> Result<Vec<Results>> {
-        // Convert array to DynamicImage
-        let dynamic_img = crate::utils::array_to_image(image)?;
-        self.predict_image(&dynamic_img, path)
-    }
-
-    /// Process a source and save results if requested.
-    ///
-    /// This method is gated by the "annotate" feature.
-    /// Uses `config.save` to determine whether to save annotated results.
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - The input source.
-    /// * `save_dir` - Directory to save results (required if saving).
-    ///
-    /// # Returns
-    ///
-    /// * Vector of `SourceMeta` and Results pairs.
-    #[cfg(feature = "annotate")]
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    #[allow(clippy::too_many_lines)]
-    pub fn predict_source(
-        &mut self,
-        source: crate::source::Source,
-        save_dir: Option<&Path>,
-    ) -> Result<Vec<(crate::source::SourceMeta, Results)>> {
-        use crate::annotate::annotate_image;
-
-        let is_video = source.is_video();
-        #[cfg(not(feature = "video"))]
-        if is_video {
-            return Err(InferenceError::FeatureNotEnabled(
-                "Video support requires '--features video'".to_string(),
-            ));
-        }
-
-        let iterator = crate::source::SourceIterator::new(source)?;
-        let mut results_vec = Vec::new();
-
-        // Initialize ResultSaver if saving is enabled (config.save defaults to true)
-        let mut result_saver = if self.config.save {
-            if let Some(d) = save_dir {
-                Some(crate::io::SaveResults::new(
-                    d.to_path_buf(),
-                    self.config.save_frames,
-                ))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        for frame_result in iterator {
-            let (img, meta) = frame_result?;
-
-            // Run inference
-            let results = self.predict_image(&img, meta.path.clone())?;
-
-            // Take the first result (since we process one frame at a time)
-            if let Some(result) = results.into_iter().next() {
-                // Save logic
-                if let Some(saver) = &mut result_saver {
-                    let annotated = annotate_image(&img, &result, None);
-                    saver.save(is_video, &meta, &annotated)?;
-                }
-
-                results_vec.push((meta, result));
-            }
-        }
-
-        // Finish saver
-        if let Some(saver) = result_saver {
-            saver.finish()?;
-        }
-
-        Ok(results_vec)
-    }
-
     /// Run the ORT session, returning outputs and measured inference time in ms.
     ///
     /// Run a single forward pass for warmup, discarding outputs.
@@ -2032,13 +1941,6 @@ impl YOLOModel {
     #[must_use]
     pub const fn quantize(&self) -> Option<Quantization> {
         self.config.quantize
-    }
-
-    /// Check whether the resolved model precision is FP16.
-    #[doc(hidden)]
-    #[must_use]
-    pub const fn is_half(&self) -> bool {
-        self.fp16_input
     }
 
     /// Get the model metadata.

--- a/src/task.rs
+++ b/src/task.rs
@@ -90,48 +90,6 @@ impl Task {
     pub fn default_model(&self) -> String {
         format!("yolo26n{}.onnx", self.model_suffix())
     }
-
-    /// Returns `true` when the task outputs bounding boxes: Detect, Segment, Pose, and Obb.
-    #[must_use]
-    pub const fn has_boxes(&self) -> bool {
-        matches!(self, Self::Detect | Self::Segment | Self::Pose | Self::Obb)
-    }
-
-    /// Returns `true` only for the Segment task, which outputs per-instance segmentation masks.
-    #[must_use]
-    pub const fn has_masks(&self) -> bool {
-        matches!(self, Self::Segment)
-    }
-
-    /// Returns `true` only for the Pose task, which outputs skeletal keypoints.
-    #[must_use]
-    pub const fn has_keypoints(&self) -> bool {
-        matches!(self, Self::Pose)
-    }
-
-    /// Returns `true` only for the Classify task, which outputs global class probabilities.
-    #[must_use]
-    pub const fn has_probs(&self) -> bool {
-        matches!(self, Self::Classify)
-    }
-
-    /// Returns `true` only for the Obb task, which outputs oriented (rotated) bounding boxes.
-    #[must_use]
-    pub const fn has_obb(&self) -> bool {
-        matches!(self, Self::Obb)
-    }
-
-    /// Returns `true` only for the `Semantic` task, which outputs a per-pixel class label map.
-    #[must_use]
-    pub const fn has_semantic_mask(&self) -> bool {
-        matches!(self, Self::Semantic)
-    }
-
-    /// Returns `true` only for the `Depth` task, which outputs a per-pixel depth map.
-    #[must_use]
-    pub const fn has_depth(&self) -> bool {
-        matches!(self, Self::Depth)
-    }
 }
 
 impl fmt::Display for Task {
@@ -205,21 +163,6 @@ mod tests {
         assert_eq!(Task::Detect.to_string(), "detect");
         assert_eq!(Task::Segment.to_string(), "segment");
         assert_eq!(Task::Semantic.to_string(), "semantic");
-    }
-
-    #[test]
-    fn test_task_capabilities() {
-        assert!(Task::Detect.has_boxes());
-        assert!(!Task::Detect.has_masks());
-        assert!(Task::Segment.has_masks());
-        assert!(Task::Pose.has_keypoints());
-        assert!(Task::Classify.has_probs());
-        assert!(Task::Obb.has_obb());
-        assert!(Task::Semantic.has_semantic_mask());
-        assert!(!Task::Detect.has_semantic_mask());
-        assert!(Task::Depth.has_depth());
-        assert!(!Task::Semantic.has_depth());
-        assert!(!Task::Depth.has_semantic_mask());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@
 ///
 /// `IoU` value between 0.0 and 1.0
 #[must_use]
-pub fn calculate_iou(box1: &[f32; 4], box2: &[f32; 4]) -> f32 {
+pub(crate) fn calculate_iou(box1: &[f32; 4], box2: &[f32; 4]) -> f32 {
     let x1 = box1[0].max(box2[0]);
     let y1 = box1[1].max(box2[1]);
     let x2 = box1[2].min(box2[2]);
@@ -202,7 +202,7 @@ pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f3
 ///
 /// Plural form of the word
 #[must_use]
-pub fn pluralize(word: &str) -> String {
+pub(crate) fn pluralize(word: &str) -> String {
     match word {
         "person" => "persons".to_string(),
         "bus" => "buses".to_string(),


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removed unused public model and task helper APIs and restricted two utility functions to crate visibility to reduce the exposed Rust API surface.

### 📊 Key Changes

- Removed `YOLOModel::predict_array` and the feature-gated `YOLOModel::predict_source` methods.
- Removed the hidden `YOLOModel::is_half` method.
- Removed `Task` capability helpers for boxes, masks, keypoints, probabilities, oriented boxes, semantic masks, and depth, along with their dedicated test.
- Changed `calculate_iou` and `pluralize` in `utils.rs` from public to crate-visible functions.

### 🎯 Purpose & Impact

- Rust callers can no longer access the removed model and task helpers as public APIs.
- `calculate_iou` and `pluralize` remain available within the crate but are no longer exported publicly.
- Existing internal inference and task behavior shown in the diff is otherwise unchanged.