### PR TITLE
Lint and test the cuda and tensorrt feature gates in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,18 @@ jobs:
         if: matrix.os != 'macos-latest'
         run: cargo test --no-default-features --features annotate
 
+      # ort/cuda and ort/tensorrt gate the execution-provider setup in model.rs
+      # and io.rs; neither needs a CUDA toolkit to compile, so lint and test
+      # them on the Linux runner. cuda-preprocess stays out - cudarc's build
+      # script shells out to nvcc, which GitHub runners do not have.
+      - name: Clippy (annotate + cuda + tensorrt)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo clippy --all-targets --no-default-features --features annotate,cuda,tensorrt -- -D warnings
+
+      - name: Tests (annotate + cuda + tensorrt)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test --no-default-features --features annotate,cuda,tensorrt
+
       # CoreML is macOS-only — covers issue #148 (GatherElements warmup) and graph_input_cast_0 fix
       - name: Clippy (coreml + annotate)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,6 @@ jobs:
         if: matrix.os != 'macos-latest'
         run: cargo test --no-default-features --features annotate
 
-      # ort/cuda and ort/tensorrt gate the execution-provider setup in model.rs
-      # and io.rs; neither needs a CUDA toolkit to compile, so lint and test
-      # them on the Linux runner. cuda-preprocess stays out - cudarc's build
-      # script shells out to nvcc, which GitHub runners do not have.
       - name: Clippy (annotate + cuda + tensorrt)
         if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --all-targets --no-default-features --features annotate,cuda,tensorrt -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ cd web && npm ci && npm run build
 cargo run -- predict
 ```
 
-- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows; `test-video` in FFmpeg 7.1/8.0/9.0 Linux containers (`--features annotate,video`); video builds on macOS (Homebrew FFmpeg 9) and Windows (FFmpeg 8.1/9.0); `wasm`; `coverage` (nightly) uploads to Codecov.
+- CI matrix (`ci.yml`): `test` on ubuntu/macos/windows (ubuntu also lints and tests `annotate,cuda,tensorrt`); `test-video` in FFmpeg 7.1/8.0/9.0 Linux containers (`--features annotate,video`); video builds on macOS (Homebrew FFmpeg 9) and Windows (FFmpeg 8.1/9.0); `wasm`; `coverage` (nightly) uploads to Codecov.
 - MSRV is Rust 1.89 (`rust-version` in Cargo.toml), edition 2024.
 - First native build downloads ONNX Runtime binaries (ort `download-binaries` feature), so builds need network once.
 


### PR DESCRIPTION
The cuda and tensorrt features gate real code in src/model.rs and src/io.rs that CI never compiled, so this adds a clippy and a test step for annotate,cuda,tensorrt to the ubuntu leg of the existing test job; neither feature needs a CUDA toolkit to build, so a standard runner covers them, while cuda-preprocess stays out because cudarc's build script shells out to nvcc. Verified locally with CUDA 13.3: clippy clean for annotate,cuda,tensorrt and for annotate,cuda-preprocess, cargo fmt clean, and the test suite green under both feature sets.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ubuntu CI to lint and test the `annotate,cuda,tensorrt` feature combination so code behind the CUDA and TensorRT gates is compiled and checked automatically.

### 📊 Key Changes

- Added an Ubuntu-only Clippy step for `annotate,cuda,tensorrt` with warnings treated as errors.
- Added an Ubuntu-only test step for `annotate,cuda,tensorrt`.
- Updated `AGENTS.md` to document the expanded Ubuntu CI coverage.
- Kept `cuda-preprocess` out of these CI steps because it requires `nvcc` during the build.

### 🎯 Purpose & Impact

- CI now checks CUDA- and TensorRT-gated Rust code that was previously not compiled by the existing test workflow.
- No user-facing runtime change; the update expands automated validation and documents the CI matrix.