### PR TITLE
Keep the README code blocks parseable by the format checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ ultralytics-inference help
 ultralytics-inference version
 
 # Run inference
-ultralytics-inference predict --model <model.onnx> --source <source>
+ultralytics-inference predict --model yolo26n.onnx --source image.jpg
 ```
 
 `--help` and `--version` are also supported as standard flag aliases.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,8 +145,8 @@ yolo export model=yolo26n.pt format=onnx quantize=16
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-model.export(format="onnx")  # FP32（默认）
-model.export(format="onnx", quantize=16)  # FP16（半精度）
+model.export(format="onnx")  # FP32 (默认)
+model.export(format="onnx", quantize=16)  # FP16 (半精度)
 ```
 
 > **精度 / 量化：** Ultralytics ≥8.4 使用统一的 `quantize` 参数，取代已弃用的
@@ -256,7 +256,7 @@ ultralytics-inference help
 ultralytics-inference version
 
 # 运行推理
-ultralytics-inference predict --model <model.onnx> --source <source>
+ultralytics-inference predict --model yolo26n.onnx --source image.jpg
 ```
 
 `--help` 和 `--version` 也可作为标准别名使用。

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -179,8 +179,8 @@ await annotate(canvas, img, results, { depthAlpha: 0.6 });
   ```python
   from ultralytics import YOLO
 
-  YOLO("yolo26n.pt").export(format="onnx")  # FP32（默认）
-  YOLO("yolo26n.pt").export(format="onnx", quantize=16)  # FP16（体积约小 50%）
+  YOLO("yolo26n.pt").export(format="onnx")  # FP32 (默认)
+  YOLO("yolo26n.pt").export(format="onnx", quantize=16)  # FP16 (体积约小 50%)
   ```
 
   > Ultralytics ≥8.4 使用 `quantize` 参数，取代已弃用的 `half=True` / `int8=True` 标志。


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated README examples to use concrete model and image filenames and replaced full-width punctuation in Chinese code comments so format checks can parse the code blocks.

### 📊 Key Changes

- Changed CLI inference examples in `README.md` and `README.zh-CN.md` from placeholder paths to `yolo26n.onnx` and `image.jpg`.
- Replaced full-width parentheses with ASCII parentheses in ONNX export comments in `README.zh-CN.md` and `web/README.zh-CN.md`.

### 🎯 Purpose & Impact

- README code blocks now use parseable example arguments and ASCII comment punctuation, improving compatibility with automated format checks.
- No runtime or library behavior was changed.