### PR TITLE
Stop per-class NMS once max_det boxes are kept

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -366,9 +366,7 @@ fn nms_keep_indices<T>(
         .iter()
         .map(|(bbox, score, class, _)| (*bbox, *score, *class))
         .collect();
-    let mut keep = nms_per_class(&nms_candidates, iou_threshold);
-    keep.truncate(max_det);
-    keep
+    nms_per_class(&nms_candidates, iou_threshold, max_det)
 }
 
 /// Write one `[x1, y1, x2, y2, score, class]` detection row into a `(_, 6)` boxes array.
@@ -1244,8 +1242,8 @@ fn postprocess_obb(
     // Apply Rotated NMS for precise suppression using ProbIoU (Hellinger distance).
     // This ensures that overlapping rotated boxes are correctly filtered based on their
     // actual geometric overlap, which standard axis-aligned IoU cannot handle.
-    let keep_indices = nms_rotated_per_class(&candidates, config.iou_threshold);
-    let num_kept = keep_indices.len().min(config.max_det);
+    let keep_indices = nms_rotated_per_class(&candidates, config.iou_threshold, config.max_det);
+    let num_kept = keep_indices.len();
 
     // Build output array: [cx, cy, w, h, rotation, conf, cls]
     let mut obb_data = Array2::zeros((num_kept, 7));

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -30,7 +30,7 @@ use crate::inference::InferenceConfig;
 use crate::preprocessing::{PreprocessResult, clip_coords, scale_coords};
 use crate::results::{Boxes, DepthMap, Keypoints, Masks, Obb, Probs, Results, SemanticMask, Speed};
 use crate::task::Task;
-use crate::utils::{nms_per_class, nms_rotated_per_class, xywh_to_xyxy};
+use crate::utils::{nms_per_class_capped, nms_rotated_per_class_capped, xywh_to_xyxy};
 
 /// Post-process raw model output based on task type.
 ///
@@ -366,7 +366,7 @@ fn nms_keep_indices<T>(
         .iter()
         .map(|(bbox, score, class, _)| (*bbox, *score, *class))
         .collect();
-    nms_per_class(&nms_candidates, iou_threshold, max_det)
+    nms_per_class_capped(&nms_candidates, iou_threshold, max_det)
 }
 
 /// Write one `[x1, y1, x2, y2, score, class]` detection row into a `(_, 6)` boxes array.
@@ -1257,7 +1257,8 @@ fn postprocess_obb(
     // Apply Rotated NMS for precise suppression using ProbIoU (Hellinger distance).
     // This ensures that overlapping rotated boxes are correctly filtered based on their
     // actual geometric overlap, which standard axis-aligned IoU cannot handle.
-    let keep_indices = nms_rotated_per_class(&candidates, config.iou_threshold, config.max_det);
+    let keep_indices =
+        nms_rotated_per_class_capped(&candidates, config.iou_threshold, config.max_det);
     let num_kept = keep_indices.len();
 
     // Build output array: [cx, cy, w, h, rotation, conf, cls]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,8 +177,7 @@ fn nms_by_class<T>(
 /// # Returns
 ///
 /// Indices of boxes to keep, at most `max_det` of them
-#[must_use]
-pub fn nms_per_class(
+pub(crate) fn nms_per_class(
     boxes: &[([f32; 4], f32, usize)],
     iou_threshold: f32,
     max_det: usize,
@@ -201,8 +200,7 @@ pub fn nms_per_class(
 /// # Returns
 ///
 /// Indices of boxes to keep, at most `max_det` of them
-#[must_use]
-pub fn nms_rotated_per_class(
+pub(crate) fn nms_rotated_per_class(
     boxes: &[([f32; 5], f32, usize)],
     iou_threshold: f32,
     max_det: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,7 +117,9 @@ fn nms_by_class<T>(
     max_det: usize,
     overlap: impl Fn(&T, &T) -> f32,
 ) -> Vec<usize> {
-    if boxes.is_empty() {
+    // `max_det == 0` is reachable through `with_max_det(0)` and `--max-det 0`, and the cap
+    // below is only checked after a box is pushed, so it has to be rejected up front.
+    if boxes.is_empty() || max_det == 0 {
         return vec![];
     }
 
@@ -341,6 +343,14 @@ mod tests {
         let keep = nms_per_class(&boxes, 0.5, usize::MAX);
         assert_eq!(keep, vec![0]);
 
+        // A zero cap keeps nothing, matching the `truncate(max_det)` this replaced.
+        let boxes = vec![
+            ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
+            ([50.0, 50.0, 60.0, 60.0], 0.8, 0),
+        ];
+        assert!(nms_per_class(&boxes, 0.5, 0).is_empty());
+        assert_eq!(nms_per_class(&boxes, 0.5, 1), vec![0]);
+
         // A NaN score used to panic in the sort comparator.
         let boxes = vec![
             ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
@@ -371,6 +381,7 @@ mod tests {
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 0),
         ];
         assert_eq!(nms_rotated_per_class(&within, 0.5, usize::MAX), vec![0]);
+        assert!(nms_rotated_per_class(&within, 0.5, 0).is_empty());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -172,12 +172,21 @@ fn nms_by_class<T>(
 ///
 /// * `boxes` - Vector of bounding boxes with scores and class IDs [(bbox, score, `class_id`)]
 /// * `iou_threshold` - `IoU` threshold for suppression
-/// * `max_det` - Stop once this many boxes are kept; pass `usize::MAX` for no cap
 ///
 /// # Returns
 ///
-/// Indices of boxes to keep, at most `max_det` of them
-pub(crate) fn nms_per_class(
+/// Indices of boxes to keep
+#[must_use]
+pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Vec<usize> {
+    nms_by_class(boxes, iou_threshold, usize::MAX, calculate_iou)
+}
+
+/// [`nms_per_class`], stopping once `max_det` boxes are kept.
+///
+/// Callers cap the result at `max_det` anyway, so suppressing past that point only orders
+/// boxes that get discarded. On a full `8400`-prediction head that is the difference
+/// between roughly 26 ms and 2 ms.
+pub(crate) fn nms_per_class_capped(
     boxes: &[([f32; 4], f32, usize)],
     iou_threshold: f32,
     max_det: usize,
@@ -195,12 +204,18 @@ pub(crate) fn nms_per_class(
 ///
 /// * `boxes` - Vector of rotated bounding boxes: [cx, cy, w, h, angle], score, `class_id`
 /// * `iou_threshold` - `IoU` threshold for suppression
-/// * `max_det` - Stop once this many boxes are kept; pass `usize::MAX` for no cap
 ///
 /// # Returns
 ///
-/// Indices of boxes to keep, at most `max_det` of them
-pub(crate) fn nms_rotated_per_class(
+/// Indices of boxes to keep
+#[must_use]
+pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f32) -> Vec<usize> {
+    nms_by_class(boxes, iou_threshold, usize::MAX, calculate_probiou)
+}
+
+/// [`nms_rotated_per_class`], stopping once `max_det` boxes are kept. See
+/// [`nms_per_class_capped`] for why that is not an approximation.
+pub(crate) fn nms_rotated_per_class_capped(
     boxes: &[([f32; 5], f32, usize)],
     iou_threshold: f32,
     max_det: usize,
@@ -331,14 +346,14 @@ mod tests {
             ([1.0, 1.0, 11.0, 11.0], 0.8, 1),
             ([100.0, 100.0, 110.0, 110.0], 0.95, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX).len(), 3);
+        assert_eq!(nms_per_class(&boxes, 0.5).len(), 3);
 
         // Overlapping within one class: the lower score is suppressed.
         let boxes = vec![
             ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
             ([1.0, 1.0, 11.0, 11.0], 0.8, 0),
         ];
-        let keep = nms_per_class(&boxes, 0.5, usize::MAX);
+        let keep = nms_per_class(&boxes, 0.5);
         assert_eq!(keep, vec![0]);
 
         // A zero cap keeps nothing, matching the `truncate(max_det)` this replaced.
@@ -346,15 +361,15 @@ mod tests {
             ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
             ([50.0, 50.0, 60.0, 60.0], 0.8, 0),
         ];
-        assert!(nms_per_class(&boxes, 0.5, 0).is_empty());
-        assert_eq!(nms_per_class(&boxes, 0.5, 1), vec![0]);
+        assert!(nms_per_class_capped(&boxes, 0.5, 0).is_empty());
+        assert_eq!(nms_per_class_capped(&boxes, 0.5, 1), vec![0]);
 
         // A NaN score used to panic in the sort comparator.
         let boxes = vec![
             ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
             ([100.0, 100.0, 110.0, 110.0], 0.9, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX).len(), 2);
+        assert_eq!(nms_per_class(&boxes, 0.5).len(), 2);
 
         // A NaN-scored box overlapping a valid one of the same class must not outrank it and
         // suppress it: the real detection is processed first and survives.
@@ -362,7 +377,7 @@ mod tests {
             ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
             ([1.0, 1.0, 11.0, 11.0], 0.9, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX), vec![1]);
+        assert_eq!(nms_per_class(&boxes, 0.5), vec![1]);
     }
 
     #[test]
@@ -372,14 +387,14 @@ mod tests {
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 1),
         ];
-        assert_eq!(nms_rotated_per_class(&across, 0.5, usize::MAX).len(), 2);
+        assert_eq!(nms_rotated_per_class(&across, 0.5).len(), 2);
 
         let within = vec![
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 0),
         ];
-        assert_eq!(nms_rotated_per_class(&within, 0.5, usize::MAX), vec![0]);
-        assert!(nms_rotated_per_class(&within, 0.5, 0).is_empty());
+        assert_eq!(nms_rotated_per_class(&within, 0.5), vec![0]);
+        assert!(nms_rotated_per_class_capped(&within, 0.5, 0).is_empty());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -114,6 +114,7 @@ pub fn calculate_probiou(box1: &[f32; 5], box2: &[f32; 5]) -> f32 {
 fn nms_by_class<T>(
     boxes: &[(T, f32, usize)],
     iou_threshold: f32,
+    max_det: usize,
     overlap: impl Fn(&T, &T) -> f32,
 ) -> Vec<usize> {
     if boxes.is_empty() {
@@ -140,6 +141,11 @@ fn nms_by_class<T>(
             continue;
         }
         keep.push(i);
+        // Callers cap the result at `max_det`, so suppression past that point only decides
+        // the order of boxes that are dropped. Stopping here is not an approximation.
+        if keep.len() >= max_det {
+            break;
+        }
 
         let class_i = boxes[i].2;
 
@@ -164,13 +170,18 @@ fn nms_by_class<T>(
 ///
 /// * `boxes` - Vector of bounding boxes with scores and class IDs [(bbox, score, `class_id`)]
 /// * `iou_threshold` - `IoU` threshold for suppression
+/// * `max_det` - Stop once this many boxes are kept; pass `usize::MAX` for no cap
 ///
 /// # Returns
 ///
-/// Indices of boxes to keep
+/// Indices of boxes to keep, at most `max_det` of them
 #[must_use]
-pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, calculate_iou)
+pub fn nms_per_class(
+    boxes: &[([f32; 4], f32, usize)],
+    iou_threshold: f32,
+    max_det: usize,
+) -> Vec<usize> {
+    nms_by_class(boxes, iou_threshold, max_det, calculate_iou)
 }
 
 /// Rotated Per-class Non-Maximum Suppression (NMS) using `ProbIoU`
@@ -183,13 +194,18 @@ pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Ve
 ///
 /// * `boxes` - Vector of rotated bounding boxes: [cx, cy, w, h, angle], score, `class_id`
 /// * `iou_threshold` - `IoU` threshold for suppression
+/// * `max_det` - Stop once this many boxes are kept; pass `usize::MAX` for no cap
 ///
 /// # Returns
 ///
-/// Indices of boxes to keep
+/// Indices of boxes to keep, at most `max_det` of them
 #[must_use]
-pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f32) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, calculate_probiou)
+pub fn nms_rotated_per_class(
+    boxes: &[([f32; 5], f32, usize)],
+    iou_threshold: f32,
+    max_det: usize,
+) -> Vec<usize> {
+    nms_by_class(boxes, iou_threshold, max_det, calculate_probiou)
 }
 
 /// Simple pluralization for common COCO class names.
@@ -315,14 +331,14 @@ mod tests {
             ([1.0, 1.0, 11.0, 11.0], 0.8, 1),
             ([100.0, 100.0, 110.0, 110.0], 0.95, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5).len(), 3);
+        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX).len(), 3);
 
         // Overlapping within one class: the lower score is suppressed.
         let boxes = vec![
             ([0.0, 0.0, 10.0, 10.0], 0.9, 0),
             ([1.0, 1.0, 11.0, 11.0], 0.8, 0),
         ];
-        let keep = nms_per_class(&boxes, 0.5);
+        let keep = nms_per_class(&boxes, 0.5, usize::MAX);
         assert_eq!(keep, vec![0]);
 
         // A NaN score used to panic in the sort comparator.
@@ -330,7 +346,7 @@ mod tests {
             ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
             ([100.0, 100.0, 110.0, 110.0], 0.9, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5).len(), 2);
+        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX).len(), 2);
 
         // A NaN-scored box overlapping a valid one of the same class must not outrank it and
         // suppress it: the real detection is processed first and survives.
@@ -338,7 +354,7 @@ mod tests {
             ([0.0, 0.0, 10.0, 10.0], f32::NAN, 0),
             ([1.0, 1.0, 11.0, 11.0], 0.9, 0),
         ];
-        assert_eq!(nms_per_class(&boxes, 0.5), vec![1]);
+        assert_eq!(nms_per_class(&boxes, 0.5, usize::MAX), vec![1]);
     }
 
     #[test]
@@ -348,13 +364,13 @@ mod tests {
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 1),
         ];
-        assert_eq!(nms_rotated_per_class(&across, 0.5).len(), 2);
+        assert_eq!(nms_rotated_per_class(&across, 0.5, usize::MAX).len(), 2);
 
         let within = vec![
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.9, 0),
             ([5.0, 5.0, 4.0, 2.0, 0.0], 0.8, 0),
         ];
-        assert_eq!(nms_rotated_per_class(&within, 0.5), vec![0]);
+        assert_eq!(nms_rotated_per_class(&within, 0.5, usize::MAX), vec![0]);
     }
 
     #[test]


### PR DESCRIPTION
Benchmarks below are `nms_per_class` alone at `max_det = 300`, measured on synthetic candidate sets (release build, one binary, alternating variants on an idle machine). The `1 class` rows pack every box into one class over a quarter of the frame, so almost every pair overlaps and the quadratic loop is at its worst.

| candidates | classes | before | after | speedup |
| ---------- | ------- | ------ | ----- | ------- |
| 8400 | 80 | 26.29ms | 2.14ms | 12.3x |
| 8400 | 1 | 35.66ms | 8.73ms | 4.1x |
| 3000 | 80 | 3.21ms | 0.69ms | 4.7x |
| 3000 | 1 | 7.29ms | 2.79ms | 2.6x |
| 1000 | 80 | 0.35ms | 0.19ms | 1.9x |
| 1000 | 1 | 1.10ms | 0.72ms | 1.5x |
| 500 | 80 | 85.1us | 81.4us | 1.0x |
| 100 | 80 | 4.75us | 4.5us | unchanged |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Postprocessing now stops per-class axis-aligned and rotated NMS as soon as `max_det` boxes are kept, avoiding unnecessary suppression work while preserving the existing output cap.

### 📊 Key Changes

- Added capped NMS helpers for standard and rotated boxes: `nms_per_class_capped` and `nms_rotated_per_class_capped`.
- Updated detection and OBB postprocessing to call the capped helpers directly instead of running full NMS and truncating afterward.
- Added an early return for `max_det == 0`, preserving empty output behavior.
- Kept the existing uncapped public NMS functions by routing them through the shared implementation with no effective limit.
- Added tests covering zero- and one-box caps for standard NMS and zero-cap behavior for rotated NMS.

### 🎯 Purpose & Impact

- NMS no longer evaluates boxes that would be discarded after reaching `max_det`, reducing postprocessing time on large candidate sets while retaining the same selected-box limit.
- `max_det=0` produces no kept boxes for both standard and rotated NMS.