### PR TITLE
Replace serial_test with a shared lock so the tests still build on Rust 1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1288,15 +1288,6 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1751,29 +1742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.18",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,15 +2089,6 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
@@ -2305,12 +2264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sdl2"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,31 +2371,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2694,7 +2622,6 @@ dependencies = [
  "ndarray",
  "ort",
  "rayon",
- "serial_test",
  "tempfile",
  "ureq",
  "video-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,6 @@ all = ["annotate", "visualize", "video"]
 
 [dev-dependencies]
 # Testing dependencies
-serial_test = "3"
 tempfile = "3"
 
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -176,7 +176,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -195,8 +194,10 @@ mod tests {
     /// offline while CI, which has network, still exercises it. `batch_size` is 1 because
     /// the default `yolo26n.onnx` only supports batch 1.
     #[test]
-    #[serial]
     fn test_batch_processor_buffers_and_flushes() {
+        let _guard = crate::model::SESSION_BUILD_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let path = std::path::Path::new("yolo26n.onnx");
         let mut model = match YOLOModel::load(path) {
             Ok(model) => model,

--- a/src/model.rs
+++ b/src/model.rs
@@ -35,6 +35,11 @@ use crate::results::{Results, Speed};
 use crate::task::Task;
 use crate::{verbose, warn};
 
+/// Serializes the tests that build an ORT session: providers compile into one shared
+/// cache, and two sessions building it at once collide there.
+#[cfg(test)]
+pub(crate) static SESSION_BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Finalize a CUDA/`TensorRT` EP builder, binding it to the `cuda-preprocess`
 /// compute stream when one is supplied.
 ///
@@ -2024,7 +2029,6 @@ fn shape_to_usize(shape: &[i64]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -2050,11 +2054,11 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // `#[serial]` with the other session-building test: providers compile into one shared
-    // cache, and two sessions building it at once collide there.
     #[test]
-    #[serial]
     fn test_model_accessors_with_dummy() {
+        let _guard = SESSION_BUILD_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // The accessors need a real instance (YOLOModel wraps an ORT session and can't be
         // mocked), so this only asserts when yolo26n.onnx is present or downloadable.
         if let Ok(model) = YOLOModel::load("yolo26n.onnx") {


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Replaced the `serial_test` dependency and attributes with a shared test-only mutex to serialize ORT session-building tests.

### 📊 Key Changes

- Added `SESSION_BUILD_LOCK` in `src/model.rs` as a crate-visible test-only `Mutex`.
- Updated `test_batch_processor_buffers_and_flushes` and `test_model_accessors_with_dummy` to acquire the shared lock before building sessions.
- Removed the `serial_test` development dependency from `Cargo.toml` and updated the lockfile.
- Preserved poisoned-lock recovery by continuing tests with the mutex’s inner value when necessary.

### 🎯 Purpose & Impact

- The affected tests no longer depend on `serial_test` and are serialized specifically around shared ORT provider-cache initialization.
- No user-facing change; this only changes test synchronization and development dependencies.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
</details>
