### PR TITLE
Run end2end models on WebGPU when asked and keep auto off software adapters

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -276,18 +276,17 @@ Notes:
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
-- **Export end2end-free models** (`end2end=False`): Ultralytics YOLO26 defaults to an
-  end-to-end, NMS-free head whose `int64` / `gather_nd` ops the LiteRT
-  **WebGPU** delegate cannot run, so those exports silently fall back to CPU/wasm.
-  Export them with `end2end=False` so the standard head is used and NMS runs in
-  this package's Rust, keeping inference on WebGPU:
+- **End2end models run on the CPU by default**: Ultralytics YOLO26 uses an
+  end-to-end, NMS-free head. Reading its outputs back from the GPU needs Asyncify,
+  which ships only in LiteRT's JSPI build, and that build excludes WASM threads.
+  Losing threads slows this package's own pre- and post-processing by more than the
+  GPU saves, so `device: "auto"` keeps these models on multithreaded wasm. Pass
+  `device: "webgpu"` to override; a browser without JSPI falls back to wasm with a
+  warning. Exporting the standard head instead keeps threads _and_ the GPU:
 
   ```bash
   yolo export model=yolo26n.pt format=litert end2end=False
   ```
-
-  If you load an end2end `.tflite` anyway, the backend auto-switches it to wasm
-  (slower) and logs a warning rather than returning empty results.
 
 - **Tasks**: detect, segment, pose, obb, classify, semantic, and depth are all supported.
 - **Cross-origin isolation**: LiteRT's threaded wasm wants `SharedArrayBuffer`,

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -255,16 +255,15 @@ wasm 默认从 jsDelivr CDN 加载；向 `YOLO.load` 传入 `litertWasmUrl: "/li
 - **需要 Ultralytics `>= 8.4.83`**：带内嵌元数据的单文件 LiteRT 导出自
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) 起提供。更早的版本
   会导出旧版 TFLite 格式，无法在这里加载。
-- **导出非 end2end 模型**（`end2end=False`）：Ultralytics YOLO26 默认使用端到端、无 NMS 的检测头，
-  其中的 `int64` / `gather_nd` 算子无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会
-  静默回退到 CPU/wasm。请使用 `end2end=False` 导出，以便使用标准检测头，并由本包的 Rust 代码执行
-  NMS，从而让推理保持在 WebGPU 上：
+- **end2end 模型默认在 CPU 上运行**：Ultralytics YOLO26 使用端到端、无 NMS 的检测头。
+  从 GPU 读回其输出需要 Asyncify，而它只包含在 LiteRT 的 JSPI 构建中，该构建不支持 WASM 多线程。
+  失去多线程对本包自身前后处理的拖慢，超过了 GPU 带来的收益，因此 `device: "auto"` 会让这类模型
+  继续使用多线程 wasm。传入 `device: "webgpu"` 可强制使用 GPU；不支持 JSPI 的浏览器会回退到 wasm
+  并打印警告。改用标准检测头导出，则可同时保留多线程与 GPU：
 
   ```bash
   yolo export model=yolo26n.pt format=litert end2end=False
   ```
-
-  如果仍然加载了 end2end 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
 
 - **支持的任务**：detect、segment、pose、obb、classify、semantic 和 depth 均已支持。
 - **跨源隔离**：LiteRT 的多线程 wasm 需要 `SharedArrayBuffer`，因此请以

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -158,10 +158,38 @@ export interface LoadOptions {
  * needs a real adapter, since `navigator.gpu` can exist while `requestAdapter()`
  * still returns `null` — so `YOLO.device` reports what actually ran.
  */
+/** Software rasterizers that expose WebGPU but run on the CPU, where wasm is faster. */
+const SOFTWARE_GPU = /swiftshader|llvmpipe|lavapipe|basic render|software/i;
+
+interface GpuAdapter {
+  isFallbackAdapter?: boolean;
+  info?: { vendor?: string; architecture?: string; description?: string };
+}
+
+/** True when the adapter is a CPU rasterizer rather than real GPU hardware.
+ *
+ * `isFallbackAdapter` is the spec answer, but Chrome leaves it `undefined` on both
+ * software and hardware adapters, so the reported vendor/architecture (which names
+ * the rasterizer outright) is what actually decides. */
+function isSoftwareAdapter({ isFallbackAdapter, info }: GpuAdapter): boolean {
+  if (isFallbackAdapter) return true;
+  return SOFTWARE_GPU.test(`${info?.vendor ?? ""} ${info?.architecture ?? ""} ${info?.description ?? ""}`);
+}
+
 async function resolveDevice(pref?: "auto" | "webgpu" | "cpu"): Promise<string> {
   if (pref === "cpu") return "cpu";
-  const gpu = (navigator as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
-  if (await gpu?.requestAdapter().catch(() => null)) return "webgpu";
+  const gpu = (navigator as { gpu?: { requestAdapter(): Promise<GpuAdapter | null> } }).gpu;
+  const adapter = (await gpu?.requestAdapter().catch(() => null)) ?? null;
+  if (adapter) {
+    // A software rasterizer reports a working adapter, but wasm with SIMD and threads
+    // beats it by a wide margin, so `"auto"` should not treat it as a GPU. An explicit
+    // `"webgpu"` is still honored.
+    if (pref !== "webgpu" && isSoftwareAdapter(adapter)) {
+      console.warn("[@ultralytics/yolo] WebGPU adapter is a software rasterizer; running on CPU, which is faster.");
+      return "cpu";
+    }
+    return "webgpu";
+  }
   if (pref === "webgpu") console.warn("[@ultralytics/yolo] WebGPU requested but no adapter found; running on CPU.");
   return "cpu";
 }
@@ -361,7 +389,8 @@ interface LiteRtCompiledModel {
   delete?(): void;
 }
 interface LiteRtModule {
-  loadLiteRt(wasmPath: string, opts?: { threads?: boolean }): Promise<void>;
+  loadLiteRt(wasmPath: string, opts?: { threads?: boolean; jspi?: boolean }): Promise<void>;
+  supportsFeature?(feature: string): Promise<boolean>;
   loadAndCompile(model: Uint8Array | string, opts: { accelerator: string | string[] }): Promise<LiteRtCompiledModel>;
   Tensor: new (data: Float32Array, shape: number[]) => LiteRtTensor;
 }
@@ -391,6 +420,8 @@ async function importLiteRt(): Promise<LiteRtModule> {
 // (reload to switch) rather than silently reusing the original assets.
 let litertInit: Promise<void> | null = null;
 let litertInitUrl: string | null = null;
+let litertInitJspi = false;
+
 /** Reject a cross-origin wasm URL on an isolated page before LiteRT fails on it.
  *
  * Threads need `crossOriginIsolated`, which needs `COEP: require-corp`, and that blocks
@@ -408,7 +439,7 @@ function checkWasmUrlReachable(wasmUrl: string): void {
   );
 }
 
-function ensureLiteRtRuntime(litert: LiteRtModule, wasmUrl: string): Promise<void> {
+function ensureLiteRtRuntime(litert: LiteRtModule, wasmUrl: string, jspi = false): Promise<void> {
   if (litertInit) {
     if (litertInitUrl !== wasmUrl) {
       return Promise.reject(
@@ -417,18 +448,32 @@ function ensureLiteRtRuntime(litert: LiteRtModule, wasmUrl: string): Promise<voi
         ),
       );
     }
+    if (litertInitJspi !== jspi) {
+      // Without this the mismatch surfaces from inside the runtime as
+      // "Asyncify is not defined", which says nothing about the cause.
+      return Promise.reject(
+        new Error(
+          `LiteRT.js loads one wasm build per page: it is already running the ${
+            litertInitJspi ? "JSPI" : "multithreaded"
+          } build, and this model needs the ${jspi ? "JSPI" : "multithreaded"} one. Load the end2end model on WebGPU first, keep every model on the same device, or reload the page.`,
+        ),
+      );
+    }
     return litertInit;
   }
   checkWasmUrlReachable(wasmUrl);
   litertInitUrl = wasmUrl;
-  // Enable WASM multithreading when the page is cross-origin isolated (COOP/COEP
-  // set, so SharedArrayBuffer is available); otherwise LiteRT.js runs single-
-  // threaded. SIMD is detected by LiteRT itself. Isolation is a page-global
-  // property, so this needs no per-load option.
+  litertInitJspi = jspi;
+  // `threads` and `jspi` are mutually exclusive builds. Only the JSPI build ships
+  // Asyncify, which WebGPU needs to read back an end2end model's outputs, so that
+  // case asks for JSPI and gives up multithreading. Everything else takes threads
+  // when the page is cross-origin isolated (COOP/COEP set, so SharedArrayBuffer is
+  // available); SIMD is detected by LiteRT itself.
   const threads = typeof crossOriginIsolated !== "undefined" && crossOriginIsolated;
-  litertInit = litert.loadLiteRt(wasmUrl, { threads }).catch((e) => {
+  litertInit = litert.loadLiteRt(wasmUrl, jspi ? { jspi: true } : { threads }).catch((e) => {
     litertInit = null; // let a later load retry if the first init failed
     litertInitUrl = null;
+    litertInitJspi = false;
     throw e;
   });
   return litertInit;
@@ -450,9 +495,14 @@ class LiteRtBackend {
 
   /** Import LiteRT.js, init its wasm, and compile the model, falling back from
    * WebGPU to wasm (CPU) if the GPU accelerator cannot compile. */
-  static async load(tflite: Uint8Array, wasmUrl: string, accelerator: "webgpu" | "wasm"): Promise<LiteRtBackend> {
+  static async load(
+    tflite: Uint8Array,
+    wasmUrl: string,
+    accelerator: "webgpu" | "wasm",
+    jspi = false,
+  ): Promise<LiteRtBackend> {
     const litert = await importLiteRt();
-    await ensureLiteRtRuntime(litert, wasmUrl);
+    await ensureLiteRtRuntime(litert, wasmUrl, jspi);
     try {
       const model = await litert.loadAndCompile(tflite, { accelerator });
       return new LiteRtBackend(litert, model, accelerator);
@@ -710,17 +760,31 @@ export class YOLO {
     // Honor `device` including `"auto"`, which feature-detects WebGPU (so a
     // browser without it goes straight to wasm instead of a failed compile).
     let accelerator: "webgpu" | "wasm" = (await resolveDevice(options?.device)) === "webgpu" ? "webgpu" : "wasm";
-    // End-to-end exports (YOLO26) do NMS/top-k with int64 + gather_nd ops the
-    // LiteRT WebGPU delegate cannot run: it fails to invoke and returns zeros.
-    // Force CPU/wasm so the model works. For WebGPU speed, re-export the model
-    // with `end2end=False` so the standard head (with NMS in Rust) is used.
+    // Reading an end2end (NMS-free) model's outputs back from the GPU needs Asyncify,
+    // which ships only in LiteRT's JSPI build. Ask for that build when the browser
+    // supports JSPI; it costs multithreading, since `threads` and `jspi` are mutually
+    // exclusive. Without JSPI the GPU path throws "Asyncify is not defined", so fall
+    // back to CPU/wasm, which is also where the threaded build is much faster.
+    let jspi = false;
     if (accelerator === "webgpu" && pipeline.end2end) {
-      accelerator = "wasm";
-      console.warn(
-        "LiteRT: this is an end2end (NMS-free) model; its WebGPU delegate can't run the int64 ops, so it runs on CPU/wasm. Re-export with `end2end=False` for WebGPU.",
-      );
+      // Only when WebGPU is asked for by name. The GPU runs an end2end model faster
+      // than wasm does (17ms against 27ms on Apple hardware), but reaching it needs
+      // the JSPI build, which excludes threads, and that leaves this package's own
+      // pre/post-processing single-threaded. End to end that is a net loss: 47ms
+      // against 32ms for multithreaded wasm. `"auto"` therefore stays on the CPU.
+      // `supportsFeature` is absent on older LiteRT builds, which then count as no JSPI.
+      const litert = await importLiteRt();
+      jspi = options?.device === "webgpu" && ((await litert.supportsFeature?.("jspi")) ?? false);
+      if (!jspi) {
+        accelerator = "wasm";
+        console.warn(
+          options?.device === "webgpu"
+            ? "LiteRT: this is an end2end (NMS-free) model and this browser has no JSPI, which its WebGPU path needs, so it runs on CPU/wasm. Re-export with `end2end=False` for WebGPU."
+            : 'LiteRT: this is an end2end (NMS-free) model, so it runs on multithreaded CPU/wasm. Pass `device: "webgpu"` to force the GPU path, or re-export with `end2end=False`.',
+        );
+      }
     }
-    const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator);
+    const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator, jspi);
     // The compiled model outranks the metadata: `pipeline.inputShape` is what sizes the
     // input tensor below, so a stale `imgsz` would build one the model rejects.
     // Signed on purpose: the engine reports a dynamic axis as a negative number, and wasm


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the WebGPU device selection and LiteRT runtime handling so end2end models use WebGPU only when explicitly requested with JSPI support, while `device: "auto"` avoids software adapters and keeps end2end models on CPU/wasm.

### 📊 Key Changes
- Added software-adapter detection using `isFallbackAdapter` and adapter vendor, architecture, and description fields; automatic selection now uses CPU/wasm for matching rasterizers, while explicit `device: "webgpu"` remains honored.
- Added LiteRT JSPI support detection and initialization, including validation that only one LiteRT wasm build—JSPI or multithreaded—runs per page.
- End2end models now remain on multithreaded CPU/wasm under `device: "auto"`; explicit WebGPU requests use JSPI when supported and otherwise fall back to CPU/wasm with a warning.
- Updated English and Chinese documentation to describe the new end2end device behavior and recommend `end2end=False` exports for retaining both WebGPU and wasm threading.

### 🎯 Purpose & Impact
- `device: "auto"` no longer selects WebGPU software rasterizers or the JSPI-based end2end path.
- `device: "webgpu"` can run end2end models through LiteRT JSPI when the browser supports it; without JSPI, the model falls back to CPU/wasm.
- Loading models that require different LiteRT builds now reports an explicit error instead of allowing an unclear runtime mismatch.