### PR TITLE
FFmpeg 9 support to the video pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,9 +124,9 @@ jobs:
       - name: Tests (annotate + video)
         run: cargo test --all --features annotate,video
 
-  # macOS FFmpeg 8 video build test
+  # macOS FFmpeg 9 video build test
   build-macos-video:
-    name: build / macos / ffmpeg 8 / video
+    name: build / macos / ffmpeg 9 / video
     runs-on: macos-latest
 
     steps:
@@ -143,13 +143,10 @@ jobs:
           echo "XCODE_VER=$(xcodebuild -version | head -1 | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        run: |
-          brew update
-          brew install ffmpeg@8
-          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@8)/lib/pkgconfig" >> "$GITHUB_ENV"
+        run: brew install ffmpeg
 
       - name: Capture FFmpeg version for cache key
-        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg@8 | awk '{print $2}')" >> "$GITHUB_ENV"
+        run: echo "FFMPEG_VERSION=$(brew list --versions ffmpeg | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: cargo test --no-default-features --features "coreml,annotate" --test integration_test test_coreml_model_loads_and_warms_up -- --ignored --exact
 
-  # Video feature tests for Linux - FFmpeg 7 and 8
+  # Video feature tests for Linux - FFmpeg 7, 8 and 9
   test-video:
     name: test / linux / ffmpeg ${{ matrix.ffmpeg_version }}
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
 
     strategy:
       matrix:
-        ffmpeg_version: ["8.0", "7.1"]
+        ffmpeg_version: ["9.0", "8.0", "7.1"]
       fail-fast: false
 
     steps:
@@ -163,14 +163,19 @@ jobs:
       - name: Build (annotate + video features)
         run: cargo build --release --features "annotate,video,visualize" --bin ultralytics-inference
 
-  # Windows FFmpeg 8 video build test
+  # Windows FFmpeg 8 and 9 video build test
   build-windows-video:
-    name: build / windows / ffmpeg 8 / video
+    name: build / windows / ffmpeg ${{ matrix.ffmpeg_version }} / video
     runs-on: windows-latest
 
+    strategy:
+      matrix:
+        ffmpeg_version: ["9.0.1", "8.1.1"]
+      fail-fast: false
+
     env:
-      FFMPEG_VERSION: "8.1.1"
-      FFMPEG_DOWNLOAD_URL: https://github.com/GyanD/codexffmpeg/releases/download/8.1.1/ffmpeg-8.1.1-full_build-shared.7z
+      FFMPEG_VERSION: ${{ matrix.ffmpeg_version }}
+      FFMPEG_DOWNLOAD_URL: https://github.com/GyanD/codexffmpeg/releases/download/${{ matrix.ffmpeg_version }}/ffmpeg-${{ matrix.ffmpeg_version }}-full_build-shared.7z
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ cd web && npm ci && npm run build
 cargo run -- predict
 ```
 
-- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0 Linux containers (`--features annotate,video`); video builds on macOS (Homebrew FFmpeg 9) and Windows (FFmpeg 8.1); `wasm`; `coverage` (nightly) uploads to Codecov.
+- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0/9.0 Linux containers (`--features annotate,video`); video builds on macOS (Homebrew FFmpeg 9) and Windows (FFmpeg 8.1/9.0); `wasm`; `coverage` (nightly) uploads to Codecov.
 - MSRV is Rust 1.89 (`rust-version` in Cargo.toml), edition 2024.
 - First native build downloads ONNX Runtime binaries (ort `download-binaries` feature), so builds need network once.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ cd web && npm ci && npm run build
 cargo run -- predict
 ```
 
-- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0 Linux containers (`--features annotate,video`); video builds on macOS/Windows; `wasm`; `coverage` (nightly) uploads to Codecov.
+- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0 Linux containers (`--features annotate,video`); video builds on macOS (Homebrew FFmpeg 9) and Windows (FFmpeg 8.1); `wasm`; `coverage` (nightly) uploads to Codecov.
 - MSRV is Rust 1.89 (`rust-version` in Cargo.toml), edition 2024.
 - First native build downloads ONNX Runtime binaries (ort `download-binaries` feature), so builds need network once.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,7 +2432,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultralytics-inference"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "ab_glyph",
  "bytemuck",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "ultralytics-inference-web"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "console_error_panic_hook",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,17 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
-]
-
-[[package]]
 name = "dlib"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
+checksum = "6380599799e175191eb7ffe82c97f36a2a90a36cbc54c738a903e5287d7f516a"
 dependencies = [
  "bitflags 2.13.1",
  "ffmpeg-sys-next",
@@ -678,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
+checksum = "9b939bf79dd5949412a4b81cfe21a07f48ea21b47fcbb5f57816c8c2de5ae30b"
 dependencies = [
  "bindgen",
  "cc",
@@ -727,15 +716,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -960,110 +940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "icu_collections"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
-
-[[package]]
-name = "icu_properties"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
-
-[[package]]
-name = "icu_provider"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,12 +1152,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -1812,15 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -2482,17 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,35 +2390,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2613,6 +2441,7 @@ dependencies = [
  "cudarc",
  "dirs",
  "fast_image_resize",
+ "ffmpeg-next",
  "half",
  "image",
  "imageproc",
@@ -2624,7 +2453,6 @@ dependencies = [
  "rayon",
  "tempfile",
  "ureq",
- "video-rs",
  "wide",
 ]
 
@@ -2696,28 +2524,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2753,18 +2563,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "video-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2633ec4c2a8aeb7c0e970f75ba99122a75841e9f7b34d5225366d0e61a870a8c"
-dependencies = [
- "ffmpeg-next",
- "ndarray",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "wasi"
@@ -3072,12 +2870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "writeable"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
-
-[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,29 +2899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,64 +2919,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
-]
 
 [[package]]
 name = "zlib-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["."]
 
 [package]
 name = "ultralytics-inference"
-version = "0.0.42"
+version = "0.0.43"
 edition = "2024"
 rust-version = "1.89"
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ colored = "^3.1.1"
 
 # Optional - Visualization and Video support
 minifb = { version = "^0.28.0", optional = true }
-video-rs = { version = ">=0.10.5, <0.12", features = ["ndarray"], optional = true }
+ffmpeg-next = { version = "^9.0", optional = true }
 
 # Optional - Image annotation (for --save feature)
 imageproc = { version = "^0.27", optional = true }
@@ -146,7 +146,7 @@ default = ["annotate", "visualize"]
 visualize = ["minifb", "annotate"]
 
 # Video file support (requires ffmpeg installed on system)
-video = ["video-rs"]
+video = ["dep:ffmpeg-next"]
 
 # Image annotation support (for --save feature in CLI)
 annotate = ["imageproc", "ab_glyph"]

--- a/README.md
+++ b/README.md
@@ -673,14 +673,14 @@ One of the key benefits of this library is a Rust/ONNX Runtime stack with no PyT
 
 ### Optional Dependencies (for Video & Visualization)
 
-| Crate      | Purpose                            |
-| ---------- | ---------------------------------- |
-| `minifb`   | Window creation and buffer display |
-| `video-rs` | Video decoding/encoding (ffmpeg)   |
+| Crate         | Purpose                            |
+| ------------- | ---------------------------------- |
+| `minifb`      | Window creation and buffer display |
+| `ffmpeg-next` | Video decoding/encoding (ffmpeg)   |
 
 ### Video Support (FFmpeg)
 
-Video features require FFmpeg (6, 7 or 8) installed on your system:
+Video features require FFmpeg (6, 7, 8 or 9) installed on your system:
 
 ```bash
 # macOS

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.42 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.43 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -249,7 +249,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.42 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.43 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -352,7 +352,7 @@ Add to your `Cargo.toml` (choose one):
 ```toml
 # Stable release from crates.io
 [dependencies]
-ultralytics-inference = "0.0.42"
+ultralytics-inference = "0.0.43"
 ```
 
 ```toml
@@ -569,7 +569,7 @@ Each accelerator feature links a prebuilt ONNX Runtime containing that provider.
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.42", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.43", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,7 +228,7 @@ ultralytics-inference predict
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.42 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.43 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n summary: 80 classes, imgsz=(640, 640)
 
@@ -248,7 +248,7 @@ ultralytics-inference predict --task segment
 ```text
 WARNING ⚠️ 'model' argument is missing. Using default '--model=yolo26n-seg.onnx'.
 WARNING ⚠️ 'source' argument is missing. Using default images: https://ultralytics.com/images/bus.jpg, https://ultralytics.com/images/zidane.jpg
-Ultralytics Inference 0.0.42 🚀 Rust ONNX FP32 CPU
+Ultralytics Inference 0.0.43 🚀 Rust ONNX FP32 CPU
 Using ONNX Runtime CPUExecutionProvider
 YOLO26n-seg summary: 80 classes, imgsz=(640, 640)
 
@@ -351,7 +351,7 @@ YOLOv8、YOLO11 和 YOLO26 ONNX 模型支持 **n / s / m / l / x** 尺寸，并�
 ```toml
 # crates.io 稳定版本
 [dependencies]
-ultralytics-inference = "0.0.42"
+ultralytics-inference = "0.0.43"
 ```
 
 ```toml
@@ -565,7 +565,7 @@ cargo build --release --features "cuda,tensorrt"
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.42", features = ["coreml", "xnnpack"] }
+ultralytics-inference = { version = "0.0.43", features = ["coreml", "xnnpack"] }
 ort = { version = "=2.0.0-rc.13", features = ["lax-feature-matching"] }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -666,14 +666,14 @@ JS/TS 封装与构建说明见 [`web/`](web/README.md)。需要支持 WebGPU 的
 
 ### 可选依赖（用于视频和可视化）
 
-| Crate      | 用途                    |
-| ---------- | ----------------------- |
-| `minifb`   | 窗口创建和缓冲区显示    |
-| `video-rs` | 视频解码/编码（ffmpeg） |
+| Crate         | 用途                    |
+| ------------- | ----------------------- |
+| `minifb`      | 窗口创建和缓冲区显示    |
+| `ffmpeg-next` | 视频解码/编码（ffmpeg） |
 
 ### 视频支持（FFmpeg）
 
-视频 features 需要系统安装 FFmpeg（6、7 或 8）：
+视频 features 需要系统安装 FFmpeg（6、7、8 或 9）：
 
 ```bash
 # macOS

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ultralytics-inference-web"
-version = "0.0.42"
+version = "0.0.43"
 edition = "2024"
 rust-version = "1.89"
 description = "Browser/WebAssembly bindings for ultralytics-inference (WebGPU via ort-web)"

--- a/docs/CUDA.md
+++ b/docs/CUDA.md
@@ -35,9 +35,9 @@ Add the feature you need in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.42", features = ["tensorrt"] }
+ultralytics-inference = { version = "0.0.43", features = ["tensorrt"] }
 # or, for the fastest path:
-ultralytics-inference = { version = "0.0.42", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.43", features = ["cuda-preprocess"] }
 ```
 
 Then `cargo build --release` - no extra flags needed.
@@ -67,7 +67,7 @@ If you need to pin a specific version at compile time instead, override the cuda
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.42", features = ["cuda-preprocess"] }
+ultralytics-inference = { version = "0.0.43", features = ["cuda-preprocess"] }
 # Replace the default feature with a pinned one (e.g. CUDA 12.8):
 cudarc = { version = "0.19", default-features = false, features = ["driver", "nvrtc", "dynamic-loading", "cuda-12080"] }
 ```

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,6 +9,9 @@ use crate::error::{InferenceError, Result};
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "video")]
+use std::borrow::Cow;
+
+#[cfg(feature = "video")]
 use std::sync::Once;
 
 #[cfg(feature = "video")]
@@ -103,6 +106,8 @@ pub struct VideoWriter {
     output: ffmpeg::format::context::Output,
     encoder: ffmpeg::encoder::Video,
     scaler: ffmpeg::software::scaling::context::Context,
+    /// Reused RGB24 staging frame; the scaler reads it before `write_frame` returns.
+    rgb: ffmpeg::util::frame::video::Video,
     stream_index: usize,
     encoder_time_base: ffmpeg::Rational,
     /// Time base the muxer settled on while writing the header.
@@ -209,10 +214,17 @@ impl VideoWriter {
         )
         .map_err(|e| InferenceError::VideoError(format!("Scaler init: {e}")))?;
 
+        let rgb = ffmpeg::util::frame::video::Video::new(
+            ffmpeg::format::Pixel::RGB24,
+            frame_width,
+            frame_height,
+        );
+
         Ok(Self {
             output,
             encoder,
             scaler,
+            rgb,
             stream_index,
             encoder_time_base,
             stream_time_base,
@@ -233,7 +245,10 @@ impl VideoWriter {
     ///
     /// Returns an error if encoding fails or frame dimensions don't match.
     pub fn write_frame(&mut self, frame: &image::DynamicImage) -> Result<()> {
-        let img_buffer = frame.to_rgb8();
+        // Annotated frames are already RGB8, so borrow them rather than converting.
+        let img_buffer = frame
+            .as_rgb8()
+            .map_or_else(|| Cow::Owned(frame.to_rgb8()), Cow::Borrowed);
         let width = img_buffer.width() as usize;
         let height = img_buffer.height() as usize;
 
@@ -244,22 +259,18 @@ impl VideoWriter {
             )));
         }
 
-        // Copy into an RGB24 frame row by row: the frame stride may be wider than width * 3.
-        let mut rgb = ffmpeg::util::frame::video::Video::new(
-            ffmpeg::format::Pixel::RGB24,
-            img_buffer.width(),
-            img_buffer.height(),
-        );
-        let stride = rgb.stride(0);
+        // Copy into the staging frame row by row: its stride may be wider than width * 3.
+        let stride = self.rgb.stride(0);
         let row_bytes = width * 3;
-        let data = rgb.data_mut(0);
+        let data = self.rgb.data_mut(0);
         for (y, row) in img_buffer.as_raw().chunks_exact(row_bytes).enumerate() {
             data[y * stride..y * stride + row_bytes].copy_from_slice(row);
         }
 
+        // The encoder keeps a reference to every frame it is given, so this one is fresh.
         let mut yuv = ffmpeg::util::frame::video::Video::empty();
         self.scaler
-            .run(&rgb, &mut yuv)
+            .run(&self.rgb, &mut yuv)
             .map_err(|e| InferenceError::VideoError(format!("Failed to convert frame: {e}")))?;
         yuv.set_pts(Some(self.frame_index));
         self.frame_index += 1;
@@ -465,6 +476,7 @@ impl SaveResults {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::source::SourceMeta;
 
     /// Truncation safety itself is guaranteed by `create_new`; what is asserted here is the

--- a/src/io.rs
+++ b/src/io.rs
@@ -153,9 +153,13 @@ impl VideoWriter {
             ))
         })?;
 
-        let codec = ffmpeg::encoder::find(ffmpeg::codec::Id::H264).ok_or_else(|| {
-            InferenceError::VideoError("FFmpeg build has no H.264 encoder".to_string())
-        })?;
+        // Prefer libx264, which the `preset` option below belongs to, over whichever
+        // H.264 encoder the build happens to register first.
+        let codec = ffmpeg::encoder::find_by_name("libx264")
+            .or_else(|| ffmpeg::encoder::find(ffmpeg::codec::Id::H264))
+            .ok_or_else(|| {
+                InferenceError::VideoError("FFmpeg build has no H.264 encoder".to_string())
+            })?;
 
         // Rational frame rate so fractional rates such as 29.97 stay exact.
         let frame_rate = ffmpeg::Rational::from(f64::from(fps));
@@ -285,7 +289,21 @@ impl VideoWriter {
     /// Interleave every packet the encoder has ready into the container.
     fn write_packets(&mut self) -> Result<()> {
         let mut packet = ffmpeg::codec::packet::Packet::empty();
-        while self.encoder.receive_packet(&mut packet).is_ok() {
+        loop {
+            match self.encoder.receive_packet(&mut packet) {
+                Ok(()) => {}
+                // The encoder wants more frames, or has been drained after end of stream.
+                Err(ffmpeg::Error::Other { errno }) if errno == ffmpeg::util::error::EAGAIN => {
+                    break;
+                }
+                Err(ffmpeg::Error::Eof) => break,
+                Err(e) => {
+                    return Err(InferenceError::VideoError(format!(
+                        "Failed to receive encoded packet: {e}"
+                    )));
+                }
+            }
+
             packet.set_stream(self.stream_index);
             // One frame lasts exactly one tick of the encoder time base.
             packet.set_duration(1);

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,7 +3,7 @@
 //! I/O utilities for saving results including video encoding.
 
 #[cfg(feature = "video")]
-use video_rs::{Encoder, Time, encode::Settings as EncoderSettings};
+use ffmpeg_next as ffmpeg;
 
 use crate::error::{InferenceError, Result};
 use std::path::{Path, PathBuf};
@@ -16,17 +16,17 @@ static INIT: Once = Once::new();
 
 /// Initialize global video logging configuration.
 ///
-/// Ensures `video-rs` is initialized and `FFmpeg` logs are silenced (only errors
-/// are shown). Safe to call multiple times.
+/// Ensures `FFmpeg` is initialized and its logs are silenced (only errors are
+/// shown). Safe to call multiple times.
 #[allow(clippy::missing_const_for_fn)]
 pub fn init_logging() {
     #[cfg(feature = "video")]
     INIT.call_once(|| {
-        if let Err(e) = video_rs::init() {
-            eprintln!("Failed to initialize video-rs: {e}");
+        if let Err(e) = ffmpeg::init() {
+            eprintln!("Failed to initialize FFmpeg: {e}");
         }
 
-        video_rs::ffmpeg::log::set_level(video_rs::ffmpeg::log::Level::Error);
+        ffmpeg::log::set_level(ffmpeg::log::Level::Error);
     });
 }
 
@@ -93,12 +93,22 @@ pub fn find_next_run_dir(base: &str, prefix: &str) -> String {
     first.to_string_lossy().into_owned()
 }
 
-/// A wrapper around `video-rs` encoder to simplify video saving.
+/// Distance between key frames, in frames.
+#[cfg(feature = "video")]
+const KEY_FRAME_INTERVAL: u32 = 12;
+
+/// An H.264 encoder that writes annotated frames to a video file.
 #[cfg(feature = "video")]
 pub struct VideoWriter {
-    encoder: Encoder,
-    frame_duration: Time,
-    position: Time,
+    output: ffmpeg::format::context::Output,
+    encoder: ffmpeg::encoder::Video,
+    scaler: ffmpeg::software::scaling::context::Context,
+    stream_index: usize,
+    encoder_time_base: ffmpeg::Rational,
+    /// Time base the muxer settled on while writing the header.
+    stream_time_base: ffmpeg::Rational,
+    frame_index: i64,
+    finished: bool,
     width: usize,
     height: usize,
 }
@@ -124,20 +134,90 @@ impl VideoWriter {
             ensure_dir(parent)?;
         }
 
-        let settings = EncoderSettings::preset_h264_yuv420p(width, height, false);
-        let encoder = Encoder::new(output_path.as_path(), settings).map_err(|e| {
-            InferenceError::VideoError(format!("Failed to create video encoder: {e}"))
+        init_logging();
+
+        let frame_width = u32::try_from(width)
+            .map_err(|_| InferenceError::VideoError(format!("Invalid video width {width}")))?;
+        let frame_height = u32::try_from(height)
+            .map_err(|_| InferenceError::VideoError(format!("Invalid video height {height}")))?;
+
+        let mut output = ffmpeg::format::output(&output_path).map_err(|e| {
+            InferenceError::VideoError(format!(
+                "Failed to open {} for writing: {e}",
+                output_path.display()
+            ))
         })?;
 
-        // video-rs uses a rational time base.
-        // We can approximate by converting seconds to Time.
-        let seconds_per_frame = 1.0 / f64::from(fps);
-        let frame_duration = Time::from_secs_f64(seconds_per_frame);
+        let codec = ffmpeg::encoder::find(ffmpeg::codec::Id::H264).ok_or_else(|| {
+            InferenceError::VideoError("FFmpeg build has no H.264 encoder".to_string())
+        })?;
+
+        // Rational frame rate so fractional rates such as 29.97 stay exact.
+        let frame_rate = ffmpeg::Rational::from(f64::from(fps));
+        let encoder_time_base = frame_rate.invert();
+
+        let mut encoder = ffmpeg::codec::context::Context::new_with_codec(codec)
+            .encoder()
+            .video()
+            .map_err(|e| {
+                InferenceError::VideoError(format!("Failed to create video encoder: {e}"))
+            })?;
+
+        encoder.set_width(frame_width);
+        encoder.set_height(frame_height);
+        encoder.set_format(ffmpeg::format::Pixel::YUV420P);
+        encoder.set_time_base(encoder_time_base);
+        encoder.set_frame_rate(Some(frame_rate));
+        encoder.set_gop(KEY_FRAME_INTERVAL);
+        if output
+            .format()
+            .flags()
+            .contains(ffmpeg::format::Flags::GLOBAL_HEADER)
+        {
+            encoder.set_flags(ffmpeg::codec::Flags::GLOBAL_HEADER);
+        }
+
+        let mut options = ffmpeg::Dictionary::new();
+        options.set("preset", "medium");
+        let encoder = encoder.open_with(options).map_err(|e| {
+            InferenceError::VideoError(format!("Failed to open H.264 encoder: {e}"))
+        })?;
+
+        let mut stream = output
+            .add_stream(codec)
+            .map_err(|e| InferenceError::VideoError(format!("Failed to add video stream: {e}")))?;
+        stream.set_parameters(&encoder);
+        stream.set_time_base(encoder_time_base);
+        let stream_index = stream.index();
+
+        output.write_header().map_err(|e| {
+            InferenceError::VideoError(format!("Failed to write video header: {e}"))
+        })?;
+
+        let stream_time_base = output
+            .stream(stream_index)
+            .map_or(encoder_time_base, |s| s.time_base());
+
+        let scaler = ffmpeg::software::scaling::context::Context::get(
+            ffmpeg::format::Pixel::RGB24,
+            frame_width,
+            frame_height,
+            ffmpeg::format::Pixel::YUV420P,
+            frame_width,
+            frame_height,
+            ffmpeg::software::scaling::flag::Flags::BILINEAR,
+        )
+        .map_err(|e| InferenceError::VideoError(format!("Scaler init: {e}")))?;
 
         Ok(Self {
+            output,
             encoder,
-            frame_duration,
-            position: Time::zero(),
+            scaler,
+            stream_index,
+            encoder_time_base,
+            stream_time_base,
+            frame_index: 0,
+            finished: false,
             width,
             height,
         })
@@ -164,18 +244,63 @@ impl VideoWriter {
             )));
         }
 
-        let raw = img_buffer.into_raw();
+        // Copy into an RGB24 frame row by row: the frame stride may be wider than width * 3.
+        let mut rgb = ffmpeg::util::frame::video::Video::new(
+            ffmpeg::format::Pixel::RGB24,
+            img_buffer.width(),
+            img_buffer.height(),
+        );
+        let stride = rgb.stride(0);
+        let row_bytes = width * 3;
+        let data = rgb.data_mut(0);
+        for (y, row) in img_buffer.as_raw().chunks_exact(row_bytes).enumerate() {
+            data[y * stride..y * stride + row_bytes].copy_from_slice(row);
+        }
 
-        #[cfg(feature = "video")]
-        let frame_array = ndarray::Array3::from_shape_vec((height, width, 3), raw)
-            .map_err(|e| InferenceError::VideoError(e.to_string()))?;
+        let mut yuv = ffmpeg::util::frame::video::Video::empty();
+        self.scaler
+            .run(&rgb, &mut yuv)
+            .map_err(|e| InferenceError::VideoError(format!("Failed to convert frame: {e}")))?;
+        yuv.set_pts(Some(self.frame_index));
+        self.frame_index += 1;
 
         self.encoder
-            .encode(&frame_array, self.position)
+            .send_frame(&yuv)
             .map_err(|e| InferenceError::VideoError(format!("Failed to encode frame: {e}")))?;
 
-        self.position = self.position.aligned_with(self.frame_duration).add();
+        self.write_packets()
+    }
+
+    /// Interleave every packet the encoder has ready into the container.
+    fn write_packets(&mut self) -> Result<()> {
+        let mut packet = ffmpeg::codec::packet::Packet::empty();
+        while self.encoder.receive_packet(&mut packet).is_ok() {
+            packet.set_stream(self.stream_index);
+            // One frame lasts exactly one tick of the encoder time base.
+            packet.set_duration(1);
+            packet.rescale_ts(self.encoder_time_base, self.stream_time_base);
+            packet.write_interleaved(&mut self.output).map_err(|e| {
+                InferenceError::VideoError(format!("Failed to write video packet: {e}"))
+            })?;
+        }
+
         Ok(())
+    }
+
+    /// Flush the encoder and write the container trailer.
+    fn finalize(&mut self) -> Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+
+        self.encoder
+            .send_eof()
+            .map_err(|e| InferenceError::VideoError(format!("Failed to flush encoder: {e}")))?;
+        self.write_packets()?;
+        self.output.write_trailer().map_err(|e| {
+            InferenceError::VideoError(format!("Failed to finish video encoding: {e}"))
+        })
     }
 
     /// Finish writing the video.
@@ -187,9 +312,16 @@ impl VideoWriter {
     ///
     /// Returns an error if the encoder fails to finish.
     pub fn finish(mut self) -> Result<()> {
-        self.encoder.finish().map_err(|e| {
-            InferenceError::VideoError(format!("Failed to finish video encoding: {e}"))
-        })
+        self.finalize()
+    }
+}
+
+#[cfg(feature = "video")]
+impl Drop for VideoWriter {
+    fn drop(&mut self) {
+        if let Err(e) = self.finalize() {
+            eprintln!("{e}");
+        }
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -230,14 +230,13 @@ impl Default for SourceMeta {
 }
 
 #[cfg(feature = "video")]
-use video_rs::ffmpeg;
+use ffmpeg_next as ffmpeg;
 
 /// Custom `FFmpeg` video decoder using `SWS_BILINEAR` for YUV -> RGB conversion.
 ///
-/// `video-rs` defaults to `SWS_AREA`, which can produce slightly different
-/// pixel values during colorspace conversion. Those differences can affect
-/// borderline confidence predictions and lead to small detection drift.
-/// For consistency, this decoder uses `SWS_BILINEAR` explicitly.
+/// Other scaler choices such as `SWS_AREA` produce slightly different pixel values
+/// during colorspace conversion. Those differences can affect borderline confidence
+/// predictions and lead to small detection drift, so `SWS_BILINEAR` is explicit here.
 /// Convert a decoded video frame to a tightly-packed RGB24 [`DynamicImage`] using a BILINEAR
 /// scaler. `scaler` caches the context and is rebuilt when the frame's format or size
 /// changes, so pass a persistent `Option` to reuse it across frames.
@@ -632,7 +631,7 @@ impl SourceIterator {
         let c_name = std::ffi::CString::new(format_name).map_err(|_| {
             InferenceError::VideoError(format!("Invalid input format name '{format_name}'"))
         })?;
-        let ptr = unsafe { video_rs::ffmpeg::ffi::av_find_input_format(c_name.as_ptr()) };
+        let ptr = unsafe { ffmpeg::ffi::av_find_input_format(c_name.as_ptr()) };
         if ptr.is_null() {
             return Err(InferenceError::VideoError(format!(
                 "Input format '{format_name}' not found"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ultralytics/yolo",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@litertjs/core": "^2.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultralytics/yolo",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Run Ultralytics YOLO models in the browser on WebGPU (WebAssembly, ONNX Runtime Web via ort-web).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Decoding and webcam capture already ran on ffmpeg-next through the video-rs re-export, so video-rs only wrapped the H.264 encoder while pinning us to ffmpeg-next 8, and moving VideoWriter onto ffmpeg-next directly drops a dependency layer and supports FFmpeg 6 through 9, verified with clippy and the full test suite against both FFmpeg 8.1.2 and 9.0, and with ffprobe reporting h264 yuv420p at the requested frame rate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Replaced `video-rs` with direct `ffmpeg-next` integration for video encoding and decoding, removing the dependency layer and extending documented FFmpeg support through version 9.

### 📊 Key Changes

- Reimplemented `VideoWriter` with direct FFmpeg APIs for H.264 encoding, RGB-to-YUV420P conversion, packet writing, encoder flushing, and trailer generation.
- Updated video initialization and input-format handling in `src/io.rs` and `src/source.rs` to use `ffmpeg-next`.
- Changed the optional `video` feature to depend on `ffmpeg-next` instead of `video-rs`.
- Expanded CI coverage to include FFmpeg 9 on Linux, macOS, and Windows alongside existing FFmpeg versions.
- Bumped package and example references from version `0.0.42` to `0.0.43` and updated English and Chinese documentation.

### 🎯 Purpose & Impact

- Video output now uses direct FFmpeg bindings and selects `libx264` when available, producing H.264 video in `yuv420p` with the requested frame rate.
- Video builds and tests are exercised across FFmpeg 7, 8, and 9 in CI, while documentation lists FFmpeg 6 through 9 for video features.
- Existing video decoding and webcam capture paths continue using FFmpeg through the new direct dependency.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `Cargo.lock`
- `web/package-lock.json`
</details>
