### PR TITLE
Read ONNX metadata props into an ordered map so the browser builds metadata text in a stable order

### DIFF
--- a/crates/web/src/onnx_meta.rs
+++ b/crates/web/src/onnx_meta.rs
@@ -8,7 +8,7 @@
 //! graph fields are skipped without being parsed. These helpers are pure
 //! (`&[u8] -> map`) and carry no wasm/JS types.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Read a protobuf base-128 varint at `pos`, advancing it. Returns `None` on a
 /// truncated/oversized value.
@@ -62,8 +62,11 @@ fn read_field<'a>(buf: &'a [u8], pos: &mut usize) -> Option<(u64, Option<&'a [u8
 /// Extract `ModelProto.metadata_props` (field 14, repeated
 /// `StringStringEntryProto`) into a key/value map. Other fields (including the
 /// large graph) are skipped without being decoded.
-pub(crate) fn parse_metadata_props(buf: &[u8]) -> HashMap<String, String> {
-    let mut map = HashMap::new();
+///
+/// Ordered by key, so the text built from it in `build_metadata` is stable
+/// across runs rather than following a hash order that varies per build.
+pub(crate) fn parse_metadata_props(buf: &[u8]) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
     let mut pos = 0;
     while let Some((field, payload)) = read_field(buf, &mut pos) {
         if field == 14


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Changed ONNX metadata property parsing from `HashMap` to `BTreeMap` so metadata entries are returned in key order for stable browser-generated text.

### 📊 Key Changes

- Updated `parse_metadata_props` in `crates/web/src/onnx_meta.rs` to return a `BTreeMap<String, String>`.
- Replaced the internal unordered `HashMap` with a key-ordered `BTreeMap`.
- Preserved the existing parsing behavior for ONNX `ModelProto.metadata_props` while documenting the stable ordering.

### 🎯 Purpose & Impact

- Metadata text built by `build_metadata` now uses a consistent key order across runs instead of hash-dependent ordering.
- No other ONNX fields or parsing behavior were changed.