### PR TITLE
Reuse the webcam scaler and return errors instead of panicking on bad input

### DIFF
--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -716,8 +716,7 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     #[allow(clippy::cast_possible_truncation)]
     let (target_h, target_w) = (target_size.0 as u32, target_size.1 as u32);
 
-    // Every failure below leaves no usable pixels, so fall back to a blank target-size frame
-    // rather than panicking: this runs under the public `preprocess_image_center_crop`.
+    // Any failure below yields no usable pixels; return a blank frame rather than panicking.
     let blank = || {
         (
             RgbImage::from_pixel(target_w, target_h, image::Rgb(LETTERBOX_COLOR)),
@@ -848,8 +847,6 @@ mod tests {
 
     /// A zero-dimension image underflowed `src_w - 1` in the LUT builder, which panics under
     /// the overflow checks the dev profile enables.
-    /// The classify path returns a blank frame for input it cannot resize rather than
-    /// panicking, since `preprocess_image_center_crop` is public.
     #[test]
     fn test_center_crop_degenerate_input_does_not_panic() {
         for (w, h) in [(0, 0), (0, 64), (64, 0)] {

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -716,11 +716,19 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     #[allow(clippy::cast_possible_truncation)]
     let (target_h, target_w) = (target_size.0 as u32, target_size.1 as u32);
 
+    // Every failure below leaves no usable pixels, so fall back to a blank target-size frame
+    // rather than panicking: this runs under the public `preprocess_image_center_crop`.
+    let blank = || {
+        (
+            RgbImage::from_pixel(target_w, target_h, image::Rgb(LETTERBOX_COLOR)),
+            (1.0, 1.0),
+        )
+    };
+
     // The cover scale below divides by each source extent, so `target / 0` is infinite: the
     // resized extents come out garbage and the allocator is asked for terabytes.
     if src_w == 0 || src_h == 0 {
-        let blank = RgbImage::from_pixel(target_w, target_h, image::Rgb(LETTERBOX_COLOR));
-        return (blank, (1.0, 1.0));
+        return blank();
     }
 
     // Calculate scale to "cover" the target area
@@ -757,8 +765,9 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
             owned_rgb.as_raw()
         }
     };
-    let src_image = ImageRef::new(src_w, src_h, src_bytes, PixelType::U8x3)
-        .expect("Failed to create source image");
+    let Ok(src_image) = ImageRef::new(src_w, src_h, src_bytes, PixelType::U8x3) else {
+        return blank();
+    };
 
     // Valid dimensions check
     let safe_new_w = new_w.max(1);
@@ -770,14 +779,18 @@ fn center_crop_image(image: &DynamicImage, target_size: (usize, usize)) -> (RgbI
     let options = ResizeOptions::new().resize_alg(ResizeAlg::Convolution(
         fast_image_resize::FilterType::Bilinear,
     ));
-    resizer
+    if resizer
         .resize(&src_image, &mut dst_image, Some(&options))
-        .expect("Failed to resize image");
+        .is_err()
+    {
+        return blank();
+    }
 
     // Convert back to RgbImage to crop
     let resized_buffer = dst_image.into_vec();
-    let resized_rgb = RgbImage::from_raw(safe_new_w, safe_new_h, resized_buffer)
-        .expect("Failed to create resized buffer");
+    let Some(resized_rgb) = RgbImage::from_raw(safe_new_w, safe_new_h, resized_buffer) else {
+        return blank();
+    };
 
     // Calculate crop offsets using Banker's Rounding (round half to even).
     #[allow(clippy::cast_precision_loss)]
@@ -835,6 +848,17 @@ mod tests {
 
     /// A zero-dimension image underflowed `src_w - 1` in the LUT builder, which panics under
     /// the overflow checks the dev profile enables.
+    /// The classify path returns a blank frame for input it cannot resize rather than
+    /// panicking, since `preprocess_image_center_crop` is public.
+    #[test]
+    fn test_center_crop_degenerate_input_does_not_panic() {
+        for (w, h) in [(0, 0), (0, 64), (64, 0)] {
+            let img = DynamicImage::ImageRgb8(image::RgbImage::new(w, h));
+            let res = preprocess_image_center_crop(&img, (224, 224), false);
+            assert_eq!(res.tensor.shape(), &[1, 3, 224, 224]);
+        }
+    }
+
     #[test]
     fn test_zero_dimension_image_does_not_panic() {
         for (w, h) in [(0, 0), (0, 64), (64, 0)] {

--- a/src/source.rs
+++ b/src/source.rs
@@ -407,6 +407,11 @@ pub struct SourceIterator {
     decoder: Option<BilinearVideoDecoder>,
     #[cfg(feature = "video")]
     webcam_decoder: Option<(ffmpeg::format::context::Input, ffmpeg::decoder::Video)>,
+    /// Colorspace conversion context for the webcam, kept across frames like
+    /// [`BilinearVideoDecoder::scaler`]. Rebuilding it per frame costs a full
+    /// `sws_getContext` for every captured frame.
+    #[cfg(feature = "video")]
+    webcam_scaler: Option<ffmpeg::software::scaling::context::Context>,
     #[cfg(feature = "video")]
     webcam_stream_index: usize,
     #[cfg(feature = "video")]
@@ -449,6 +454,8 @@ impl SourceIterator {
             decoder: None,
             #[cfg(feature = "video")]
             webcam_decoder: None,
+            #[cfg(feature = "video")]
+            webcam_scaler: None,
             #[cfg(feature = "video")]
             webcam_stream_index: 0,
             #[cfg(feature = "video")]
@@ -630,7 +637,12 @@ impl SourceIterator {
                 };
 
                 // Find input format by name using low-level C API
-                let c_name = std::ffi::CString::new(input_format_name).unwrap();
+                let Ok(c_name) = std::ffi::CString::new(input_format_name) else {
+                    self.webcam_init_failed = true;
+                    return Some(Err(InferenceError::VideoError(format!(
+                        "Invalid input format name '{input_format_name}'"
+                    ))));
+                };
                 #[allow(unsafe_code)]
                 let ptr = unsafe { video_rs::ffmpeg::ffi::av_find_input_format(c_name.as_ptr()) };
 
@@ -686,10 +698,19 @@ impl SourceIterator {
                                     let stream_index = stream.index();
                                     self.webcam_stream_index = stream_index;
                                     let context_decoder =
-                                        ffmpeg::codec::context::Context::from_parameters(
+                                        match ffmpeg::codec::context::Context::from_parameters(
                                             stream.parameters(),
-                                        )
-                                        .unwrap();
+                                        ) {
+                                            Ok(ctx) => ctx,
+                                            Err(e) => {
+                                                self.webcam_init_failed = true;
+                                                return Some(Err(InferenceError::VideoError(
+                                                    format!(
+                                                        "Failed to read webcam stream parameters: {e}"
+                                                    ),
+                                                )));
+                                            }
+                                        };
                                     match context_decoder.decoder().video() {
                                         Ok(decoder) => {
                                             self.webcam_decoder = Some((ictx, decoder));
@@ -733,9 +754,8 @@ impl SourceIterator {
                         && decoder.send_packet(&packet).is_ok()
                         && decoder.receive_frame(&mut decoded).is_ok()
                     {
-                        // Convert the decoded frame to RGB via the shared scaler helper.
-                        let mut scaler = None;
-                        let img = match frame_to_rgb_image(&mut scaler, &decoded) {
+                        // Convert the decoded frame to RGB, reusing the scaler across frames.
+                        let img = match frame_to_rgb_image(&mut self.webcam_scaler, &decoded) {
                             Ok(img) => img,
                             Err(e) => return Some(Err(e)),
                         };

--- a/src/source.rs
+++ b/src/source.rs
@@ -239,35 +239,37 @@ use video_rs::ffmpeg;
 /// borderline confidence predictions and lead to small detection drift.
 /// For consistency, this decoder uses `SWS_BILINEAR` explicitly.
 /// Convert a decoded video frame to a tightly-packed RGB24 [`DynamicImage`] using a BILINEAR
-/// scaler. `scaler` caches the conversion context and is initialized lazily from the frame's
-/// format and dimensions, so pass a persistent `Option` to reuse it across frames or a fresh
-/// `None` for a one-shot conversion.
+/// scaler. `scaler` caches the context and is rebuilt when the frame's format or size
+/// changes, so pass a persistent `Option` to reuse it across frames.
 #[cfg(feature = "video")]
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn frame_to_rgb_image(
     scaler: &mut Option<ffmpeg::software::scaling::context::Context>,
     decoded: &ffmpeg::util::frame::video::Video,
 ) -> Result<DynamicImage> {
-    // Initialize scaler on first frame (we need actual dimensions).
-    if scaler.is_none() {
-        *scaler = Some(
-            ffmpeg::software::scaling::context::Context::get(
-                decoded.format(),
-                decoded.width(),
-                decoded.height(),
-                ffmpeg::format::Pixel::RGB24,
-                decoded.width(),
-                decoded.height(),
-                ffmpeg::software::scaling::flag::Flags::BILINEAR,
-            )
-            .map_err(|e| InferenceError::VideoError(format!("Scaler init: {e}")))?,
-        );
-    }
+    // Drop a cached context whose source properties no longer match: a webcam can
+    // renegotiate format or resolution mid-capture.
+    let reusable = scaler.take().filter(|s| {
+        let i = s.input();
+        i.format == decoded.format() && i.width == decoded.width() && i.height == decoded.height()
+    });
+    let context = match reusable {
+        Some(s) => s,
+        None => ffmpeg::software::scaling::context::Context::get(
+            decoded.format(),
+            decoded.width(),
+            decoded.height(),
+            ffmpeg::format::Pixel::RGB24,
+            decoded.width(),
+            decoded.height(),
+            ffmpeg::software::scaling::flag::Flags::BILINEAR,
+        )
+        .map_err(|e| InferenceError::VideoError(format!("Scaler init: {e}")))?,
+    };
 
     let mut rgb_frame = ffmpeg::util::frame::video::Video::empty();
     scaler
-        .as_mut()
-        .unwrap()
+        .insert(context)
         .run(decoded, &mut rgb_frame)
         .map_err(|e| InferenceError::VideoError(format!("Scale: {e}")))?;
 
@@ -407,9 +409,7 @@ pub struct SourceIterator {
     decoder: Option<BilinearVideoDecoder>,
     #[cfg(feature = "video")]
     webcam_decoder: Option<(ffmpeg::format::context::Input, ffmpeg::decoder::Video)>,
-    /// Colorspace conversion context for the webcam, kept across frames like
-    /// [`BilinearVideoDecoder::scaler`]. Rebuilding it per frame costs a full
-    /// `sws_getContext` for every captured frame.
+    /// Colorspace context reused across webcam frames, as the video path does.
     #[cfg(feature = "video")]
     webcam_scaler: Option<ffmpeg::software::scaling::context::Context>,
     #[cfg(feature = "video")]
@@ -754,7 +754,6 @@ impl SourceIterator {
                         && decoder.send_packet(&packet).is_ok()
                         && decoder.receive_frame(&mut decoded).is_ok()
                     {
-                        // Convert the decoded frame to RGB, reusing the scaler across frames.
                         let img = match frame_to_rgb_image(&mut self.webcam_scaler, &decoded) {
                             Ok(img) => img,
                             Err(e) => return Some(Err(e)),


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Webcam frame conversion now reuses a compatible FFmpeg scaler, while invalid webcam configuration and image-processing failures are handled without panics.

### 📊 Key Changes

- Added `webcam_scaler` to `SourceIterator` and passed it across webcam frames for reuse.
- Updated `frame_to_rgb_image` to rebuild the scaler when the input format or dimensions change.
- Replaced webcam initialization panics for invalid format names and unreadable stream parameters with `InferenceError::VideoError` results.
- Updated `center_crop_image` to return a blank letterboxed frame when image creation, resizing, or buffer conversion fails, and added degenerate-input coverage.

### 🎯 Purpose & Impact

- Webcam capture avoids recreating the colorspace conversion context for every frame while still adapting to format or resolution changes.
- Bad webcam configuration now propagates an error through the source iterator instead of panicking; invalid image-processing inputs produce a correctly shaped blank frame instead of panicking.