### PR TITLE
Pin the macOS video build to ffmpeg@8 so it stops picking up Homebrew FFmpeg 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,16 @@ jobs:
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
+      # Homebrew's rolling `ffmpeg` is now FFmpeg 9, whose headers drop the
+      # deprecated AVCodec fields and codec IDs that ffmpeg-next 8 still uses.
+      # Stay on the keg-only ffmpeg@8 until video-rs moves to ffmpeg-next 9.
       - name: Install dependencies
-        run: brew install ffmpeg
+        run: |
+          brew install ffmpeg@8
+          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@8)/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Capture FFmpeg version for cache key
-        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg | awk '{print $2}')" >> "$GITHUB_ENV"
+        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg@8 | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,9 @@ jobs:
           xcodebuild -version
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
-      # Homebrew's rolling `ffmpeg` is now FFmpeg 9, whose headers drop the
-      # deprecated AVCodec fields and codec IDs that ffmpeg-next 8 still uses.
-      # Stay on the keg-only ffmpeg@8 until video-rs moves to ffmpeg-next 9.
       - name: Install dependencies
         run: |
+          brew update
           brew install ffmpeg@8
           echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@8)/lib/pkgconfig" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Homebrew now ships FFmpeg 9, whose headers drop the deprecated AVCodec fields and codec IDs that ffmpeg-next 8 (via video-rs) still uses, so the macOS video job fails to build until video-rs moves to ffmpeg-next 9.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The macOS video CI workflow now installs and uses Homebrew `ffmpeg@8` instead of the unversioned FFmpeg package to maintain compatibility with the current video dependencies.

### 📊 Key Changes

- Runs `brew update` before installing dependencies.
- Installs the versioned `ffmpeg@8` Homebrew formula.
- Sets `PKG_CONFIG_PATH` to the `ffmpeg@8` package configuration directory.
- Uses the installed `ffmpeg@8` version when generating the CI cache key.

### 🎯 Purpose & Impact

- Prevents the macOS video build from selecting Homebrew FFmpeg 9, whose removed headers and codec IDs are incompatible with `ffmpeg-next` 8 through `video-rs`.
- No user-facing change.