### PR TITLE
Compute rotated box covariance once per box instead of once per pair

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -88,6 +88,15 @@ struct ProbIouBox {
 }
 
 impl ProbIouBox {
+    /// Reduce every box once, keeping each score and class alongside it so the shared
+    /// suppression loop can consume the result directly.
+    fn prepare_all(boxes: &[([f32; 5], f32, usize)]) -> Vec<(Self, f32, usize)> {
+        boxes
+            .iter()
+            .map(|(b, score, class)| (Self::new(b), *score, *class))
+            .collect()
+    }
+
     fn new(b: &[f32; 5]) -> Self {
         let (a, bb, c) = get_covariance_params(b[2], b[3], b[4]);
         Self {
@@ -130,12 +139,11 @@ fn probiou_prepared(p1: &ProbIouBox, p2: &ProbIouBox) -> f32 {
 /// `overlap` computes the IoU-like suppression score for the task-specific box type.
 /// The public wrappers keep task-specific signatures while sharing the score sorting,
 /// class filtering, and suppression loop.
-fn nms_by_class<T, P>(
+fn nms_by_class<T>(
     boxes: &[(T, f32, usize)],
     iou_threshold: f32,
     max_det: usize,
-    prepare: impl Fn(&T) -> P,
-    overlap: impl Fn(&P, &P) -> f32,
+    overlap: impl Fn(&T, &T) -> f32,
 ) -> Vec<usize> {
     // `max_det == 0` is reachable through `with_max_det(0)` and `--max-det 0`, and the cap
     // below is only checked after a box is pushed, so it has to be rejected up front.
@@ -155,9 +163,6 @@ fn nms_by_class<T, P>(
             .then_with(|| boxes[b].1.total_cmp(&boxes[a].1))
     });
 
-    // Per-box work is done once here rather than for both boxes of every pair below.
-    let prepared: Vec<P> = boxes.iter().map(|(b, _, _)| prepare(b)).collect();
-
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
 
@@ -176,7 +181,7 @@ fn nms_by_class<T, P>(
 
         for &j in &indices[pos + 1..] {
             if !suppressed[j] && boxes[j].2 == class_i {
-                let iou = overlap(&prepared[i], &prepared[j]);
+                let iou = overlap(&boxes[i].0, &boxes[j].0);
                 if iou > iou_threshold {
                     suppressed[j] = true;
                 }
@@ -201,7 +206,7 @@ fn nms_by_class<T, P>(
 /// Indices of boxes to keep
 #[must_use]
 pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, usize::MAX, |b| *b, calculate_iou)
+    nms_by_class(boxes, iou_threshold, usize::MAX, calculate_iou)
 }
 
 /// [`nms_per_class`], stopping once `max_det` boxes are kept.
@@ -214,7 +219,7 @@ pub(crate) fn nms_per_class_capped(
     iou_threshold: f32,
     max_det: usize,
 ) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, max_det, |b| *b, calculate_iou)
+    nms_by_class(boxes, iou_threshold, max_det, calculate_iou)
 }
 
 /// Rotated Per-class Non-Maximum Suppression (NMS) using `ProbIoU`
@@ -234,10 +239,9 @@ pub(crate) fn nms_per_class_capped(
 #[must_use]
 pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f32) -> Vec<usize> {
     nms_by_class(
-        boxes,
+        &ProbIouBox::prepare_all(boxes),
         iou_threshold,
         usize::MAX,
-        ProbIouBox::new,
         probiou_prepared,
     )
 }
@@ -250,10 +254,9 @@ pub(crate) fn nms_rotated_per_class_capped(
     max_det: usize,
 ) -> Vec<usize> {
     nms_by_class(
-        boxes,
+        &ProbIouBox::prepare_all(boxes),
         iou_threshold,
         max_det,
-        ProbIouBox::new,
         probiou_prepared,
     )
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,36 +68,55 @@ fn get_covariance_params(w: f32, h: f32, angle: f32) -> (f32, f32, f32) {
 /// `ProbIoU` value between 0.0 and 1.0
 #[must_use]
 pub fn calculate_probiou(box1: &[f32; 5], box2: &[f32; 5]) -> f32 {
+    probiou_prepared(&ProbIouBox::new(box1), &ProbIouBox::new(box2))
+}
+
+/// A rotated box reduced to the terms [`probiou_prepared`] needs.
+///
+/// The covariance `(a, b, c)` and its determinant depend only on one box, but
+/// [`calculate_probiou`] recomputed them for both boxes of every pair, putting four trig
+/// calls inside an O(n^2) loop. Building this once per box moves that work to O(n).
+#[derive(Clone, Copy)]
+struct ProbIouBox {
+    x: f32,
+    y: f32,
+    a: f32,
+    b: f32,
+    c: f32,
+    /// `a * b - c^2`, clamped at zero for the `t3` denominator.
+    det: f32,
+}
+
+impl ProbIouBox {
+    fn new(b: &[f32; 5]) -> Self {
+        let (a, bb, c) = get_covariance_params(b[2], b[3], b[4]);
+        Self {
+            x: b[0],
+            y: b[1],
+            a,
+            b: bb,
+            c,
+            det: a.mul_add(bb, -c.powi(2)).max(0.0),
+        }
+    }
+}
+
+/// [`calculate_probiou`] over two boxes whose covariance terms are already computed.
+fn probiou_prepared(p1: &ProbIouBox, p2: &ProbIouBox) -> f32 {
     let eps = 1e-7;
 
-    let x1 = box1[0];
-    let y1 = box1[1];
-    let w1 = box1[2];
-    let h1 = box1[3];
-    let r1 = box1[4];
+    let (a1, b1, c1) = (p1.a, p1.b, p1.c);
+    let (a2, b2, c2) = (p2.a, p2.b, p2.c);
+    let (x1, y1, x2, y2) = (p1.x, p1.y, p2.x, p2.y);
 
-    let x2 = box2[0];
-    let y2 = box2[1];
-    let w2 = box2[2];
-    let h2 = box2[3];
-    let r2 = box2[4];
+    let denom = (a1 + a2).mul_add(b1 + b2, -(c1 + c2).powi(2) + eps);
 
-    let (a1, b1, c1) = get_covariance_params(w1, h1, r1);
-    let (a2, b2, c2) = get_covariance_params(w2, h2, r2);
+    let t1 = ((a1 + a2).mul_add((y1 - y2).powi(2), (b1 + b2) * (x1 - x2).powi(2)) / denom) * 0.25;
 
-    let t1 = ((a1 + a2).mul_add((y1 - y2).powi(2), (b1 + b2) * (x1 - x2).powi(2))
-        / (a1 + a2).mul_add(b1 + b2, -(c1 + c2).powi(2) + eps))
-        * 0.25;
-
-    let t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2))
-        / (a1 + a2).mul_add(b1 + b2, -(c1 + c2).powi(2) + eps))
-        * 0.5;
+    let t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / denom) * 0.5;
 
     let t3_num = (a1 + a2).mul_add(b1 + b2, -(c1 + c2).powi(2));
-    let t3_den = 4.0f32.mul_add(
-        ((a1.mul_add(b1, -c1.powi(2))).max(0.0) * (a2.mul_add(b2, -c2.powi(2))).max(0.0)).sqrt(),
-        eps,
-    );
+    let t3_den = 4.0f32.mul_add((p1.det * p2.det).sqrt(), eps);
     let t3 = (t3_num / t3_den + eps).ln() * 0.5;
 
     let bd = (t1 + t2 + t3).clamp(eps, 100.0);
@@ -111,11 +130,12 @@ pub fn calculate_probiou(box1: &[f32; 5], box2: &[f32; 5]) -> f32 {
 /// `overlap` computes the IoU-like suppression score for the task-specific box type.
 /// The public wrappers keep task-specific signatures while sharing the score sorting,
 /// class filtering, and suppression loop.
-fn nms_by_class<T>(
+fn nms_by_class<T, P>(
     boxes: &[(T, f32, usize)],
     iou_threshold: f32,
     max_det: usize,
-    overlap: impl Fn(&T, &T) -> f32,
+    prepare: impl Fn(&T) -> P,
+    overlap: impl Fn(&P, &P) -> f32,
 ) -> Vec<usize> {
     // `max_det == 0` is reachable through `with_max_det(0)` and `--max-det 0`, and the cap
     // below is only checked after a box is pushed, so it has to be rejected up front.
@@ -135,6 +155,9 @@ fn nms_by_class<T>(
             .then_with(|| boxes[b].1.total_cmp(&boxes[a].1))
     });
 
+    // Per-box work is done once here rather than for both boxes of every pair below.
+    let prepared: Vec<P> = boxes.iter().map(|(b, _, _)| prepare(b)).collect();
+
     let mut keep = vec![];
     let mut suppressed = vec![false; boxes.len()];
 
@@ -153,7 +176,7 @@ fn nms_by_class<T>(
 
         for &j in &indices[pos + 1..] {
             if !suppressed[j] && boxes[j].2 == class_i {
-                let iou = overlap(&boxes[i].0, &boxes[j].0);
+                let iou = overlap(&prepared[i], &prepared[j]);
                 if iou > iou_threshold {
                     suppressed[j] = true;
                 }
@@ -178,7 +201,7 @@ fn nms_by_class<T>(
 /// Indices of boxes to keep
 #[must_use]
 pub fn nms_per_class(boxes: &[([f32; 4], f32, usize)], iou_threshold: f32) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, usize::MAX, calculate_iou)
+    nms_by_class(boxes, iou_threshold, usize::MAX, |b| *b, calculate_iou)
 }
 
 /// [`nms_per_class`], stopping once `max_det` boxes are kept.
@@ -191,7 +214,7 @@ pub(crate) fn nms_per_class_capped(
     iou_threshold: f32,
     max_det: usize,
 ) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, max_det, calculate_iou)
+    nms_by_class(boxes, iou_threshold, max_det, |b| *b, calculate_iou)
 }
 
 /// Rotated Per-class Non-Maximum Suppression (NMS) using `ProbIoU`
@@ -210,7 +233,13 @@ pub(crate) fn nms_per_class_capped(
 /// Indices of boxes to keep
 #[must_use]
 pub fn nms_rotated_per_class(boxes: &[([f32; 5], f32, usize)], iou_threshold: f32) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, usize::MAX, calculate_probiou)
+    nms_by_class(
+        boxes,
+        iou_threshold,
+        usize::MAX,
+        ProbIouBox::new,
+        probiou_prepared,
+    )
 }
 
 /// [`nms_rotated_per_class`], stopping once `max_det` boxes are kept. See
@@ -220,7 +249,13 @@ pub(crate) fn nms_rotated_per_class_capped(
     iou_threshold: f32,
     max_det: usize,
 ) -> Vec<usize> {
-    nms_by_class(boxes, iou_threshold, max_det, calculate_probiou)
+    nms_by_class(
+        boxes,
+        iou_threshold,
+        max_det,
+        ProbIouBox::new,
+        probiou_prepared,
+    )
 }
 
 /// Simple pluralization for common COCO class names.


### PR DESCRIPTION
`calculate_probiou` derived each box's covariance from `w`, `h`, and `angle` on every call, so four trig calls and two determinants were recomputed for both boxes of every pair inside the O(n^2) suppression loop. Those terms depend on a single box, so the rotated wrappers now reduce each box once and hand the result to the shared loop.

`nms_by_class` and the axis-aligned path are untouched: `git diff` against main shows no change to either, so `nms_per_class` runs exactly the code it ran before.

Timings are `nms_rotated_per_class` with both variants alternating in one release binary on an idle machine. The `1 class` rows put every box in one class over a third of the frame so almost every pair is compared.

| boxes | classes | before | after | speedup |
| ----- | ------- | ------ | ----- | ------- |
| 3000 | 15 | 14.59ms | 11.83ms | 1.23x |
| 3000 | 1 | 5.55ms | 2.36ms | 2.35x |
| 1000 | 15 | 1.74ms | 1.27ms | 1.37x |
| 1000 | 1 | 1.06ms | 0.63ms | 1.68x |
| 500 | 1 | 485us | 276us | 1.76x |
| 200 | 15 | 55.9us | 39.8us | 1.41x |

Preparing every box up front costs nothing measurable even when the loop compares no pairs at all. Giving every box its own class, so no two boxes are ever compared, still runs faster than before: 258us against 303us at 1000 boxes, and 2.26ms against 2.90ms at 3000.

Output is unchanged, not approximated. Compared against the previous implementation over 77220 box pairs: 77220 bit-identical results, maximum absolute difference zero, including a zero-size box, a 1e-6 box, and an extreme aspect ratio where both return NaN. The suppression loop returns the same kept indices on every benchmark case, and `predict --task obb` on `assets/boats.jpg` still reports 169 ships and 1 harbor.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Rotated-box ProbIoU computation now prepares each box’s covariance terms once before suppression, reducing repeated work in rotated NMS without changing results.

### 📊 Key Changes
- Added `ProbIouBox` to store each box’s coordinates, covariance terms, and clamped determinant.
- Added `probiou_prepared` for pairwise ProbIoU using precomputed box data; `calculate_probiou` continues to support the existing two-box API.
- Updated `nms_rotated_per_class` and `nms_rotated_per_class_capped` to prepare all boxes once before calling the shared suppression loop.
- Left `nms_by_class` and the axis-aligned `nms_per_class` path unchanged.

### 🎯 Purpose & Impact
- Rotated NMS avoids recalculating trigonometric covariance terms and determinants for every box pair, improving suppression performance, especially with many boxes in the same class.
- The PR reports unchanged kept indices and bit-identical ProbIoU results for the compared box pairs, including edge cases.
- No user-facing behavior change to axis-aligned NMS or rotated-box suppression results.