### PR TITLE
Update dirs to 7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "num-complex",
 ] }
 ureq = "^3.3.0"
-dirs = "^6.0"
+dirs = "^7.0"
 rayon = "^1.12"
 clap = { version = "^4.6.1", features = ["derive"] }
 # rayon-backed parallelism for ndarray and fast_image_resize, native only.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Rust `dirs` dependency from version 6.0 to 7.0 and refreshed the lockfile accordingly.

### 📊 Key Changes
- Changed the `dirs` dependency constraint in `Cargo.toml` from `^6.0` to `^7.0`.
- Updated the auto-generated `Cargo.lock` file to reflect the dependency change.

### 🎯 Purpose & Impact
- Rust builds now resolve the `dirs` crate from the 7.x release series.
- No other source-code or user-facing behavior changes are shown in the diff.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
