### PR TITLE
Cover FFmpeg 9 in the macOS video build with a patched video-rs and document how to build against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,19 @@ jobs:
       - name: Tests (annotate + video)
         run: cargo test --all --features annotate,video
 
-  # macOS FFmpeg 8 video build test
+  # macOS FFmpeg video build test
   build-macos-video:
-    name: build / macos / ffmpeg 8 / video
+    name: build / macos / ffmpeg ${{ matrix.ffmpeg }} / video
     runs-on: macos-latest
+
+    strategy:
+      matrix:
+        include:
+          - ffmpeg: "8"
+            formula: ffmpeg@8
+          - ffmpeg: "9"
+            formula: ffmpeg
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -145,11 +154,11 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install ffmpeg@8
-          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@8)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install ${{ matrix.formula }}
+          echo "PKG_CONFIG_PATH=$(brew --prefix ${{ matrix.formula }})/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Capture FFmpeg version for cache key
-        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg@8 | awk '{print $2}')" >> "$GITHUB_ENV"
+        run: echo "FFMPEG_VERSION=$(brew list --versions ${{ matrix.formula }} | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -162,6 +171,12 @@ jobs:
 
       - name: Ensure toolchain
         run: rustup show
+
+      - name: Patch video-rs for FFmpeg 9
+        if: matrix.ffmpeg == '9'
+        run: |
+          mkdir -p .cargo
+          printf '[patch.crates-io]\nvideo-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }\n' > .cargo/config.toml
 
       - name: Build (annotate + video features)
         run: cargo build --release --features "annotate,video,visualize" --bin ultralytics-inference

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         if: matrix.ffmpeg == '9'
         run: |
           mkdir -p .cargo
-          printf '[patch.crates-io]\nvideo-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }\n' > .cargo/config.toml
+          printf '[patch.crates-io]\nvideo-rs = { git = "https://github.com/onuralpszr/video-rs", rev = "861f6071da71f594d8b098a6d53be94ebafa0284" }\n' > .cargo/config.toml
 
       - name: Build (annotate + video features)
         run: cargo build --release --features "annotate,video,visualize" --bin ultralytics-inference

--- a/README.md
+++ b/README.md
@@ -679,11 +679,18 @@ apt-get install -y ffmpeg libavutil-dev libavformat-dev libavfilter-dev libavdev
 cargo build --release --features video
 ```
 
-To build against FFmpeg 9 before `video-rs` releases support, point Cargo at a `video-rs` branch that carries the fix by adding this to `.cargo/config.toml`:
+To build against FFmpeg 9 before `video-rs` releases support, install FFmpeg 9 and point Cargo at a `video-rs` revision that carries the fix:
+
+```bash
+# macOS
+brew install ffmpeg
+export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig"
+```
 
 ```toml
+# .cargo/config.toml
 [patch.crates-io]
-video-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }
+video-rs = { git = "https://github.com/onuralpszr/video-rs", rev = "861f6071da71f594d8b098a6d53be94ebafa0284" }
 ```
 
 To build without annotation and visualization support (smaller binary):

--- a/README.md
+++ b/README.md
@@ -665,17 +665,25 @@ One of the key benefits of this library is a Rust/ONNX Runtime stack with no PyT
 
 ### Video Support (FFmpeg)
 
-Video features require FFmpeg (6, 7 or 8) installed on your system:
+Video features require FFmpeg (6, 7 or 8) installed on your system. Homebrew's `ffmpeg` is FFmpeg 9, which `video-rs` does not support yet, so macOS needs the versioned formula:
 
 ```bash
 # macOS
-brew install ffmpeg
+brew install ffmpeg@8
+export PKG_CONFIG_PATH="$(brew --prefix ffmpeg@8)/lib/pkgconfig"
 
 # Ubuntu/Debian
 apt-get install -y ffmpeg libavutil-dev libavformat-dev libavfilter-dev libavdevice-dev libclang-dev
 
 # Build with video support
 cargo build --release --features video
+```
+
+To build against FFmpeg 9 before `video-rs` releases support, point Cargo at a `video-rs` branch that carries the fix by adding this to `.cargo/config.toml`:
+
+```toml
+[patch.crates-io]
+video-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }
 ```
 
 To build without annotation and visualization support (smaller binary):

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -651,17 +651,25 @@ JS/TS 封装与构建说明见 [`web/`](web/README.md)。需要支持 WebGPU 的
 
 ### 视频支持（FFmpeg）
 
-视频 features 需要系统安装 FFmpeg（6、7 或 8）：
+视频 features 需要系统安装 FFmpeg（6、7 或 8）。Homebrew 的 `ffmpeg` 现在是 FFmpeg 9，`video-rs` 尚不支持，因此 macOS 需要使用带版本的 formula：
 
 ```bash
 # macOS
-brew install ffmpeg
+brew install ffmpeg@8
+export PKG_CONFIG_PATH="$(brew --prefix ffmpeg@8)/lib/pkgconfig"
 
 # Ubuntu/Debian
 apt-get install -y ffmpeg libavutil-dev libavformat-dev libavfilter-dev libavdevice-dev libclang-dev
 
 # 使用视频支持构建
 cargo build --release --features video
+```
+
+在 `video-rs` 发布支持之前，如需针对 FFmpeg 9 构建，请在 `.cargo/config.toml` 中添加以下内容，将 Cargo 指向带有该修复的 `video-rs` 分支：
+
+```toml
+[patch.crates-io]
+video-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }
 ```
 
 如需构建不含标注和可视化支持的更小二进制：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -665,11 +665,18 @@ apt-get install -y ffmpeg libavutil-dev libavformat-dev libavfilter-dev libavdev
 cargo build --release --features video
 ```
 
-在 `video-rs` 发布支持之前，如需针对 FFmpeg 9 构建，请在 `.cargo/config.toml` 中添加以下内容，将 Cargo 指向带有该修复的 `video-rs` 分支：
+在 `video-rs` 发布支持之前，如需针对 FFmpeg 9 构建，请安装 FFmpeg 9 并将 Cargo 指向带有该修复的 `video-rs` 修订版：
+
+```bash
+# macOS
+brew install ffmpeg
+export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig"
+```
 
 ```toml
+# .cargo/config.toml
 [patch.crates-io]
-video-rs = { git = "https://github.com/onuralpszr/video-rs", branch = "ffmpeg9-support" }
+video-rs = { git = "https://github.com/onuralpszr/video-rs", rev = "861f6071da71f594d8b098a6d53be94ebafa0284" }
 ```
 
 如需构建不含标注和可视化支持的更小二进制：


### PR DESCRIPTION
Homebrew ffmpeg is FFmpeg 9 now, video-rs still pins ffmpeg-next 8, so the macOS video job runs as a matrix over ffmpeg@8 and ffmpeg 9, with the FFmpeg 9 leg patched to a video-rs branch carrying the one line fix until that lands upstream.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The macOS video build now covers Homebrew FFmpeg 8 and 9, using a patched `video-rs` revision for FFmpeg 9, with matching build instructions added to both README files.

### 📊 Key Changes

- Updated `.github/workflows/ci.yml` to run the macOS video build as an FFmpeg 8/9 matrix using `ffmpeg@8` and `ffmpeg` Homebrew formulas.
- Added version-specific `PKG_CONFIG_PATH` and cache-version handling for each FFmpeg matrix entry.
- Configured the FFmpeg 9 job to patch crates.io `video-rs` with revision `861f6071da71f594d8b098a6d53be94ebafa0284`.
- Updated the English and Chinese documentation to use `ffmpeg@8` on macOS and documented the FFmpeg 9 build workaround with the Cargo patch configuration.

### 🎯 Purpose & Impact

- macOS CI now builds the video-enabled binary against both FFmpeg 8 and FFmpeg 9 without allowing one matrix failure to cancel the other.
- Developers can build with Homebrew FFmpeg 8 using the documented versioned formula, or with FFmpeg 9 by applying the pinned patched `video-rs` dependency.