### PR TITLE
Delete the ModelMetadata half field that only mirrored quantize

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -42,9 +42,6 @@ pub struct ModelMetadata {
     pub channels: usize,
     /// Precision recorded by the model export metadata.
     pub quantize: Option<Quantization>,
-    /// Legacy FP16 metadata alias. Use [`Self::quantize`] instead.
-    #[doc(hidden)]
-    pub half: bool,
     /// Class ID to class name mapping.
     pub names: Arc<HashMap<usize, String>>,
     /// Whether the model was exported with end-to-end NMS-free output
@@ -184,7 +181,6 @@ impl ModelMetadata {
             // flag, so it maps straight through without the deprecation warning.
             metadata.quantize = half.unwrap_or(false).then_some(Quantization::Fp16);
         }
-        metadata.half = metadata.quantize == Some(Quantization::Fp16);
 
         // imgsz is a two-integer list (`[640, 640]` inline or a `- 640` block),
         // parsed with the same helper as kpt_shape.
@@ -420,7 +416,6 @@ impl Default for ModelMetadata {
             imgsz: None,
             channels: 3,
             quantize: None,
-            half: false,
             names: Arc::new(HashMap::new()),
             end2end: false,
             kpt_shape: None,
@@ -543,14 +538,12 @@ channels: 3
     fn test_precision_metadata_compatibility() {
         let metadata = ModelMetadata::from_yaml_str("args: {'half': True}").unwrap();
         assert_eq!(metadata.quantize, Some(Quantization::Fp16));
-        assert!(metadata.half);
 
         let metadata = ModelMetadata::from_yaml_str(
             "quantize: 32\nhalf: true\nargs: {'quantize': 16, 'half': True}",
         )
         .unwrap();
         assert_eq!(metadata.quantize, Some(Quantization::Fp32));
-        assert!(!metadata.half);
     }
 
     #[test]


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed the redundant `ModelMetadata::half` field and its synchronization logic, keeping `quantize` as the sole precision metadata representation.

### 📊 Key Changes
- Deleted the hidden `half: bool` field from `ModelMetadata`.
- Removed initialization of `half` in `Default` and assignment during YAML metadata parsing.
- Updated precision compatibility tests to validate only `quantize`.
- Preserved parsing behavior for legacy `half` metadata by mapping it to `Quantization::Fp16` when applicable.

### 🎯 Purpose & Impact
- Simplifies `ModelMetadata` by eliminating a field that duplicated `quantize`.
- Existing metadata parsing continues to determine precision through `quantize`; consumers can no longer access the removed `half` field.