### PR TITLE
Align all inference export guidance with unified NMS arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,16 @@ ultralytics-inference help
 
 ### Export a YOLO Model to ONNX
 
+These examples use Ultralytics `>=8.4.142`. For detect, segment, pose, and OBB,
+`nms=None` (the default) exports raw one-to-many outputs and this library runs NMS;
+`nms=False` selects the NMS-free one-to-one head when available (e.g. YOLO26);
+`nms=True` embeds NMS in the ONNX graph. All three output layouts are supported.
+Use `nms=None` for semantic, depth, and classify. Existing compatible ONNX files
+continue to load without re-exporting.
+
 ```bash
+pip install -U "ultralytics[export-base]>=8.4.142"
+
 # Using Ultralytics CLI (FP32, default)
 yolo export model=yolo26n.pt format=onnx
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,7 +132,16 @@ ultralytics-inference help
 
 ### 将 YOLO 模型导出为 ONNX
 
+以下示例使用 Ultralytics `>=8.4.142`。对于 detect、segment、pose 和 OBB，
+`nms=None`（默认值）导出原始的一对多输出，由本库执行 NMS；
+`nms=False` 在模型支持时选择无 NMS 的一对一检测头（例如 YOLO26）；
+`nms=True` 将 NMS 嵌入 ONNX 图中。本库支持这三种输出布局。
+semantic、depth 和 classify 使用 `nms=None`。现有的兼容 ONNX 文件
+无需重新导出即可继续加载。
+
 ```bash
+pip install -U "ultralytics[export-base]>=8.4.142"
+
 # 使用 Ultralytics CLI（FP32，默认）
 yolo export model=yolo26n.pt format=onnx
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -661,7 +661,7 @@ impl YoloPipeline {
         self.metadata.task.as_str().to_owned()
     }
 
-    /// Whether this is an end-to-end (NMS-free) export, e.g. YOLO26. Its head runs
+    /// Whether this is an NMS-free export, e.g. YOLO26 with `nms=False`. Its head runs
     /// the NMS/top-k with `int64`/`gather_nd` ops that the LiteRT WebGPU delegate
     /// cannot execute, so such models must run on the CPU (wasm) accelerator.
     #[wasm_bindgen(getter)]

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -662,7 +662,7 @@ impl YoloPipeline {
     }
 
     /// Whether this is an NMS-free export, e.g. YOLO26 with `nms=False`. Its head runs
-    /// the NMS/top-k with `int64`/`gather_nd` ops that the LiteRT WebGPU delegate
+    /// top-k selection with `int64`/`gather_nd` ops that the LiteRT WebGPU delegate
     /// cannot execute, so such models must run on the CPU (wasm) accelerator.
     #[wasm_bindgen(getter)]
     #[must_use]

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,12 +62,14 @@ Found 5 detections
 The examples load `yolo26n.onnx`, downloading it on first use. To provide the model yourself, export it with the Ultralytics Python package. The command below writes `yolo26n.onnx` into the current directory, which the example then loads instead of downloading. The positional argument is still the input image:
 
 ```bash
-pip install ultralytics
+pip install -U "ultralytics[export-base]>=8.4.142"
 yolo export model=yolo26n.pt format=onnx
 
 cargo run --example basic -- image.jpg
 ```
 
+The default `nms=None` exports raw one-to-many outputs, with NMS handled by this library.
+For the other NMS modes and tasks, see [ONNX export options](../README.md#export-a-yolo-model-to-onnx).
 To run a different model, change the model path in the example.
 
 ## 🤝 Contributing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@
 //!
 //! ## Task-Specific Examples
 //!
-//! The library supports all YOLO tasks. Export models to ONNX:
+//! The library supports all YOLO tasks. Export models to ONNX with Ultralytics >=8.4.142:
 //!
 //! ```bash
 //! # Detection (default)
@@ -178,8 +178,14 @@
 //! yolo export model=yolo26n-depth.pt format=onnx
 //! ```
 //!
+//! For detect, segment, pose, and OBB, `nms=None` (default) exports raw one-to-many
+//! outputs for NMS in Rust; `nms=False` selects the NMS-free one-to-one head when
+//! available (e.g. YOLO26); `nms=True` embeds NMS in ONNX. All three layouts are
+//! supported. Use `nms=None` for semantic, depth, and classify. Existing compatible
+//! models do not need re-exporting.
+//!
 //! Add `quantize=16` for an FP16 ONNX, or `quantize=8` for INT8 (which also
-//! needs a calibration dataset via `data=`). Requires Ultralytics >= 8.4.
+//! needs a calibration dataset via `data=`).
 //!
 //! The task is auto-detected from ONNX metadata:
 //!

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -44,8 +44,8 @@ pub struct ModelMetadata {
     pub quantize: Option<Quantization>,
     /// Class ID to class name mapping.
     pub names: Arc<HashMap<usize, String>>,
-    /// Whether the exported graph is NMS-free, from the ONNX `end2end` metadata key
-    /// (selected with `nms=False`; YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
+    /// Whether the graph uses the NMS-free one-to-one head, from the `end2end` metadata key
+    /// (selected with `nms=False` when available; output: `[B, max_det, 6+extra]`).
     pub end2end: bool,
     /// Pose keypoint shape as (`num_keypoints`, `dims`), e.g. (17, 3).
     pub kpt_shape: Option<(usize, usize)>,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -44,7 +44,7 @@ pub struct ModelMetadata {
     pub quantize: Option<Quantization>,
     /// Class ID to class name mapping.
     pub names: Arc<HashMap<usize, String>>,
-    /// Whether the model was exported with end-to-end NMS-free output
+    /// Whether the model was exported NMS-free with `nms=False`, formerly `end2end=True`
     /// (YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
     pub end2end: bool,
     /// Pose keypoint shape as (`num_keypoints`, `dims`), e.g. (17, 3).

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -44,8 +44,8 @@ pub struct ModelMetadata {
     pub quantize: Option<Quantization>,
     /// Class ID to class name mapping.
     pub names: Arc<HashMap<usize, String>>,
-    /// Whether the model was exported NMS-free with `nms=False`, formerly `end2end=True`
-    /// (YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
+    /// Whether the exported graph is NMS-free, from the ONNX `end2end` metadata key
+    /// (selected with `nms=False`; YOLO26-style post-NMS output: `[B, max_det, 6+extra]`).
     pub end2end: bool,
     /// Pose keypoint shape as (`num_keypoints`, `dims`), e.g. (17, 3).
     pub kpt_shape: Option<(usize, usize)>,

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1280,9 +1280,10 @@ fn postprocess_obb(
     results
 }
 
-// YOLO26 end-to-end (NMS-free) postprocessing.
+// Post-NMS output postprocessing: the YOLO26 NMS-free one-to-one head (`nms=False`) and
+// exports with NMS baked into the graph (`nms=True`).
 //
-// End-to-end exports bake NMS into the graph and produce a tensor of shape
+// Both produce a tensor of shape
 // `[B, max_det, 6 + extra]`, where the first 6 columns are always
 // `[x1, y1, x2, y2, conf, cls]` (OBB is the exception; see `postprocess_obb_end2end`).
 // Coordinates are in the letterboxed model-input space, so we still scale/pad-correct

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -1280,7 +1280,7 @@ fn postprocess_obb(
     results
 }
 
-// Post-NMS output postprocessing: the YOLO26 NMS-free one-to-one head (`nms=False`) and
+// Postprocessing for the YOLO26 NMS-free one-to-one head (`nms=False`) and
 // exports with NMS baked into the graph (`nms=True`).
 //
 // Both produce a tensor of shape

--- a/web/README.md
+++ b/web/README.md
@@ -185,7 +185,7 @@ await annotate(canvas, img, results, { depthAlpha: 0.6 });
   `YOLO.load("/models/yolo26n.onnx", { device: "webgpu" | "cpu" })` (default `"auto"`). If
   WebGPU cannot engage, the load falls back to CPU; `model.device` reports what
   actually ran.
-- **Model format**: export your model to ONNX with Ultralytics so the metadata
+- **Model format**: export your model to ONNX with Ultralytics `>=8.4.142` so the metadata
   (task, class names, `imgsz`) is embedded:
 
   ```python
@@ -194,6 +194,11 @@ await annotate(canvas, img, results, { depthAlpha: 0.6 });
   YOLO("yolo26n.pt").export(format="onnx")  # FP32 (default)
   YOLO("yolo26n.pt").export(format="onnx", quantize=16)  # FP16 (~50% smaller)
   ```
+
+  For detect, segment, pose, and OBB, `nms=None` (the default) exports raw outputs
+  for NMS in Rust; `nms=False` selects the NMS-free head when available (e.g. YOLO26);
+  `nms=True` embeds NMS in the ONNX graph. Use `nms=None` for semantic, depth, and classify.
+  Existing compatible ONNX files do not need re-exporting.
 
   > Ultralytics ≥8.4 uses the `quantize` argument instead of the deprecated
   > `half=True` / `int8=True` flags. For ONNX the supported values are
@@ -272,22 +277,21 @@ Notes:
 - **Model**: export with Ultralytics to `.tflite` (float32 for WebGPU). It loads
   from the single file. The metadata (task, class names, `imgsz`, stride) is read
   straight from the `.tflite`, the same as the `.onnx` path. No sidecar.
-- **Requires Ultralytics `>= 8.4.83`**: the single-file LiteRT export (with
+- **Existing model compatibility**: the single-file LiteRT export (with
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
 - **Keep the one-to-many head for WebGPU** (`nms=None`): the NMS-free YOLO26 head, exported
   with `nms=False`, has `int64` / `gather_nd` ops the LiteRT **WebGPU** delegate cannot
-  run, so those exports silently fall back to CPU/wasm. Ultralytics `>= 8.4.142` exports
+  run, so those exports fall back to CPU/wasm. Use Ultralytics `>=8.4.142` for this recipe; it exports
   the one-to-many head by default, so NMS runs in this package's Rust and inference stays
   on WebGPU:
 
   ```bash
-  yolo export model=yolo26n.pt format=litert
+  yolo export model=yolo26n.pt format=litert nms=None
   ```
 
-  Earlier versions default to the NMS-free head; pass `end2end=False` there for the same
-  result. If you load an NMS-free `.tflite` anyway, the backend auto-switches it to wasm
+  If you load an NMS-free `.tflite`, the backend auto-switches it to wasm
   (slower) and logs a warning rather than returning empty results.
 
 - **Tasks**: detect, segment, pose, obb, classify, semantic, and depth are all supported.

--- a/web/README.md
+++ b/web/README.md
@@ -276,11 +276,11 @@ Notes:
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
-- **Keep the standard head for WebGPU** (`nms=None`): the NMS-free YOLO26 head, exported
+- **Keep the one-to-many head for WebGPU** (`nms=None`): the NMS-free YOLO26 head, exported
   with `nms=False`, has `int64` / `gather_nd` ops the LiteRT **WebGPU** delegate cannot
   run, so those exports silently fall back to CPU/wasm. Ultralytics `>= 8.4.142` exports
-  the standard head by default, so NMS runs in this package's Rust and inference stays on
-  WebGPU:
+  the one-to-many head by default, so NMS runs in this package's Rust and inference stays
+  on WebGPU:
 
   ```bash
   yolo export model=yolo26n.pt format=litert

--- a/web/README.md
+++ b/web/README.md
@@ -276,17 +276,18 @@ Notes:
   embedded metadata) ships in
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) and
   later. Earlier versions emit the legacy TFLite format and won't load here.
-- **Export end2end-free models** (`end2end=False`): Ultralytics YOLO26 defaults to an
-  end-to-end, NMS-free head whose `int64` / `gather_nd` ops the LiteRT
-  **WebGPU** delegate cannot run, so those exports silently fall back to CPU/wasm.
-  Export them with `end2end=False` so the standard head is used and NMS runs in
-  this package's Rust, keeping inference on WebGPU:
+- **Keep the standard head for WebGPU** (`nms=None`): the NMS-free YOLO26 head, exported
+  with `nms=False`, has `int64` / `gather_nd` ops the LiteRT **WebGPU** delegate cannot
+  run, so those exports silently fall back to CPU/wasm. Ultralytics `>= 8.4.142` exports
+  the standard head by default, so NMS runs in this package's Rust and inference stays on
+  WebGPU:
 
   ```bash
-  yolo export model=yolo26n.pt format=litert end2end=False
+  yolo export model=yolo26n.pt format=litert
   ```
 
-  If you load an end2end `.tflite` anyway, the backend auto-switches it to wasm
+  Earlier versions default to the NMS-free head; pass `end2end=False` there for the same
+  result. If you load an NMS-free `.tflite` anyway, the backend auto-switches it to wasm
   (slower) and logs a warning rather than returning empty results.
 
 - **Tasks**: detect, segment, pose, obb, classify, semantic, and depth are all supported.

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -255,9 +255,9 @@ wasm 默认从 jsDelivr CDN 加载；向 `YOLO.load` 传入 `litertWasmUrl: "/li
 - **需要 Ultralytics `>= 8.4.83`**：带内嵌元数据的单文件 LiteRT 导出自
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) 起提供。更早的版本
   会导出旧版 TFLite 格式，无法在这里加载。
-- **为 WebGPU 保留标准检测头**（`nms=None`）：以 `nms=False` 导出的 YOLO26 无 NMS 检测头包含
+- **为 WebGPU 保留一对多检测头**（`nms=None`）：以 `nms=False` 导出的 YOLO26 无 NMS 检测头包含
   `int64` / `gather_nd` 算子，无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会静默
-  回退到 CPU/wasm。Ultralytics `>= 8.4.142` 默认导出标准检测头，NMS 由本包的 Rust 代码执行，
+  回退到 CPU/wasm。Ultralytics `>= 8.4.142` 默认导出一对多检测头，NMS 由本包的 Rust 代码执行，
   推理得以保持在 WebGPU 上：
 
   ```bash

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -255,16 +255,17 @@ wasm 默认从 jsDelivr CDN 加载；向 `YOLO.load` 传入 `litertWasmUrl: "/li
 - **需要 Ultralytics `>= 8.4.83`**：带内嵌元数据的单文件 LiteRT 导出自
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) 起提供。更早的版本
   会导出旧版 TFLite 格式，无法在这里加载。
-- **导出非 end2end 模型**（`end2end=False`）：Ultralytics YOLO26 默认使用端到端、无 NMS 的检测头，
-  其中的 `int64` / `gather_nd` 算子无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会
-  静默回退到 CPU/wasm。请使用 `end2end=False` 导出，以便使用标准检测头，并由本包的 Rust 代码执行
-  NMS，从而让推理保持在 WebGPU 上：
+- **为 WebGPU 保留标准检测头**（`nms=None`）：以 `nms=False` 导出的 YOLO26 无 NMS 检测头包含
+  `int64` / `gather_nd` 算子，无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会静默
+  回退到 CPU/wasm。Ultralytics `>= 8.4.142` 默认导出标准检测头，NMS 由本包的 Rust 代码执行，
+  推理得以保持在 WebGPU 上：
 
   ```bash
-  yolo export model=yolo26n.pt format=litert end2end=False
+  yolo export model=yolo26n.pt format=litert
   ```
 
-  如果仍然加载了 end2end 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
+  更早的版本默认使用无 NMS 检测头，在这些版本上请传入 `end2end=False` 以获得相同结果。如果仍然
+  加载了无 NMS 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
 
 - **支持的任务**：detect、segment、pose、obb、classify、semantic 和 depth 均已支持。
 - **跨源隔离**：LiteRT 的多线程 wasm 需要 `SharedArrayBuffer`，因此请以

--- a/web/README.zh-CN.md
+++ b/web/README.zh-CN.md
@@ -174,7 +174,7 @@ await annotate(canvas, img, results, { depthAlpha: 0.6 });
   `YOLO.load` 会自动回退到通用的 **CPU/wasm** 构建，随处可用。可通过
   `YOLO.load("/models/yolo26n.onnx", { device: "webgpu" | "cpu" })` 指定设备（默认 `"auto"`）。若 WebGPU
   无法启用，加载会回退到 CPU；`model.device` 会报告实际使用的设备。
-- **模型格式**：请使用 Ultralytics 导出为 ONNX，以便元数据（任务、类别名称、`imgsz`）被嵌入模型：
+- **模型格式**：请使用 Ultralytics `>=8.4.142` 导出为 ONNX，以便元数据（任务、类别名称、`imgsz`）被嵌入模型：
 
   ```python
   from ultralytics import YOLO
@@ -182,6 +182,10 @@ await annotate(canvas, img, results, { depthAlpha: 0.6 });
   YOLO("yolo26n.pt").export(format="onnx")  # FP32 (默认)
   YOLO("yolo26n.pt").export(format="onnx", quantize=16)  # FP16 (体积约小 50%)
   ```
+
+  对于 detect、segment、pose 和 OBB，`nms=None`（默认值）导出原始输出，由 Rust 执行 NMS；
+  `nms=False` 在模型支持时选择无 NMS 检测头（例如 YOLO26）；`nms=True` 将 NMS 嵌入 ONNX 图中。
+  semantic、depth 和 classify 使用 `nms=None`。现有的兼容 ONNX 文件无需重新导出。
 
   > Ultralytics ≥8.4 使用 `quantize` 参数，取代已弃用的 `half=True` / `int8=True` 标志。
   > 对于 ONNX，支持的取值为 `32`/`fp32`（默认）、`16`/`fp16` 和 `8`/`int8`；旧标志
@@ -252,20 +256,19 @@ wasm 默认从 jsDelivr CDN 加载；向 `YOLO.load` 传入 `litertWasmUrl: "/li
 - **模型**：使用 Ultralytics 导出为 `.tflite`（WebGPU 需要 float32）。模型从单个文件加载，
   元数据（任务、类别名称、`imgsz`、stride）直接从 `.tflite` 中读取，与 `.onnx` 路径相同，
   无需额外的附属文件。
-- **需要 Ultralytics `>= 8.4.83`**：带内嵌元数据的单文件 LiteRT 导出自
+- **现有模型兼容性**：带内嵌元数据的单文件 LiteRT 导出自
   [v8.4.83](https://github.com/ultralytics/ultralytics/releases/tag/v8.4.83) 起提供。更早的版本
   会导出旧版 TFLite 格式，无法在这里加载。
 - **为 WebGPU 保留一对多检测头**（`nms=None`）：以 `nms=False` 导出的 YOLO26 无 NMS 检测头包含
-  `int64` / `gather_nd` 算子，无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会静默
-  回退到 CPU/wasm。Ultralytics `>= 8.4.142` 默认导出一对多检测头，NMS 由本包的 Rust 代码执行，
+  `int64` / `gather_nd` 算子，无法在 LiteRT 的 **WebGPU** delegate 上运行，因此这类导出会
+  回退到 CPU/wasm。以下命令需要 Ultralytics `>=8.4.142`，默认导出一对多检测头，NMS 由本包的 Rust 代码执行，
   推理得以保持在 WebGPU 上：
 
   ```bash
-  yolo export model=yolo26n.pt format=litert
+  yolo export model=yolo26n.pt format=litert nms=None
   ```
 
-  更早的版本默认使用无 NMS 检测头，在这些版本上请传入 `end2end=False` 以获得相同结果。如果仍然
-  加载了无 NMS 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
+  如果加载了无 NMS 的 `.tflite`，后端会自动切换到 wasm（较慢）并打印警告，而不是返回空结果。
 
 - **支持的任务**：detect、segment、pose、obb、classify、semantic 和 depth 均已支持。
 - **跨源隔离**：LiteRT 的多线程 wasm 需要 `SharedArrayBuffer`，因此请以

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -713,7 +713,7 @@ export class YOLO {
     // NMS-free exports (YOLO26, `nms=False`) do NMS/top-k with int64 + gather_nd ops the
     // LiteRT WebGPU delegate cannot run: it fails to invoke and returns zeros.
     // Force CPU/wasm so the model works. For WebGPU speed, re-export the model
-    // with the default `nms=None` so the standard head (with NMS in Rust) is used.
+    // with the default `nms=None` so the one-to-many head (with NMS in Rust) is used.
     if (accelerator === "webgpu" && pipeline.end2end) {
       accelerator = "wasm";
       console.warn(

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -710,14 +710,14 @@ export class YOLO {
     // Honor `device` including `"auto"`, which feature-detects WebGPU (so a
     // browser without it goes straight to wasm instead of a failed compile).
     let accelerator: "webgpu" | "wasm" = (await resolveDevice(options?.device)) === "webgpu" ? "webgpu" : "wasm";
-    // NMS-free exports (YOLO26, `nms=False`) do NMS/top-k with int64 + gather_nd ops the
+    // NMS-free exports (YOLO26, `nms=False`) do top-k selection with int64 + gather_nd ops the
     // LiteRT WebGPU delegate cannot run: it fails to invoke and returns zeros.
     // Force CPU/wasm so the model works. For WebGPU speed, re-export the model
-    // with the default `nms=None` so the one-to-many head (with NMS in Rust) is used.
+    // with Ultralytics >=8.4.142 and `nms=None` for the one-to-many head (NMS in Rust).
     if (accelerator === "webgpu" && pipeline.end2end) {
       accelerator = "wasm";
       console.warn(
-        "LiteRT: this is an NMS-free model; its WebGPU delegate can't run the int64 ops, so it runs on CPU/wasm. Re-export with the default `nms=None` for WebGPU.",
+        "LiteRT: this is an NMS-free model; its WebGPU delegate can't run the int64 ops, so it runs on CPU/wasm. Re-export with Ultralytics >=8.4.142 and `nms=None` for WebGPU.",
       );
     }
     const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -710,14 +710,14 @@ export class YOLO {
     // Honor `device` including `"auto"`, which feature-detects WebGPU (so a
     // browser without it goes straight to wasm instead of a failed compile).
     let accelerator: "webgpu" | "wasm" = (await resolveDevice(options?.device)) === "webgpu" ? "webgpu" : "wasm";
-    // End-to-end exports (YOLO26) do NMS/top-k with int64 + gather_nd ops the
+    // NMS-free exports (YOLO26, `nms=False`) do NMS/top-k with int64 + gather_nd ops the
     // LiteRT WebGPU delegate cannot run: it fails to invoke and returns zeros.
     // Force CPU/wasm so the model works. For WebGPU speed, re-export the model
-    // with `end2end=False` so the standard head (with NMS in Rust) is used.
+    // with the default `nms=None` so the standard head (with NMS in Rust) is used.
     if (accelerator === "webgpu" && pipeline.end2end) {
       accelerator = "wasm";
       console.warn(
-        "LiteRT: this is an end2end (NMS-free) model; its WebGPU delegate can't run the int64 ops, so it runs on CPU/wasm. Re-export with `end2end=False` for WebGPU.",
+        "LiteRT: this is an NMS-free model; its WebGPU delegate can't run the int64 ops, so it runs on CPU/wasm. Re-export with the default `nms=None` for WebGPU.",
       );
     }
     const backend = await LiteRtBackend.load(tflite, wasmUrl, accelerator);


### PR DESCRIPTION
Ultralytics 8.4.142 replaced the `end2end` export argument with `nms=None|False|True`. The LiteRT WebGPU instructions and fallback warning still recommended the removed argument. This PR uses an explicit `nms=None` recipe and its 8.4.142 minimum, and documents the raw, NMS-free, and embedded-NMS modes across the English/Chinese native and browser READMEs, examples, and Rust API docs.

Clarifies one-to-one selection versus embedded NMS in metadata/postprocessing comments. The `end2end` metadata key, output decoding, and automatic LiteRT wasm fallback remain valid. Existing compatible ONNX/LiteRT files and published assets need no regeneration; the LiteRT metadata format's historical 8.4.83 minimum is distinguished from the new recipe's minimum.

Audited all nine distinct tracked Markdown files, Rust/TypeScript documentation and warnings, workflows, and manifests. This repository contains no Python export scripts or Python dependency manifests requiring migration.

Validation:
- 205 unit tests, 10 integration tests, and 19 doctests passed; native Clippy and formatting passed.
- All four Python documentation blocks parse; no obsolete `end2end=` export arguments remain.
- Fifteen fresh Ultralytics 8.4.142 ONNX exports passed real-image inference through this branch's Rust CPU runtime: detect/segment/pose/OBB in all three modes, plus semantic/depth/classify. This establishes compatibility, not accuracy parity; OBB counts differ from the Python reference by 1–2 detections.
- Complete wasm-pack release build and TypeScript build passed locally (`npm ci && npm run build`); browser/WebGPU execution was source-reviewed, not rerun.
- Independent Claude Code Fable 5.1 (`claude-fable-5-1`), effort `xhigh`: cold full-diff **LGTM, no findings**, exact head `266a9a057796b6f06cb9101005103c29820d185f`.
- All 15 GitHub checks passed on the reviewed head, including Linux/macOS/Windows, both FFmpeg matrices, wasm/browser build, CodeQL, and coverage; zero unresolved review threads.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated ONNX and LiteRT export guidance to use Ultralytics `nms=None|False|True` arguments, matching the export interface introduced in Ultralytics 8.4.142.

### 📊 Key Changes
- Documented the three supported export modes: raw one-to-many outputs with `nms=None`, NMS-free one-to-one heads with `nms=False` when available, and embedded NMS with `nms=True`.
- Updated English and Chinese READMEs, examples, Rust API documentation, and browser guidance to require Ultralytics `>=8.4.142` for the new export recipes.
- Replaced the LiteRT `end2end=False` recommendation with `nms=None`, while distinguishing the Ultralytics `>=8.4.142` recipe requirement from the existing LiteRT metadata compatibility available since `v8.4.83`.
- Clarified metadata and postprocessing comments: the existing `end2end` metadata key identifies NMS-free outputs, and both NMS-free and embedded-NMS outputs use the corresponding postprocessing path.
- Updated the LiteRT WebGPU warning and documentation to refer to NMS-free exports and retain automatic CPU/wasm fallback.

### 🎯 Purpose & Impact
- Users following the documented export commands now receive valid guidance for current Ultralytics releases and can select the intended NMS layout for each task.
- Existing compatible ONNX and LiteRT files remain supported without regeneration; the LiteRT WebGPU fallback behavior is unchanged, while its warning and remediation text now use `nms=None` and `nms=False`.