### PR TITLE
Write only the pixels inside the box when compositing an instance mask

### DIFF
--- a/crates/web/src/payload.rs
+++ b/crates/web/src/payload.rs
@@ -212,9 +212,9 @@ fn put(buf: &mut [u8], w: usize, x: usize, y: usize, c: Color, a: u8) {
 /// Build a translucent colored RGBA overlay (`width*height*4`) from the segment
 /// instance masks or the semantic class map, colored by the class palette.
 /// Empty for other tasks or if the mask resolution does not match the image.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn build_mask_overlay(r: &Results) -> Vec<u8> {
     let (h, w) = (r.orig_shape.0 as usize, r.orig_shape.1 as usize);
-    let mut buf = vec![0u8; w * h * 4];
 
     // Segment: per-instance binary masks, each colored by its detection class.
     if let (Some(masks), Some(boxes)) = (&r.masks, &r.boxes) {
@@ -222,12 +222,24 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
         if mh != h || mw != w {
             return Vec::new();
         }
+        let mut buf = vec![0u8; w * h * 4];
         let cls = boxes.cls();
+        let xyxy = boxes.xyxy();
         for i in 0..n.min(cls.len()) {
             let c = Color::from_index(cls[i] as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    if masks.data[[i, y, x]] > 0.5 {
+            // `apply_mask_proto` leaves a mask zero outside its own detection box, so the
+            // rest of the frame cannot contribute and scanning it per instance is wasted
+            // work. Casting a float to an integer saturates, so a huge or non-finite
+            // coordinate clamps instead of wrapping.
+            let x0 = xyxy[[i, 0]].max(0.0) as usize;
+            let y0 = xyxy[[i, 1]].max(0.0) as usize;
+            let x1 = (xyxy[[i, 2]].max(0.0) as usize).saturating_add(1).min(w);
+            let y1 = (xyxy[[i, 3]].max(0.0) as usize).saturating_add(1).min(h);
+            let mask = masks.data.index_axis(ndarray::Axis(0), i);
+            for y in y0..y1 {
+                let row = mask.row(y);
+                for x in x0..x1 {
+                    if row[x] > 0.5 {
                         put(&mut buf, w, x, y, c, 140);
                     }
                 }
@@ -235,6 +247,8 @@ fn build_mask_overlay(r: &Results) -> Vec<u8> {
         }
         return buf;
     }
+
+    let mut buf = vec![0u8; w * h * 4];
 
     // Semantic: per-pixel class map, blended 50/50 like the native renderer.
     if let Some(sem) = &r.semantic_mask {

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -737,12 +737,15 @@ fn apply_mask_proto(
     let x_end = (x2.floor() as usize).min(ow - 1);
     let y_end = (y2.floor() as usize).min(oh - 1);
 
-    for y in y_start..=y_end {
-        let row = &dst_slice[y * ow..(y + 1) * ow];
-        for x in x_start..=x_end {
-            mask_out[[y, x]] = row[x];
-        }
+    if x_start > x_end || y_start > y_end {
+        return;
     }
+
+    // Copy the box region in one row-wise `assign` rather than element by element.
+    let src = ArrayView2::from_shape((oh, ow), dst_slice).expect("resized buffer is oh*ow");
+    mask_out
+        .slice_mut(s![y_start..=y_end, x_start..=x_end])
+        .assign(&src.slice(s![y_start..=y_end, x_start..=x_end]));
 }
 
 /// Combine per-detection mask coefficients with the prototype masks, then crop/resize each

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -723,12 +723,24 @@ fn apply_mask_proto(
     let x2 = box_data[2].max(0.0).min(ow as f32);
     let y2 = box_data[3].max(0.0).min(oh as f32);
 
-    for y in 0..oh as usize {
-        for x in 0..ow as usize {
-            let val = dst_slice[y * ow as usize + x];
-            if x as f32 >= x1 && x as f32 <= x2 && y as f32 >= y1 && y as f32 <= y2 {
-                mask_out[[y, x]] = val;
-            }
+    let (ow, oh) = (ow as usize, oh as usize);
+    if ow == 0 || oh == 0 {
+        return;
+    }
+
+    // Only pixels inside the box are ever written and `mask_out` arrives zeroed from the
+    // caller's `Array3::zeros`, so walk the box instead of testing every pixel in the frame.
+    // The bounds are the integer pixels satisfying the old `x >= x1 && x <= x2` test; a
+    // degenerate box gives an empty range and writes nothing, as before.
+    let x_start = x1.ceil() as usize;
+    let y_start = y1.ceil() as usize;
+    let x_end = (x2.floor() as usize).min(ow - 1);
+    let y_end = (y2.floor() as usize).min(oh - 1);
+
+    for y in y_start..=y_end {
+        let row = &dst_slice[y * ow..(y + 1) * ow];
+        for x in x_start..=x_end {
+            mask_out[[y, x]] = row[x];
         }
     }
 }
@@ -1891,6 +1903,57 @@ fn postprocess_semantic(output: &[f32], shape: &[usize], mut results: Results) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::Array1;
+
+    /// `apply_mask_proto` writes the box interior and nothing else, so the caller's zeroed
+    /// output stays zero outside it. Checks a plain box, one overhanging every edge, and a
+    /// degenerate one, against the `x1 <= x <= x2 && y1 <= y <= y2` rule it replaced.
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn test_apply_mask_proto_writes_only_inside_the_box() {
+        let (mw, mh, ow, oh) = (8usize, 8usize, 8u32, 8u32);
+        // Large logits so every resized pixel sigmoids to ~1.0 and "written" is unambiguous.
+        let mask_flat = Array1::from_elem(mw * mh, 10.0f32);
+
+        for (label, bbox) in [
+            ("interior", [2.0f32, 3.0, 5.0, 6.0]),
+            ("overhangs every edge", [-4.0f32, -4.0, 99.0, 99.0]),
+            ("degenerate", [4.0f32, 6.0, 4.0, 2.0]),
+        ] {
+            let mut out = Array2::<f32>::zeros((oh as usize, ow as usize));
+            let bbox = Array1::from_vec(bbox.to_vec());
+            apply_mask_proto(
+                out.view_mut(),
+                &mask_flat.view(),
+                &bbox.view(),
+                mw,
+                mh,
+                ow,
+                oh,
+                0.0,
+                0.0,
+                mw as f32,
+                mh as f32,
+            );
+
+            let (x1, y1) = (bbox[0].max(0.0), bbox[1].max(0.0));
+            let (x2, y2) = (bbox[2].min(ow as f32), bbox[3].min(oh as f32));
+            for y in 0..oh as usize {
+                for x in 0..ow as usize {
+                    let inside = (x as f32) >= x1
+                        && (x as f32) <= x2
+                        && (y as f32) >= y1
+                        && (y as f32) <= y2;
+                    assert_eq!(
+                        out[[y, x]] > 0.5,
+                        inside,
+                        "{label}: pixel ({x}, {y}) = {}",
+                        out[[y, x]]
+                    );
+                }
+            }
+        }
+    }
 
     /// Class names `class0..class{nc-1}`.
     fn make_names(nc: usize) -> Arc<HashMap<usize, String>> {


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Instance-mask compositing now writes and scans only the pixels within each detection box, reducing unnecessary full-frame processing while preserving the box-boundary behavior.

### 📊 Key Changes

- Updated `apply_mask_proto` to copy mask values only within the clipped detection-box region, leaving pixels outside the box at zero.
- Updated `build_mask_overlay` to iterate over each instance’s box bounds instead of scanning the entire image.
- Added handling for empty and degenerate boxes, plus bounds clamping for out-of-range coordinates.
- Added tests covering interior, edge-overhanging, and degenerate boxes.

### 🎯 Purpose & Impact

- Instance-mask generation and web overlay compositing avoid processing pixels outside detection boxes.
- Pixels outside each detection box remain excluded from the resulting instance mask and overlay.
- The existing inclusive box-boundary behavior is preserved.