### PR TITLE
Serialize the model accessor test against the other session-building test

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -2011,6 +2011,7 @@ fn shape_to_usize(shape: &[i64]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -2036,7 +2037,13 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // Serialized against every other test that builds a session: execution providers cache
+    // compiled models under one shared path (`CoreML` writes into
+    // `~/Library/Caches/ultralytics-inference/coreml/...`), and two sessions compiling the
+    // same model at once collide there with "an item with the same name already exists".
+    // `#[serial]` only excludes other `#[serial]` tests, so this one has to carry it too.
     #[test]
+    #[serial]
     fn test_model_accessors_with_dummy() {
         // The accessors need a real instance (YOLOModel wraps an ORT session and can't be
         // mocked), so this only asserts when yolo26n.onnx is present or downloadable.

--- a/src/model.rs
+++ b/src/model.rs
@@ -2037,11 +2037,8 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Serialized against every other test that builds a session: execution providers cache
-    // compiled models under one shared path (`CoreML` writes into
-    // `~/Library/Caches/ultralytics-inference/coreml/...`), and two sessions compiling the
-    // same model at once collide there with "an item with the same name already exists".
-    // `#[serial]` only excludes other `#[serial]` tests, so this one has to carry it too.
+    // `#[serial]` with the other session-building test: providers compile into one shared
+    // cache, and two sessions building it at once collide there.
     #[test]
     #[serial]
     fn test_model_accessors_with_dummy() {


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The `test_model_accessors_with_dummy` test now runs serially to prevent concurrent session builds from colliding in the shared provider cache.

### 📊 Key Changes

- Imported the `serial_test::serial` test attribute.
- Added `#[serial]` to `test_model_accessors_with_dummy`.
- Documented that provider compilation uses a shared cache and simultaneous session creation can conflict.

### 🎯 Purpose & Impact

- Prevents this model accessor test from running concurrently with the other session-building test.
- No user-facing change.