### PR TITLE
Update chacha20 off the yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Rust `chacha20` dependency away from the yanked `0.10.1` release.

### 📊 Key Changes
- Changes the resolved `chacha20` dependency version.
- Updates the generated `Cargo.lock` entries accordingly.

### 🎯 Purpose & Impact
- Prevents dependency resolution from selecting the yanked `chacha20` `0.10.1` release.
- No user-facing change.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
